### PR TITLE
glstuff: Fix incorectly handle of Transpose in Shader Inputs

### DIFF
--- a/panda/src/glstuff/glShaderContext_src.cxx
+++ b/panda/src/glstuff/glShaderContext_src.cxx
@@ -590,6 +590,7 @@ reflect_uniform(int i, char *name_buffer, GLsizei name_buflen) {
   size_t size = strlen(name_buffer);
   if (size > 3 && strncmp(name_buffer + (size - 3), "[0]", 3) == 0) {
     name_buffer[size - 3] = 0;
+    size -= 3;
   }
 
   string param_name(name_buffer);
@@ -606,6 +607,7 @@ reflect_uniform(int i, char *name_buffer, GLsizei name_buflen) {
     bool transpose = false;
     bool inverse = false;
     string matrix_name(noprefix);
+    size = matrix_name.size();
 
     // Check for and chop off any "Transpose" or "Inverse" suffix.
     if (size > 15 && matrix_name.compare(size - 9, 9, "Transpose") == 0) {


### PR DESCRIPTION
	- Added missing recalculation of size when
	input buffer is "resized" (due to removing of
	post/pre-fixes). Now the "Transponse" part is
	correctly handled.

Signed-off-by: deflected <deflected@github>