### PR TITLE
Fix invalid assumptions in GravityWalker

### DIFF
--- a/direct/src/controls/GravityWalker.py
+++ b/direct/src/controls/GravityWalker.py
@@ -697,8 +697,7 @@ class GravityWalker(DirectObject.DirectObject):
     # There are sometimes issues if the collision ray height is
     # so tall that it collides with multiple levels of floors.
     def setCollisionRayHeight(self, height):
-        oldNode = self.avatarNodePath.getNode(0)
-        cRayNode = oldNode.getChild(2)
+        cRayNode = self.cRayNodePath.node()
         cRayNode.removeSolid(0)
         cRay = CollisionRay(0.0, 0.0, height, 0.0, 0.0, -1.0)
-        cRayNode.addSolid(cRay)        
+        cRayNode.addSolid(cRay)


### PR DESCRIPTION
The setCollisionRayHeight method assumed that the 0th child on the
avatar would be the av's GeomNode, and again assumed that the 2nd child of
the GeomNode would be this Walker's cRayNode. This is not always the case,
as scene graph manipulations can change the parenting order of nodes.

The fix is to simply pull the cRayNode from the Walker's own cRayNodePath
handle.