### PR TITLE
Remove useless "children" property of DistributedObjectBase

### DIFF
--- a/direct/src/distributed/DistributedObjectBase.py
+++ b/direct/src/distributed/DistributedObjectBase.py
@@ -13,7 +13,6 @@ class DistributedObjectBase(DirectObject):
     def __init__(self, cr):
         assert self.notify.debugStateCall(self)
         self.cr = cr
-        self.children = {}
         self.parentId = None
         self.zoneId = None
 


### PR DESCRIPTION
This property is not used and causes problems on the latest build.