### PR TITLE
 Mouse grab support (Windows / X11 only)

### DIFF
--- a/panda/src/display/windowProperties.I
+++ b/panda/src/display/windowProperties.I
@@ -905,6 +905,67 @@ clear_parent_window() {
   _parent_window = NULL;
 }
 
+////////////////////////////////////////////////////////////////////
+//     Function: WindowProperties::set_mouse_grabbed
+//       Access: Published
+//  Description: Specifies whether the primary mouse is grabbed
+//               by the window (true) or is free to move beyond the
+//               window (false, the default).
+//
+//               This is intended to handle cases like FPSes where
+//               the user can move the mouse arbitrarily while
+//               ensuring Panda3D always gets mouse events.
+//
+//               This operates differently on different OSes,
+//               however.  On Windows, the mouse is physically
+//               restricted to the window boundary.  On others,
+//               the mouse reports coordinates outside the window.
+//
+//               To implement the FPS use case, periodically
+//               move the pointer to the center of the window
+//               and track movement deltas.
+////////////////////////////////////////////////////////////////////
+INLINE void WindowProperties::
+set_mouse_grabbed(bool mouse_grabbed) {
+  if (mouse_grabbed) {
+    _flags |= F_mouse_grabbed;
+  } else {
+    _flags &= ~F_mouse_grabbed;
+  }
+  _specified |= S_mouse_grabbed;
+}
+
+////////////////////////////////////////////////////////////////////
+//     Function: WindowProperties::get_mouse_grabbed
+//       Access: Published
+//  Description: Returns true if the window is in mouse_grabbed mode.
+////////////////////////////////////////////////////////////////////
+INLINE bool WindowProperties::
+get_mouse_grabbed() const {
+  return (_flags & F_mouse_grabbed) != 0;
+}
+
+////////////////////////////////////////////////////////////////////
+//     Function: WindowProperties::has_mouse_grabbed
+//       Access: Published
+//  Description: Returns true if set_mouse_grabbed() has been specified.
+////////////////////////////////////////////////////////////////////
+INLINE bool WindowProperties::
+has_mouse_grabbed() const {
+  return ((_specified & S_mouse_grabbed) != 0);
+}
+
+////////////////////////////////////////////////////////////////////
+//     Function: WindowProperties::clear_mouse_grabbed
+//       Access: Published
+//  Description: Removes the mouse_grabbed specification from the properties.
+////////////////////////////////////////////////////////////////////
+INLINE void WindowProperties::
+clear_mouse_grabbed() {
+  _specified &= ~S_mouse_grabbed;
+  _flags &= ~F_mouse_grabbed;
+}
+
 
 INLINE ostream &
 operator << (ostream &out, const WindowProperties &properties) {

--- a/panda/src/display/windowProperties.cxx
+++ b/panda/src/display/windowProperties.cxx
@@ -285,6 +285,9 @@ add_properties(const WindowProperties &other) {
   if (other.has_parent_window()) {
     set_parent_window(other.get_parent_window());
   }
+  if (other.has_mouse_grabbed()) {
+    set_mouse_grabbed(other.has_mouse_grabbed());
+  }
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -347,6 +350,9 @@ output(ostream &out) const {
     } else {
       out << "parent:" << *get_parent_window() << " ";
     }
+  }
+  if (has_mouse_grabbed()) {
+    out << get_mouse_grabbed() << " ";
   }
 }
 

--- a/panda/src/display/windowProperties.h
+++ b/panda/src/display/windowProperties.h
@@ -147,6 +147,11 @@ PUBLISHED:
   INLINE bool has_parent_window() const;
   INLINE void clear_parent_window();
 
+  INLINE void set_mouse_grabbed(bool mouse_grabbed);
+  INLINE bool get_mouse_grabbed() const;
+  INLINE bool has_mouse_grabbed() const;
+  INLINE void clear_mouse_grabbed();
+
   void add_properties(const WindowProperties &other);
 
   void output(ostream &out) const;
@@ -172,6 +177,7 @@ private:
     S_mouse_mode           = 0x02000,
     S_parent_window        = 0x04000,
     S_raw_mice             = 0x08000,
+    S_mouse_grabbed        = 0x10000,
   };
 
   // This bitmask represents the true/false settings for various
@@ -186,6 +192,7 @@ private:
     F_cursor_hidden  = S_cursor_hidden,
     F_fixed_size     = S_fixed_size,
     F_raw_mice       = S_raw_mice,
+    F_mouse_grabbed  = S_mouse_grabbed,
   };
 
   int _specified;

--- a/panda/src/windisplay/winGraphicsWindow.h
+++ b/panda/src/windisplay/winGraphicsWindow.h
@@ -214,6 +214,12 @@ private:
   static BOOL _saved_cursor_shadow;
   static BOOL _saved_mouse_vanish;
 
+  // This tracks the current window on which the user set the
+  // mouse_grabbed property.  Since only one window in the
+  // system has capture state, this can be a global.
+  static WinGraphicsWindow *_mouse_grabbed_window;
+  static RECT _mouse_ungrabbed_cliprect;
+
   // Since the Panda API requests icons and cursors by filename, we
   // need a table mapping filenames to handles, so we can avoid
   // re-reading the file each time we change icons.

--- a/panda/src/x11display/x11GraphicsWindow.cxx
+++ b/panda/src/x11display/x11GraphicsWindow.cxx
@@ -711,6 +711,32 @@ set_properties_now(WindowProperties &properties) {
     properties.clear_foreground();
   }
 
+  if (properties.has_mouse_grabbed()) {
+    if (properties.get_mouse_grabbed()) {
+      X11_Cursor cursor = None;
+      if (_properties.get_cursor_hidden()) {
+        x11GraphicsPipe *x11_pipe;
+        DCAST_INTO_V(x11_pipe, _pipe);
+        cursor = x11_pipe->get_hidden_cursor();
+      }
+
+      if (XGrabPointer(_display, _xwindow, True, 0, GrabModeAsync,
+          GrabModeAsync, _xwindow, cursor, CurrentTime) != GrabSuccess) {
+        x11display_cat.error() << "Failed to grab pointer!\n";
+      } else {
+        _properties.set_mouse_grabbed(true);
+        properties.clear_mouse_grabbed();
+      }
+    } else {
+      if (XUngrabPointer(_display, CurrentTime) != GrabSuccess) {
+        x11display_cat.error() << "Failed to ungrab pointer!\n";
+      } else {
+        _properties.set_mouse_grabbed(false);
+        properties.clear_mouse_grabbed();
+      }
+    }
+  }
+
   set_wm_properties(wm_properties, true);
 }
 


### PR DESCRIPTION
Add support for grabbing the mouse using WindowProperties#set_mouse_grabbed().
    
Implementation only for Windows and X11 so far.
