### PR TITLE
Fix swizzle masks on vector types

### DIFF
--- a/panda/src/linmath/lpoint3_src.h
+++ b/panda/src/linmath/lpoint3_src.h
@@ -42,6 +42,10 @@ PUBLISHED:
   INLINE_LINMATH FLOATNAME(LPoint2) get_xz() const;
   INLINE_LINMATH FLOATNAME(LPoint2) get_yz() const;
 
+  MAKE_PROPERTY(xy, get_xy);
+  MAKE_PROPERTY(xz, get_xz);
+  MAKE_PROPERTY(yz, get_yz);
+
   INLINE_LINMATH FLOATNAME(LPoint3) operator - () const;
 
   INLINE_LINMATH FLOATNAME(LVecBase3)

--- a/panda/src/linmath/lpoint4_src.I
+++ b/panda/src/linmath/lpoint4_src.I
@@ -105,6 +105,28 @@ unit_w() {
   return (const FLOATNAME(LPoint4) &)FLOATNAME(LVecBase4)::unit_w();
 }
 
+
+////////////////////////////////////////////////////////////////////
+//     Function: LPoint4::get_xyz
+//       Access: Published
+//  Description: Returns the x, y and z component of this vector
+////////////////////////////////////////////////////////////////////
+INLINE_LINMATH FLOATNAME(LPoint3) FLOATNAME(LPoint4)::
+get_xyz() const {
+  return FLOATNAME(LPoint3)(_v(0), _v(1), _v(2));
+}
+
+////////////////////////////////////////////////////////////////////
+//     Function: LPoint4::get_xy
+//       Access: Published
+//  Description: Returns the x and y component of this vector
+////////////////////////////////////////////////////////////////////
+INLINE_LINMATH FLOATNAME(LPoint2) FLOATNAME(LPoint4)::
+get_xy() const {
+  return FLOATNAME(LPoint2)(_v(0), _v(1));
+}
+
+
 ////////////////////////////////////////////////////////////////////
 //     Function: LPoint4::unary -
 //       Access: Public

--- a/panda/src/linmath/lpoint4_src.h
+++ b/panda/src/linmath/lpoint4_src.h
@@ -33,6 +33,12 @@ PUBLISHED:
   INLINE_LINMATH static const FLOATNAME(LPoint4) &unit_z();
   INLINE_LINMATH static const FLOATNAME(LPoint4) &unit_w();
 
+  INLINE_LINMATH FLOATNAME(LPoint3) get_xyz() const;
+  INLINE_LINMATH FLOATNAME(LPoint2) get_xy() const;
+
+  MAKE_PROPERTY(xyz, get_xyz);
+  MAKE_PROPERTY(xy, get_xy);
+
   INLINE_LINMATH FLOATNAME(LPoint4) operator - () const;
 
   INLINE_LINMATH FLOATNAME(LVecBase4)

--- a/panda/src/linmath/lvecBase3_src.h
+++ b/panda/src/linmath/lvecBase3_src.h
@@ -74,6 +74,8 @@ PUBLISHED:
   MAKE_PROPERTY(y, get_y, set_y);
   MAKE_PROPERTY(z, get_z, set_z);
   MAKE_PROPERTY(xy, get_xy);
+  MAKE_PROPERTY(xz, get_xz);
+  MAKE_PROPERTY(yz, get_yz);
 
   // These next functions add to an existing value.
   // i.e. foo.set_x(foo.get_x() + value)

--- a/panda/src/linmath/lvecBase4_src.h
+++ b/panda/src/linmath/lvecBase4_src.h
@@ -84,8 +84,9 @@ PUBLISHED:
   MAKE_PROPERTY(x, get_x, set_x);
   MAKE_PROPERTY(y, get_y, set_y);
   MAKE_PROPERTY(z, get_z, set_z);
-  MAKE_PROPERTY(xy, get_xy);
+
   MAKE_PROPERTY(xyz, get_xyz);
+  MAKE_PROPERTY(xy, get_xy);
 
   // These next functions add to an existing value.
   // i.e. foo.set_x(foo.get_x() + value)

--- a/panda/src/linmath/lvector3_src.h
+++ b/panda/src/linmath/lvector3_src.h
@@ -42,6 +42,11 @@ PUBLISHED:
   INLINE_LINMATH FLOATNAME(LVector2) get_xz() const;
   INLINE_LINMATH FLOATNAME(LVector2) get_yz() const;
 
+  MAKE_PROPERTY(xy, get_xy);
+  MAKE_PROPERTY(xz, get_xz);
+  MAKE_PROPERTY(yz, get_yz);
+
+
   INLINE_LINMATH FLOATNAME(LVector3) operator - () const;
 
   INLINE_LINMATH FLOATNAME(LVecBase3) operator + (const FLOATNAME(LVecBase3) &other) const;

--- a/panda/src/linmath/lvector4_src.I
+++ b/panda/src/linmath/lvector4_src.I
@@ -106,6 +106,26 @@ unit_w() {
 }
 
 ////////////////////////////////////////////////////////////////////
+//     Function: LVector4::get_xyz
+//       Access: Published
+//  Description: Returns the x, y and z component of this vector
+////////////////////////////////////////////////////////////////////
+INLINE_LINMATH FLOATNAME(LVector3) FLOATNAME(LVector4)::
+get_xyz() const {
+  return FLOATNAME(LVector3)(_v(0), _v(1), _v(2));
+}
+
+////////////////////////////////////////////////////////////////////
+//     Function: LVector4::get_xy
+//       Access: Published
+//  Description: Returns the x and y component of this vector
+////////////////////////////////////////////////////////////////////
+INLINE_LINMATH FLOATNAME(LVector2) FLOATNAME(LVector4)::
+get_xy() const {
+  return FLOATNAME(LVector2)(_v(0), _v(1));
+}
+
+////////////////////////////////////////////////////////////////////
 //     Function: LVector4::unary -
 //       Access: Public
 //  Description:

--- a/panda/src/linmath/lvector4_src.h
+++ b/panda/src/linmath/lvector4_src.h
@@ -33,6 +33,12 @@ PUBLISHED:
   INLINE_LINMATH static const FLOATNAME(LVector4) &unit_z();
   INLINE_LINMATH static const FLOATNAME(LVector4) &unit_w();
 
+  INLINE_LINMATH FLOATNAME(LVector3) get_xyz() const;
+  INLINE_LINMATH FLOATNAME(LVector2) get_xy() const;
+
+  MAKE_PROPERTY(xyz, get_xyz);
+  MAKE_PROPERTY(xy, get_xy);
+
   INLINE_LINMATH FLOATNAME(LVector4) operator - () const;
 
   INLINE_LINMATH FLOATNAME(LVecBase4) operator + (const FLOATNAME(LVecBase4) &other) const;


### PR DESCRIPTION
This pull requests fixes certain swizzle masks on the builtin vector types, namely those derived from LVecBase3 and LVecBase4. 

It ensures that calling get_xy() on a LPoint3f for example returns an LPoint2f, and not LVecBase3f.
