### PR TITLE
Fix MeshDrawer::stream

### DIFF
--- a/panda/src/grutil/meshDrawer.cxx
+++ b/panda/src/grutil/meshDrawer.cxx
@@ -369,8 +369,9 @@ void MeshDrawer::stream(const LVector3 &start, const LVector3 &stop, const LVect
   LVector3 relative_pos = stop;
   LVector3 vec = stop - start;
   PN_stdfloat distance = vec.length();
+  vec.normalize();
   for(int i = 0; i < number; i++) {
-    relative_pos = stop + vec * ((i-offset)*(distance/PN_stdfloat(number)));
+    relative_pos = start + vec * ((i+offset)*(distance/PN_stdfloat(number)));
     billboard(relative_pos,frame,size,_color);
   }
 }


### PR DESCRIPTION
Direction vector is computed as stop - start, but the position
in the loop is computed from stop as base, instead of from start;
this is changed to start as the base (and then offset must be added).
Multiplication of non-normalized direction vector with its length
yields square of the expected current step inside the loop;
this is changed to use the normalized direction vector.