### PR TITLE
Fix Python3 support

### DIFF
--- a/direct/src/task/Task.py
+++ b/direct/src/task/Task.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     signal = None
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 from panda3d.core import *
 from direct.extensions_native import HTTPChannel_extensions
 


### PR DESCRIPTION
Another way to fix Python3 support. Only this PR or #106 should be accepted, but not both. #106 seems a bit nicer to me, but I don't know if it will work (i.e., support unicode) for Python2.