### PR TITLE
stdpy: Fix an import error introduced with the core.pyd rename.

### DIFF
--- a/direct/src/stdpy/file.py
+++ b/direct/src/stdpy/file.py
@@ -10,7 +10,7 @@ __all__ = [
     'execfile',
     ]
 
-import panda3d._core as core
+from panda3d import core
 import sys
 import os
 import io


### PR DESCRIPTION
Just a 1-line fix for an issue I encountered.