### PR TITLE
Implement confined mouse mode for OS X.

### DIFF
--- a/panda/src/cocoadisplay/cocoaPandaView.mm
+++ b/panda/src/cocoadisplay/cocoaPandaView.mm
@@ -116,7 +116,10 @@
   NSPoint loc = [self convertPoint:[event locationInWindow] fromView:nil];
   BOOL inside = [self mouse:loc inRect:[self bounds]];
 
-  if (_graphicsWindow->get_properties().get_mouse_mode() == WindowProperties::M_relative) {
+  // the correlation between mouse deltas and location
+  // are "debounced" apparently, so send deltas for both
+  // relative and confined modes
+  if (_graphicsWindow->get_properties().get_mouse_mode() != WindowProperties::M_absolute) {
     _graphicsWindow->handle_mouse_moved_event(inside, [event deltaX], [event deltaY], false);
   } else {
     _graphicsWindow->handle_mouse_moved_event(inside, loc.x, loc.y, true);

--- a/panda/src/osxdisplay/osxGraphicsWindow.mm
+++ b/panda/src/osxdisplay/osxGraphicsWindow.mm
@@ -2064,6 +2064,25 @@ set_properties_now(WindowProperties &properties) {
     properties.clear_minimized();
   }
 
+  if (properties.has_mouse_mode()) {
+    switch (properties.get_mouse_mode()) {
+    case WindowProperties::M_absolute:
+      CGAssociateMouseAndMouseCursorPosition(true);
+      _properties.set_mouse_mode(WindowProperties::M_absolute);
+      properties.clear_mouse_mode();
+      break;
+
+    case WindowProperties::M_relative:
+      CGAssociateMouseAndMouseCursorPosition(false);
+      _properties.set_mouse_mode(WindowProperties::M_relative);
+      properties.clear_mouse_mode();
+      break;
+
+    case WindowProperties::M_confined:
+      break;
+    }
+  }
+
   if (osxdisplay_cat.is_debug()) {
     osxdisplay_cat.debug()
       << "set_properties_now Out....." << _properties << "\n";

--- a/samples/mouse-modes/main.py
+++ b/samples/mouse-modes/main.py
@@ -34,7 +34,8 @@ class App(ShowBase):
         # Disable the camera trackball controls.
         self.disableMouse()
         
-        self.mouseMagnitude = 144
+        # control mapping of mouse movement to box movement
+        self.mouseMagnitude = 1
 
         self.rotateX, self.rotateY = 0, 0
 
@@ -146,7 +147,8 @@ class App(ShowBase):
         if self.manualRecenterMouse:
             # move mouse back to center
             self.recenterMouse()             
-
+            self.lastMouseX, self.lastMouseY = 0, 0  
+                
         # scale position and delta to pixels for user
         w, h = self.win.getSize()
         
@@ -158,8 +160,8 @@ class App(ShowBase):
              int(dx*w), int(dy*h))) 
 
         # rotate box by delta
-        self.rotateX += dx * 10
-        self.rotateY += dy * 10
+        self.rotateX += dx * 10 * self.mouseMagnitude
+        self.rotateY += dy * 10 * self.mouseMagnitude
 
         self.positionText.setText("Model rotation: {0}, {1}".format(
              int(self.rotateX*1000)/1000., int(self.rotateY*1000)/1000.))        


### PR DESCRIPTION
Note: it seems that using #set_pointer() will result in
a long delay before an absolute mouse position is updated,
even though deltas are reported.

Thus, in CocoaPandaView, the mouse deltas are sent for both
relative and confined modes, so client code (e.g. the "mouse
modes" demo) will be able to recenter the mouse without
choppy movement.