### PR TITLE
Fix missing coordinate system in sample

### DIFF
--- a/samples/shader-terrain/main.py
+++ b/samples/shader-terrain/main.py
@@ -20,6 +20,7 @@ class ShaderTerrainDemo(ShowBase):
         load_prc_file_data("", """
             textures-power-2 none
             window-title Panda3D Shader Terrain Demo
+            gl-coordinate-system default
         """)
 
         # Initialize the showbase


### PR DESCRIPTION
This adds `gl-coordinate-system default` to the shader terrain mesh sample to make the shader terrain works as expected. Otherwise the LOD is computed in a wrong way.