### PR TITLE
Add back default model loading

### DIFF
--- a/direct/src/gui/DirectDialog.py
+++ b/direct/src/gui/DirectDialog.py
@@ -94,7 +94,7 @@ class DirectDialog(DirectFrame):
             ('text',              '',            None),
             ('text_align',        TextNode.ALeft,   None),
             ('text_scale',        0.06,          None),
-            ('image',             None,          None),
+            ('image',             DGG.getDefaultDialogGeom(), None),
             ('relief',            DGG.RAISED,     None),
             ('borderWidth',       (0.01, 0.01),  None),
             ('buttonTextList',    [],            DGG.INITOPT),

--- a/direct/src/gui/DirectDialog.py
+++ b/direct/src/gui/DirectDialog.py
@@ -95,7 +95,7 @@ class DirectDialog(DirectFrame):
             ('text_align',        TextNode.ALeft,   None),
             ('text_scale',        0.06,          None),
             ('image',             DGG.getDefaultDialogGeom(), None),
-            ('relief',            DGG.RAISED,     None),
+            ('relief',            None,     None),
             ('borderWidth',       (0.01, 0.01),  None),
             ('buttonTextList',    [],            DGG.INITOPT),
             ('buttonGeomList',    [],            DGG.INITOPT),


### PR DESCRIPTION
How does this bother anybody? This is a very useful feature.. especially when you already have a project with tons of DirectDialogs that you haven't set a model for.

Why was this removed?