### PR TITLE
Make more keys available to libRocket event handlers

### DIFF
--- a/panda/src/rocket/rocketInputHandler.cxx
+++ b/panda/src/rocket/rocketInputHandler.cxx
@@ -113,6 +113,22 @@ get_rocket_key(const ButtonHandle handle) {
   keymap[KeyboardButton::rshift().get_index()]       = KI_RSHIFT;
   keymap[KeyboardButton::scroll_lock().get_index()]  = KI_SCROLL;
 
+  // these "OEM" keys have standard mappings in Panda3D
+  keymap[KeyboardButton::ascii_key(';').get_index()]  = KI_OEM_1;
+  keymap[KeyboardButton::ascii_key('=').get_index()]  = KI_OEM_PLUS;
+  keymap[KeyboardButton::ascii_key(',').get_index()]  = KI_OEM_COMMA;
+  keymap[KeyboardButton::ascii_key('-').get_index()]  = KI_OEM_MINUS;
+  keymap[KeyboardButton::ascii_key('.').get_index()]  = KI_OEM_PERIOD;
+  keymap[KeyboardButton::ascii_key('/').get_index()]  = KI_OEM_2;
+  keymap[KeyboardButton::ascii_key('`').get_index()]  = KI_OEM_3;
+  keymap[KeyboardButton::ascii_key('[').get_index()]  = KI_OEM_4;
+  keymap[KeyboardButton::ascii_key('\\').get_index()] = KI_OEM_5;
+  keymap[KeyboardButton::ascii_key(']').get_index()]  = KI_OEM_6;
+
+  // comment says this may either be "<>" or "\|", but "\" (unshifted) is handled already,
+  // and "<" is only available "shifted" on 101-keyboards, so assume it's this one...
+  keymap[KeyboardButton::ascii_key('<').get_index()]  = KI_OEM_102;
+
   for (char c = 'a'; c <= 'z'; ++c) {
     keymap[KeyboardButton::ascii_key(c).get_index()] = (c - 'a') + KI_A;
   }


### PR DESCRIPTION
Some ASCII chars fell through and generate no events when modifier keys are held down.  E.g. pressing "Ctrl+\" emits neither a 'keydown' nor a 'textinput' event for libRocket.  

libRocket calls several punctuation keys "OEM" in its KeyIdentifier enum, so I assume those were overlooked.  This patch fills those in from Panda's side, assuming a US English keyboard, like libRocket's comments say.  Better that than losing the events entirely...?