### PR TITLE
OpenMayaMac.h Removed

### DIFF
--- a/pandatool/src/mayaprogs/mayaSavePview.h
+++ b/pandatool/src/mayaprogs/mayaSavePview.h
@@ -26,7 +26,7 @@
 
 #ifdef __MACH__
 #undef _BOOL
-#include "maya/OpenMayaMac.h"
+#define OSMac_ 1
 #endif
 
 // Even though we don't include any Panda headers, it's safe to include this


### PR DESCRIPTION
OpenMayaMac.h has been removed as it is no longer used. Customer's legacy projects must be updated to remove the use of the header file.