### PR TITLE
Fix typo in glGraphicsStateGuardian

### DIFF
--- a/panda/src/glstuff/glGraphicsStateGuardian_src.cxx
+++ b/panda/src/glstuff/glGraphicsStateGuardian_src.cxx
@@ -184,7 +184,7 @@ static const string default_fshader =
 #ifndef OPENGLES
   "  p3d_FragColor = texture(p3d_Texture0, texcoord);\n"
   "  p3d_FragColor += p3d_TexAlphaOnly;\n" // Hack for text rendering
-  "  p3d_FragColor = color;\n"
+  "  p3d_FragColor *= color;\n"
 #else
   "  gl_FragColor = texture2D(p3d_Texture0, texcoord).bgra;\n"
   "  gl_FragColor += p3d_TexAlphaOnly;\n" // Hack for text rendering


### PR DESCRIPTION
This pr fixes a typo in glGraphicsStateGuardian, preventing text and sprites to be rendered with their color only.