### PR TITLE
Fix a rash of asserts from PNMImage::get_alpha_val

### DIFF
--- a/panda/src/gobj/texture.cxx
+++ b/panda/src/gobj/texture.cxx
@@ -3071,10 +3071,16 @@ do_read_one(CData *cdata, const Filename &fullpath, const Filename &alpha_fullpa
 
     if (alpha_file_channel == 4 ||
         (alpha_file_channel == 2 && alpha_image.get_num_channels() == 2)) {
-      // Use the alpha channel.
-      for (int x = 0; x < image.get_x_size(); x++) {
-        for (int y = 0; y < image.get_y_size(); y++) {
-          image.set_alpha(x, y, alpha_image.get_alpha(x, y));
+
+      if (!alpha_image.has_alpha()) {
+        gobj_cat.error()
+          << alpha_fullpath.get_basename() << " has no channel " << alpha_file_channel << ".\n";
+      } else {
+        // Use the alpha channel.
+        for (int x = 0; x < image.get_x_size(); x++) {
+          for (int y = 0; y < image.get_y_size(); y++) {
+            image.set_alpha(x, y, alpha_image.get_alpha(x, y));
+          }
         }
       }
       cdata->_alpha_file_channel = alpha_image.get_num_channels();


### PR DESCRIPTION
I saw a reference to this on irc the other day and then ran into it myself once I loaded up some MakeHuman-generated models.

-- originally the code had an explicit check for a missing alpha channel, that went away in 22120524a2f9a1f9330cdfa2b35bbcdf15d721d4

-- example is:

```
<Texture> tongue01:diffuse.002 {
  "./tex/tongue01_diffuse.png"
  <Scalar> envtype { MODULATE }
  <Scalar> minfilter { LINEAR_MIPMAP_LINEAR }
  <Scalar> magfilter { LINEAR_MIPMAP_LINEAR }
  <Scalar> wrap { REPEAT }
  <Scalar> alpha-file { "./tex/tongue01_diffuse.png" }
  <Scalar> alpha-file-channel { 4 }
}
```

for an image w/o alpha:
```
file ./tex/tongue01_diffuse.png
./tex/tongue01_diffuse.png: PNG image data, 1024 x 1024, 8-bit/color RGB, non-interlaced
```

