### PR TITLE
Add bilinear filtering to TexturePeeker

### DIFF
--- a/panda/src/gobj/texturePeeker.I
+++ b/panda/src/gobj/texturePeeker.I
@@ -48,3 +48,11 @@ INLINE int TexturePeeker::
 get_z_size() const {
   return _z_size;
 }
+
+/**
+ * Returns whether a given coordinate is inside of the texture dimensions.
+ */
+INLINE bool TexturePeeker::
+has_pixel(size_t x, size_t y) const {
+  return x >= 0 && y >= 0 && x < _x_size && y < _y_size;
+}

--- a/panda/src/gobj/texturePeeker.h
+++ b/panda/src/gobj/texturePeeker.h
@@ -36,8 +36,11 @@ PUBLISHED:
   INLINE int get_y_size() const;
   INLINE int get_z_size() const;
 
+  INLINE bool has_pixel(size_t x, size_t y) const;
   void lookup(LColor &color, PN_stdfloat u, PN_stdfloat v) const;
   void lookup(LColor &color, PN_stdfloat u, PN_stdfloat v, PN_stdfloat w) const;
+  void fetch_pixel(LColor &color, size_t x, size_t y) const;
+  bool lookup_bilinear(LColor &color, PN_stdfloat u, PN_stdfloat v) const;
   void filter_rect(LColor &color,
                    PN_stdfloat min_u, PN_stdfloat min_v,
                    PN_stdfloat max_u, PN_stdfloat max_v) const;


### PR DESCRIPTION
This adds the `calc_bilinear_point` method to the TexturePeeker, so bilinear lookups can be performed. This is similar to `PfmFile::calc_bilinear_point()`.