### PR TITLE
Implement make_copy() for BulletRigidBodyNode

### DIFF
--- a/panda/src/bullet/bulletBodyNode.cxx
+++ b/panda/src/bullet/bulletBodyNode.cxx
@@ -37,6 +37,25 @@ BulletBodyNode(const char *name) : PandaNode(name) {
 }
 
 /**
+ *
+ */
+BulletBodyNode::
+BulletBodyNode(const BulletBodyNode &copy) :
+  PandaNode(copy),
+  _shapes(copy._shapes)
+{
+  if (copy._shape && copy._shape->getShapeType() == COMPOUND_SHAPE_PROXYTYPE) {
+    _shape = new btCompoundShape(copy._shape);
+  }
+  else if (copy._shape && copy._shape->getShapeType() == EMPTY_SHAPE_PROXYTYPE) {
+    _shape = new btEmptyShape();
+  }
+  else {
+    _shape = copy._shape;
+  }
+}
+
+/**
  * Returns the subset of CollideMask bits that may be set for this particular
  * type of PandaNode.  For BodyNodes this returns all bits on.
  */

--- a/panda/src/bullet/bulletBodyNode.h
+++ b/panda/src/bullet/bulletBodyNode.h
@@ -33,6 +33,7 @@ class BulletShape;
 class EXPCL_PANDABULLET BulletBodyNode : public PandaNode {
 protected:
   BulletBodyNode(const char *name);
+  BulletBodyNode(const BulletBodyNode &copy);
 
 PUBLISHED:
   INLINE ~BulletBodyNode();

--- a/panda/src/bullet/bulletRigidBodyNode.cxx
+++ b/panda/src/bullet/bulletRigidBodyNode.cxx
@@ -47,6 +47,28 @@ BulletRigidBodyNode(const char *name) : BulletBodyNode(name) {
 }
 
 /**
+ * Do not call the copy constructor directly; instead, use make_copy() or
+ * copy_subgraph() to make a copy of a node.
+ */
+BulletRigidBodyNode::
+BulletRigidBodyNode(const BulletRigidBodyNode &copy) :
+  BulletBodyNode(copy)
+{
+  _motion = new MotionState(*copy._motion);
+  _rigid = new btRigidBody(*copy._rigid);
+}
+
+/**
+ * Returns a newly-allocated PandaNode that is a shallow copy of this one.  It
+ * will be a different pointer, but its internal data may or may not be shared
+ * with that of the original PandaNode.  No children will be copied.
+ */
+PandaNode *BulletRigidBodyNode::
+make_copy() const {
+  return new BulletRigidBodyNode(*this);
+}
+
+/**
  *
  */
 void BulletRigidBodyNode::

--- a/panda/src/bullet/bulletRigidBodyNode.h
+++ b/panda/src/bullet/bulletRigidBodyNode.h
@@ -130,8 +130,10 @@ private:
 public:
   static void register_with_read_factory();
   virtual void write_datagram(BamWriter *manager, Datagram &dg);
+  virtual PandaNode *make_copy() const;
 
 protected:
+  BulletRigidBodyNode(const BulletRigidBodyNode &copy);
   static TypedWritable *make_from_bam(const FactoryParams &params);
   void fillin(DatagramIterator &scan, BamReader *manager);
 


### PR DESCRIPTION
This appears to be the last piece needed to load BulletRigidBodyNodes
from BAM files.