### PR TITLE
Fix pmerge to work with Python 3

### DIFF
--- a/direct/src/p3d/SeqValue.py
+++ b/direct/src/p3d/SeqValue.py
@@ -77,6 +77,12 @@ class SeqValue:
         """ Compares to another seq value. """
         return cmp(self.value, other.value)
 
+    def __lt__(self, other):
+        return self.value < other.value
+
+    def __gt__(self, other):
+        return self.value > other.value
+
     def __bool__(self):
         return bool(self.value)
 


### PR DESCRIPTION
Python 3 uses `__lt__` and `__gt__` instead of `__cmp__`.