### PR TITLE
Send libRocket key events before mouse events

### DIFF
--- a/panda/src/rocket/rocketInputHandler.cxx
+++ b/panda/src/rocket/rocketInputHandler.cxx
@@ -302,30 +302,6 @@ void RocketInputHandler::
 update_context(Rocket::Core::Context *context, int xoffs, int yoffs) {
   MutexHolder holder(_lock);
 
-  if (_mouse_xy_changed) {
-    _mouse_xy_changed = false;
-
-    context->ProcessMouseMove(_mouse_xy.get_x() - xoffs,
-                              _mouse_xy.get_y() - yoffs, _modifiers);
-  }
-
-  if (_mouse_buttons.size() > 0) {
-    ButtonActivityMap::const_iterator it;
-    for (it = _mouse_buttons.begin(); it != _mouse_buttons.end(); ++it) {
-      if (it->second) {
-        context->ProcessMouseButtonDown(it->first, _modifiers);
-      } else {
-        context->ProcessMouseButtonUp(it->first, _modifiers);
-      }
-    }
-    _mouse_buttons.clear();
-  }
-
-  if (_wheel_delta != 0) {
-    context->ProcessMouseWheel(_wheel_delta, _modifiers);
-    _wheel_delta = 0;
-  }
-
   if (_keys.size() > 0) {
     ButtonActivityMap::const_iterator it;
     for (it = _keys.begin(); it != _keys.end(); ++it) {
@@ -354,6 +330,30 @@ update_context(Rocket::Core::Context *context, int xoffs, int yoffs) {
       context->ProcessTextInput(*it);
     }
     _text_input.clear();
+  }
+
+  if (_mouse_xy_changed) {
+    _mouse_xy_changed = false;
+
+    context->ProcessMouseMove(_mouse_xy.get_x() - xoffs,
+                              _mouse_xy.get_y() - yoffs, _modifiers);
+  }
+
+  if (_mouse_buttons.size() > 0) {
+    ButtonActivityMap::const_iterator it;
+    for (it = _mouse_buttons.begin(); it != _mouse_buttons.end(); ++it) {
+      if (it->second) {
+        context->ProcessMouseButtonDown(it->first, _modifiers);
+      } else {
+        context->ProcessMouseButtonUp(it->first, _modifiers);
+      }
+    }
+    _mouse_buttons.clear();
+  }
+
+  if (_wheel_delta != 0) {
+    context->ProcessMouseWheel(_wheel_delta, _modifiers);
+    _wheel_delta = 0;
   }
 
   context->Update();


### PR DESCRIPTION
On Linux (at least), a key event is accompanied with a mouse position
event.  If a libRocket UI is listening to e.g. "mouseover" events,
then any keypress will first appear to be a mouse movement, tripping
up code that tries to handle focus with both keyboard and mouse
support.

This change merely dispatches key events before any mouse events to
avoid this problem.