### PR TITLE
Fix broken animations when multipart actor have completely overlapping parts

### DIFF
--- a/direct/src/actor/Actor.py
+++ b/direct/src/actor/Actor.py
@@ -1019,11 +1019,6 @@ class Actor(DirectObject, NodePath):
         if (partName in partDict):
             del(partDict[partName])
 
-        # remove the bundle handle, in case this part is ever
-        # loaded again in the future
-        if partName in self.__commonBundleHandles:
-            del self.__commonBundleHandles[partName]
-
     def hidePart(self, partName, lodName="lodRoot"):
         """
         Make the given part of the optionally given lod not render,


### PR DESCRIPTION
Revert "Patch by cfsworks: actor: On removePart, clean up the part's commonBundleHandle."

This reverts commit a4563fb342715bccd9a63aa320395f13abaace46.

commonBundleHandle is not holding bundle for this part only. When
two or more parts shares or have similar bundles - their bundles
are merged. In these cases it is not correct to remove
the commonBundleHandle for this parts.