### PR TITLE
Support for setting a heightfield handle directly on the ShaderTerrainMesh

### DIFF
--- a/panda/src/grutil/shaderTerrainMesh.I
+++ b/panda/src/grutil/shaderTerrainMesh.I
@@ -12,26 +12,28 @@
  */
 
 /**
- * @brief Sets the path to the heightfield
- * @details This sets the path to the terrain heightfield. It should be 16bit
+ * @brief Sets the heightfield texture
+ * @details This sets the heightfield texture. It should be 16bit
  *   single channel, and have a power-of-two resolution greater than 32.
  *   Common sizes are 2048x2048 or 4096x4096.
  *
- * @param filename Path to the heightfield
+ *   You should call generate() after setting the heightfield.
+ *
+ * @param filename Heightfield texture
  */
-INLINE void ShaderTerrainMesh::set_heightfield_filename(const Filename& filename) {
-  _heightfield_source = filename;
+INLINE void ShaderTerrainMesh::set_heightfield(Texture* heightfield) {
+  _heightfield_tex = heightfield;
 }
 
 /**
- * @brief Returns the heightfield path
- * @details This returns the path of the terrain heightfield, previously set with
+ * @brief Returns the heightfield
+ * @details This returns the terrain heightfield, previously set with
  *   set_heightfield()
  *
  * @return Path to the heightfield
  */
-INLINE const Filename& ShaderTerrainMesh::get_heightfield_filename() const {
-  return _heightfield_source;
+INLINE Texture* ShaderTerrainMesh::get_heightfield() const {
+  return _heightfield_tex;
 }
 
 /**

--- a/panda/src/grutil/shaderTerrainMesh.h
+++ b/panda/src/grutil/shaderTerrainMesh.h
@@ -55,9 +55,9 @@ PUBLISHED:
 
   ShaderTerrainMesh();
 
-  INLINE void set_heightfield_filename(const Filename& filename);
-  INLINE const Filename& get_heightfield_filename() const;
-  MAKE_PROPERTY(heightfield_filename, get_heightfield_filename, set_heightfield_filename);
+  INLINE void set_heightfield(Texture* heightfield);
+  INLINE Texture* get_heightfield() const;
+  MAKE_PROPERTY(heightfield, get_heightfield, set_heightfield);
 
   INLINE void set_chunk_size(size_t chunk_size);
   INLINE size_t get_chunk_size() const;
@@ -152,8 +152,8 @@ private:
     ChunkDataEntry* storage_ptr;
   };
 
-  bool do_load_heightfield();
-  void do_convert_heightfield();
+  bool do_check_heightfield();
+  void do_extract_heightfield();
   void do_init_data_texture();
   void do_create_chunks();
   void do_init_chunk(Chunk* chunk);
@@ -164,7 +164,6 @@ private:
   bool do_check_lod_matches(Chunk* chunk, TraversalData* data);
 
   Chunk _base_chunk;
-  Filename _heightfield_source;
   size_t _size;
   size_t _chunk_size;
   bool _generate_patches;

--- a/samples/shader-terrain/main.py
+++ b/samples/shader-terrain/main.py
@@ -2,15 +2,14 @@
 
 # Author: tobspr
 #
-# Last Updated: 2016-02-13
+# Last Updated: 2016-04-30
 #
 # This tutorial provides an example of using the ShaderTerrainMesh class
-
-import os, sys, math, random
 
 from direct.showbase.ShowBase import ShowBase
 from panda3d.core import ShaderTerrainMesh, Shader, load_prc_file_data
 from panda3d.core import SamplerState
+
 
 class ShaderTerrainDemo(ShowBase):
     def __init__(self):
@@ -19,14 +18,14 @@ class ShaderTerrainDemo(ShowBase):
         # before the ShowBase is initialized
         load_prc_file_data("", """
             textures-power-2 none
-            window-title Panda3D Shader Terrain Demo
             gl-coordinate-system default
+            window-title Panda3D ShaderTerrainMesh Demo
         """)
 
         # Initialize the showbase
         ShowBase.__init__(self)
 
-        # Increase camera FOV aswell as the far plane
+        # Increase camera FOV as well as the far plane
         self.camLens.set_fov(90)
         self.camLens.set_near_far(0.1, 50000)
 
@@ -35,7 +34,7 @@ class ShaderTerrainDemo(ShowBase):
 
         # Set a heightfield, the heightfield should be a 16-bit png and
         # have a quadratic size of a power of two.
-        self.terrain_node.heightfield_filename = "heightfield.png"
+        self.terrain_node.heightfield = self.loader.loadTexture("heightfield.png")
 
         # Set the target triangle width. For a value of 10.0 for example,
         # the terrain will attempt to make every triangle 10 pixels wide on screen.
@@ -44,16 +43,20 @@ class ShaderTerrainDemo(ShowBase):
         # Generate the terrain
         self.terrain_node.generate()
 
-        # Attach the terrain to the main scene and set its scale
+        # Attach the terrain to the main scene and set its scale. With no scale
+        # set, the terrain ranges from (0, 0, 0) to (1, 1, 1)
         self.terrain = self.render.attach_new_node(self.terrain_node)
         self.terrain.set_scale(1024, 1024, 100)
         self.terrain.set_pos(-512, -512, -70.0)
 
         # Set a shader on the terrain. The ShaderTerrainMesh only works with
-        # an applied shader. You can use the shaders used here in your own shaders
+        # an applied shader. You can use the shaders used here in your own application
         terrain_shader = Shader.load(Shader.SL_GLSL, "terrain.vert.glsl", "terrain.frag.glsl")
         self.terrain.set_shader(terrain_shader)
         self.terrain.set_shader_input("camera", self.camera)
+
+        # Shortcut to view the wireframe mesh
+        self.accept("f3", self.toggleWireframe)
 
         # Set some texture on the terrain
         grass_tex = self.loader.loadTexture("textures/grass.png")
@@ -61,7 +64,7 @@ class ShaderTerrainDemo(ShowBase):
         grass_tex.set_anisotropic_degree(16)
         self.terrain.set_texture(grass_tex)
 
-        # Load some skybox - you can safely ignore this code
+        # Load a skybox - you can safely ignore this code
         skybox = self.loader.loadModel("models/skybox.bam")
         skybox.reparent_to(self.render)
         skybox.set_scale(20000)
@@ -77,5 +80,4 @@ class ShaderTerrainDemo(ShowBase):
         skybox_shader = Shader.load(Shader.SL_GLSL, "skybox.vert.glsl", "skybox.frag.glsl")
         skybox.set_shader(skybox_shader)
 
-demo = ShaderTerrainDemo()
-demo.run()
+ShaderTerrainDemo().run()


### PR DESCRIPTION
This patch allows setting the heightfield handle directly on the shader terrain mesh, instead of specifying a filename.

This makes the terrain more flexible, and also avoids having to copy the heightfield each time it changed.

The property `heightfield_filename` has been replaced with `heightfield`