### PR TITLE
Work around timestamp precision in ramdisks

### DIFF
--- a/panda/src/express/virtualFileMountRamdisk.cxx
+++ b/panda/src/express/virtualFileMountRamdisk.cxx
@@ -235,7 +235,13 @@ open_write_file(const Filename &file, bool truncate) {
   if (truncate) {
     // Reset to an empty string.
     f->_data.str(string());
-    f->_timestamp = time(NULL);
+
+    // Instead of setting the time, we ensure that we always store a newer time.
+    // This is a workarround for the case that a file is written twice per
+    // second, since the timer only has a one second precision. The proper
+    // solution to fix this would be to switch to a higher precision
+    // timer everywhere.
+    f->_timestamp = max(f->_timestamp + 1, time(NULL));
   }
 
   return new OSubStream(&f->_wrapper, 0, 0);
@@ -275,7 +281,9 @@ open_read_write_file(const Filename &file, bool truncate) {
   if (truncate) {
     // Reset to an empty string.
     f->_data.str(string());
-    f->_timestamp = time(NULL);
+
+    // See open_write_file
+    f->_timestamp = max(f->_timestamp + 1, time(NULL));
   }
 
   return new SubStream(&f->_wrapper, 0, 0);


### PR DESCRIPTION
When writing multiple times per second to a file on a VirtualFileMountRamdisk, the file is not cached properly. This is due to the timestamp resolution (which only captures seconds).

This PR fixes the issue, by ensuring that the modified timestamp is always greater than the original timestamp.
This might lead to timestamps from the future, however this is not a concern.

The proper solution would be to switch to a higher precision timer, but for now, this fixes the issue.