### PR TITLE
Add PNMImage premultiply/unpremultiply methods.

### DIFF
--- a/panda/src/pnmimage/pnmImage.cxx
+++ b/panda/src/pnmimage/pnmImage.cxx
@@ -623,6 +623,63 @@ make_grayscale(float rc, float gc, float bc) {
 }
 
 ////////////////////////////////////////////////////////////////////
+//     Function: PNMImage::premultiply_alpha
+//       Access: Published
+//  Description: Converts an image in-place to its "premultiplied"
+//               form, where, for every pixel in the image, the
+//               red, green, and blue components are multiplied by
+//               that pixel's alpha value.
+//
+//               This does not modify any alpha values.
+////////////////////////////////////////////////////////////////////
+void PNMImage::
+premultiply_alpha() {
+  if (!has_alpha()) {
+    return;
+  }
+
+  for (int y = 0; y < get_y_size(); y++) {
+    for (int x = 0; x < get_x_size(); x++) {
+      float alpha = get_alpha(x, y);
+      float r = get_red(x, y) * alpha;
+      float g = get_green(x, y) * alpha;
+      float b = get_blue(x, y) * alpha;
+      set_xel(x, y, r, g, b);
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////
+//     Function: PNMImage::unpremultiply_alpha
+//       Access: Published
+//  Description: Converts an image in-place to its "straight alpha"
+//               form (presumably from a "premultiplied" form),
+//               where, for every pixel in the image, the red,
+//               green, and blue components are divided by that
+//               pixel's alpha value.
+//
+//               This does not modify any alpha values.
+////////////////////////////////////////////////////////////////////
+void PNMImage::
+unpremultiply_alpha() {
+  if (!has_alpha()) {
+    return;
+  }
+
+  for (int y = 0; y < get_y_size(); y++) {
+    for (int x = 0; x < get_x_size(); x++) {
+      float alpha = get_alpha(x, y);
+      if (alpha > 0) {
+        float r = get_red(x, y) / alpha;
+        float g = get_green(x, y) / alpha;
+        float b = get_blue(x, y) / alpha;
+        set_xel(x, y, r, g, b);
+      }
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////
 //     Function: PNMImage::reverse_rows
 //       Access: Published
 //  Description: Performs an in-place reversal of the row (y) data.

--- a/panda/src/pnmimage/pnmImage.h
+++ b/panda/src/pnmimage/pnmImage.h
@@ -133,6 +133,9 @@ PUBLISHED:
   void make_grayscale(float rc, float gc, float bc);
   INLINE void make_rgb();
 
+  void premultiply_alpha();
+  void unpremultiply_alpha();
+
   BLOCKING void reverse_rows();
   BLOCKING void flip(bool flip_x, bool flip_y, bool transpose);
 


### PR DESCRIPTION
Ought to be straightforward, except perhaps the naming of the methods.  Feel free to change them.

(I fought so hard thinking blend_sub_image() or blend() had some bug, and was making all sorts of elaborate fixes and extensions for that, but finally realized it was all my fault, hence these methods :-p.)