### PR TITLE
Fix error "TypeError: 'NoneType' object is not iterable"

### DIFF
--- a/direct/src/fsm/FSM.py
+++ b/direct/src/fsm/FSM.py
@@ -310,7 +310,7 @@ class FSM(DirectObject):
                 self.name, request, str(args)[1:]))
 
             filter = self.getCurrentFilter()
-            result = list(filter(request, args))
+            result = filter(request, args)
             if result:
                 if isinstance(result, str):
                     # If the return value is a string, it's just the name


### PR DESCRIPTION
filter(request, args) can return None, and in that case an error will be thrown.

The list() procedure is unnecessary, since if the filter returns a string, it will be wrapped into a tuple anyways.