### PR TITLE
Handle code-driven resizes when WindowProperties::fixed_size is set.

### DIFF
--- a/panda/src/x11display/x11GraphicsWindow.h
+++ b/panda/src/x11display/x11GraphicsWindow.h
@@ -99,6 +99,7 @@ protected:
   long _event_mask;
   bool _awaiting_configure;
   bool _dga_mouse_enabled;
+  int _expected_fixed_size_x, _expected_fixed_size_y;
   Atom _wm_delete_window;
 
   struct MouseDeviceInfo {


### PR DESCRIPTION
-- X11 seems to send multiple conflicting ConfigureEvents after
resizing a window, so it does not suffice to ignore ConfigureEvents
that change the window size.
-- Instead, record the desired new fixed size and honor a resize
to that size (only).
-- Tested with windowed and fullscreen under xfwm4
-- Added x11display debug logging for resizing in these cases.