### PR TITLE
Handle Python 2 vs Python 3 stdlib differences when building the morepy package

### DIFF
--- a/direct/src/p3d/panda3d.pdef
+++ b/direct/src/p3d/panda3d.pdef
@@ -1,3 +1,4 @@
+import sys
 from panda3d.core import Filename, PandaSystem, getModelPath
 
 # This file defines a number of standard "packages" that correspond to
@@ -140,60 +141,81 @@ class morepy(package):
     config(display_name = "Python standard library")
     require('panda3d')
 
-    module('string', 're', 'struct', 'difflib', 'StringIO',
-           'cStringIO', 'StringIO', 'textwrap', 'codecs',
-           'unicodedata', 'stringprep', 'fpformat', 'datetime',
+    module('string', 're', 'struct', 'difflib', 'StringIO', 'StringIO',
+           'textwrap', 'codecs', 'unicodedata', 'stringprep', 'datetime',
            'calendar', 'collections', 'heapq', 'bisect', 'array',
-           'sets', 'sched', 'mutex', 'queue', 'weakref', 'UserDict',
-           'UserList', 'UserString', 'types', 'new', 'copy', 'pprint',
-           'repr', 'numbers', 'math', 'cmath', 'decimal', 'fractions',
+           'sched', 'queue', 'weakref', 'types', 'copy', 'pprint',
+           'numbers', 'math', 'cmath', 'decimal', 'fractions',
            'random', 'itertools', 'functools', 'operator', 'os.path',
-           'fileinput', 'stat', 'statvfs', 'filecmp', 'tempfile',
-           'glob', 'fnmatch', 'linecache', 'shutil', 'dircache',
-           'macpath', 'pickle', 'cPickle', 'copy_reg', 'shelve',
-           'marshal', 'anydbm', 'whichdb', 'dbm', 'gdbm', 'dbhash',
-           'bsddb', 'dumbdbm', 'zlib', 'gzip', 'bz2', 'zipfile',
-           'tarfile', 'csv', 'ConfigParser', 'robotparser', 'netrc',
-           'xdrlib', 'plistlib', 'hashlib', 'hmac', 'md5', 'sha', 'os',
+           'fileinput', 'filecmp', 'tempfile', 'glob', 'fnmatch', 'linecache',
+           'shutil', 'macpath', 'pickle', 'shelve', 'marshal', 'bsddb', 'zlib',
+           'gzip', 'bz2', 'zipfile', 'tarfile', 'csv', 'netrc',
+           'xdrlib', 'plistlib', 'hashlib', 'hmac', 'os',
            'time', 'optparse', 'getopt', 'logging', 'logging.*')
     module('getpass', 'curses', 'curses.textpad', 'curses.wrapper',
            'curses.ascii', 'curses.panel', 'platform', 'errno',
-           'ctypes', 'select', 'threading', 'thread',
-           'dummy_threading', 'dummy_thread', 'multiprocessing',
-           'mmap', 'readline', 'rlcompleter', 'subprocess', 'socket',
-           'ssl', 'signal', 'popen2', 'asyncore', 'asynchat', 'email',
-           'json', 'mailcap', 'mailbox', 'mhlib', 'mimetools',
-           'mimetypes', 'MimeWriter', 'mimify', 'multifile', 'rfc822',
-           'base64', 'binhex', 'binascii', 'quopri', 'uu',
-           'HTMLParser', 'sgmllib', 'htmllib', 'htmlentitydefs',
-           'xml.parsers.expat', 'xml.dom', 'xml.dom.minidom',
+           'ctypes', 'select', 'threading', 'dummy_threading', 'dummy_thread',
+           'multiprocessing', 'mmap', 'readline', 'rlcompleter', 'subprocess',
+           'socket', 'ssl', 'signal', 'asyncore', 'asynchat', 'email', 'json',
+           'mailcap', 'mailbox', 'mimetypes', 'base64', 'binhex', 'binascii',
+           'quopri', 'uu', 'xml.parsers.expat', 'xml.dom', 'xml.dom.minidom',
            'xml.dom.pulldom', 'xml.sax', 'xml.sax.handler',
            'xml.sax.saxutils', 'xml.sax.xmlreader',
            'xml.etree.ElementTree', 'webbrowser', 'cgi', 'cgitb')
-    module('wsgiref', 'urllib', 'urllib2', 'httplib', 'ftplib',
-           'poplib', 'imaplib', 'nntplib', 'smtplib', 'smtpd',
-           'telnetlib', 'uuid', 'urlparse', 'SocketServer',
-           'BaseHTTPServer', 'SimpleHTTPServer', 'CGIHTTPServer',
-           'cookielib', 'Cookie', 'xmlrpclib', 'SimpleXMLRPCServer',
-           'DocXMLRPCServer', 'audioop', 'imageop', 'aifc', 'sunau',
+    module('wsgiref', 'ftplib', 'poplib', 'imaplib', 'nntplib', 'smtplib',
+           'smtpd', 'telnetlib', 'uuid', 'audioop', 'aifc', 'sunau',
            'wave', 'chunk', 'colorsys', 'imghdr', 'sndhdr',
            'ossaudiodev', 'gettext', 'locale', 'cmd', 'shlex',
            'pydoc', 'doctest', 'unittest', 'test',
-           'test.test_support', 'bdb', 'pdb', 'hotshot', 'timeit',
-           'trace', 'sys', '__builtin__')
+           'bdb', 'pdb', 'hotshot', 'timeit', 'trace', 'sys', '__builtin__')
     module('future_builtins', 'warnings', 'contextlib', 'abc',
            'atexit', 'traceback', '__future__', 'gc', 'inspect',
-           'site', 'user', 'fpectl', 'code', 'codeop', 'rexec',
-           'Bastion', 'imp', 'imputil', 'zipimport', 'pkgutil',
+           'site', 'fpectl', 'code', 'codeop', 'zipimport', 'pkgutil',
            'modulefinder', 'runpy', 'parser', 'symtable', 'symbol',
            'token', 'keyword', 'tokenize', 'tabnanny', 'pyclbr',
            'py_compile', 'compileall', 'dis', 'pickletools',
-           'distutils', 'formatter', 'msilib', 'msvcrt', '_winreg',
-           'winsound', 'posix', 'pwd', 'spwd', 'grp', 'crypt', 'dl',
-           'termios', 'tty', 'pty', 'fcntl', 'pipes', 'posixfile',
-           'resource', 'nis', 'syslog', 'commands', 'ic', 'MacOS',
-           'macostools', 'findertools', 'EasyDialogs', 'FrameWork',
-           'autoGIL', 'ColorPicker', 'ast')
+           'distutils', 'msilib', 'msvcrt', 'winsound', 'posix', 'pwd', 'spwd',
+           'grp', 'crypt', 'termios', 'tty', 'pty', 'fcntl', 'pipes',
+           'resource', 'nis', 'syslog', 'ast')
+
+    # Handle module name differences between Python 2 and Python 3 (see PEP3108)
+    if sys.version_info[0] < 3:
+        # Deprecated modules that were removed in Python 3
+        module('posixfile', 'rfc822', 'mimetools','MimeWriter', 'mimify',
+               'multifile', 'sets', 'md5', 'sha', 'imp',  'formatter')
+        # Mac-specific modules that were removed
+        module('autoGIL', 'ColorPicker', 'EasyDialogs', 'findertools',
+               'FrameWork', 'ic',  'MacOS', 'macostools')
+        # Removed because they were hardly used
+        module('imputil', 'mutex', 'user', 'new')
+        # Removed because they were obsolete
+        module('Bastion', 'rexec', 'commands', 'dircache', 'dl', 'fpformat',
+               'htmllib', 'imageop', 'mhlib', 'popen2', 'sgmllib', 'stat',
+               'statvfs', 'thread', 'UserDict', 'UserList', 'UserString')
+        # Renamed to fix PEP8 violations
+        module('_winreg', 'ConfigParser', 'copy_reg', 'SocketServer')
+        # C and Python implementations of the same interface were merged
+        module('cPickle', 'cStringIO')
+        # Renamed because of poorly chosen names
+        module('repr', 'test.test_support')
+        # Modules that got grouped under packages
+        module('anydbm', 'whichdb', 'dbm', 'dumbdbm', 'gdbm', 'dbhash')
+        module('HTMLParser', 'htmlentitydefs')
+        module('BaseHTTPServer', 'SimpleHTTPServer', 'cookielib', 'Cookie',
+               'CGIHTTPServer', 'httplib')
+        module('urllib', 'urllib2', 'urlparse', 'robotparser')
+        module('xmlrpclib', 'SimpleXMLRPCServer', 'DocXMLRPCServer')
+    else:
+        # Renamed to fix PEP8 violations
+        module('winreg', 'configparser', 'copyreg', 'socketserver')
+        # Renamed because of poorly chosen names
+        module('reprlib', 'test.support')
+        # Modules that got grouped under packages
+        module('dbm')
+        module('html')
+        module('http')
+        module('urllib')
+        module('xmlrpc')
 
     # To add the multitude of standard Python string encodings.
     module('encodings', 'encodings.*')


### PR DESCRIPTION

See PEP3108 for more details on stdlib differences. This has only been tested on Python 3.