### PR TITLE
Removed a nonexistent import from GridChild

### DIFF
--- a/direct/src/distributed/GridChild.py
+++ b/direct/src/distributed/GridChild.py
@@ -1,6 +1,5 @@
 from direct.distributed.DistributedSmoothNodeBase import DistributedSmoothNodeBase
 from direct.distributed.GridParent import GridParent
-from pandac.PandaModules import EmbeddedValue
 
 class GridChild:
     """


### PR DESCRIPTION
This import is nonexistent and has no calls to it. The only purpose it serves right now is causing an ImportError :P.