### PR TITLE
Add bulletHeightfieldShape constructor for use with ShaderTerrainMesh. Fix bulletHeightfieldShape to support non-square images.

### DIFF
--- a/panda/src/bullet/bulletHeightfieldShape.cxx
+++ b/panda/src/bullet/bulletHeightfieldShape.cxx
@@ -7,7 +7,7 @@
  * with this source code in a file named "LICENSE."
  *
  * @file bulletHeightfieldShape.cxx
- * @author enn0x, wolfgangp
+ * @author enn0x
  * @date 2010-02-05
  */
 

--- a/panda/src/bullet/bulletHeightfieldShape.cxx
+++ b/panda/src/bullet/bulletHeightfieldShape.cxx
@@ -79,7 +79,6 @@ BulletHeightfieldShape(Texture *tex, PN_stdfloat max_height, BulletUpAxis up) {
 
   PN_stdfloat step_x = 1.0 / (PN_stdfloat)tex->get_x_size();
   PN_stdfloat step_y = 1.0 / (PN_stdfloat)tex->get_y_size();
-  //bullet_cat.warning() << "Steps: " << step_x << "\n" << step_y << endl;
 
   PT(TexturePeeker) peeker = tex->peek();
   LColor sample;

--- a/panda/src/bullet/bulletHeightfieldShape.cxx
+++ b/panda/src/bullet/bulletHeightfieldShape.cxx
@@ -8,7 +8,7 @@
  *
  * @file bulletHeightfieldShape.cxx
  * @author enn0x, wolfgangp
- * @date 2016-03-02
+ * @date 2010-02-05
  */
 
 #include "bulletHeightfieldShape.h"

--- a/panda/src/bullet/bulletHeightfieldShape.cxx
+++ b/panda/src/bullet/bulletHeightfieldShape.cxx
@@ -73,12 +73,12 @@ set_use_diamond_subdivision(bool flag) {
 BulletHeightfieldShape::
 BulletHeightfieldShape(Texture *tex, PN_stdfloat max_height, BulletUpAxis up) {
 
-  _num_rows = tex->get_x_size()+1;
-  _num_cols = tex->get_y_size()+1;
+  _num_rows = tex->get_x_size() + 1;
+  _num_cols = tex->get_y_size() + 1;
   _data = new float[_num_rows * _num_cols];
 
-  PN_stdfloat step_x = 1.0/(PN_stdfloat)tex->get_x_size();
-  PN_stdfloat step_y = 1.0/(PN_stdfloat)tex->get_y_size();
+  PN_stdfloat step_x = 1.0 / (PN_stdfloat)tex->get_x_size();
+  PN_stdfloat step_y = 1.0 / (PN_stdfloat)tex->get_y_size();
   //bullet_cat.warning() << "Steps: " << step_x << "\n" << step_y << endl;
 
   PT(TexturePeeker) peeker = tex->peek();
@@ -86,8 +86,8 @@ BulletHeightfieldShape(Texture *tex, PN_stdfloat max_height, BulletUpAxis up) {
 
   for (int row=0; row < _num_rows; row++) {
     for (int column=0; column < _num_cols; column++) {
-      if (!peeker->lookup_bilinear(sample, row*step_x, column*step_y)){
-      bullet_cat.error() << "Could not sample texture." << endl;
+      if (!peeker->lookup_bilinear(sample, row * step_x, column * step_y)) {
+        bullet_cat.error() << "Could not sample texture." << endl;
       }
       // Transpose
       _data[_num_rows * column + row] = max_height * sample.get_x();

--- a/panda/src/bullet/bulletHeightfieldShape.h
+++ b/panda/src/bullet/bulletHeightfieldShape.h
@@ -21,6 +21,8 @@
 #include "bulletShape.h"
 
 #include "pnmImage.h"
+#include "texture.h"
+#include "texturePeeker.h"
 
 /**
  *
@@ -29,6 +31,7 @@ class EXPCL_PANDABULLET BulletHeightfieldShape : public BulletShape {
 
 PUBLISHED:
   BulletHeightfieldShape(const PNMImage &image, PN_stdfloat max_height, BulletUpAxis up=Z_up);
+  BulletHeightfieldShape(Texture *tex, PN_stdfloat max_height, BulletUpAxis up=Z_up);
   INLINE BulletHeightfieldShape(const BulletHeightfieldShape &copy);
   INLINE void operator = (const BulletHeightfieldShape &copy);
   INLINE ~BulletHeightfieldShape();

--- a/panda/src/bullet/bulletManifoldPoint.cxx
+++ b/panda/src/bullet/bulletManifoldPoint.cxx
@@ -92,7 +92,7 @@ get_position_world_on_b() const {
 LPoint3 BulletManifoldPoint::
 get_normal_world_on_b() const {
 
-  return btVector3_to_LPoint3(_pt.m_normalWorldOnB);
+  return btVector3_to_LVector3(_pt.m_normalWorldOnB);
 }
 
 /**

--- a/panda/src/bullet/bulletManifoldPoint.h
+++ b/panda/src/bullet/bulletManifoldPoint.h
@@ -34,7 +34,7 @@ PUBLISHED:
   PN_stdfloat get_applied_impulse() const;
   LPoint3 get_position_world_on_a() const;
   LPoint3 get_position_world_on_b() const;
-  LPoint3 get_normal_world_on_b() const;
+  LVector3 get_normal_world_on_b() const;
   LPoint3 get_local_point_a() const;
   LPoint3 get_local_point_b() const;
 


### PR DESCRIPTION
To use bulletHeightfieldShape's texture constructor with samples/shader-terrain/main.py:

```python
"""
Bullet collision for ShaderTerrainMesh

Assumptions:
1) BulletWorld is self.BulletWorld and BulletWorld's NodePath is self.BulletWorldNP.
2) A 16bit grayscale image is used with STM (recommended).

N.B.: The Bullet Heightfield collision mesh will only match up correctly with the
ShaderTerrainMesh if the STM sample's vertex shader is used (and no tessellation
shaders)!
"""
from panda3d.bullet import BulletRigidBodyNode, BulletHeightfieldShape

stm_tex = self.terrain_node.get_heightfield_tex()
stm_pos = self.terrain.get_pos()
stm_scale = self.terrain.get_scale()

stm_coll = BulletHeightfieldShape(stm_tex, stm_scale.z)
# Should match the Panda3D config variable "stm-use-hexagonal-layout" (default is True)
stm_coll.set_use_diamond_subdivision(True)  # default is False
stm_t = BulletRigidBodyNode('stm_bullet')
stm_t.set_static(True)
stm_t.add_shape(stm_coll)
stmNP = self.BulletWorldNP.attach_new_node(stm_t)
stmNP.set_sx(stm_scale.x / stm_tex.get_x_size())
stmNP.set_sy(stm_scale.y / stm_tex.get_y_size())
stmNP.set_pos(stm_pos + stm_scale / 2)
self.BulletWorld.attach(stm_t)
```