### PR TITLE
Added fixed functions pipeline checking in runtime (bad)

### DIFF
--- a/panda/src/display/graphicsStateGuardian.I
+++ b/panda/src/display/graphicsStateGuardian.I
@@ -531,6 +531,14 @@ get_supports_depth_stencil() const {
 }
 
 /**
+ * Returns true if this particular GSG supports luminance textures.
+ */
+INLINE bool GraphicsStateGuardian::
+get_supports_luminance_texture() const {
+  return _supports_luminance_texture;
+}
+
+/**
  * Returns true if this particular GSG supports the filter mode FT_shadow for
  * depth textures.
  */

--- a/panda/src/display/graphicsStateGuardian.cxx
+++ b/panda/src/display/graphicsStateGuardian.cxx
@@ -245,6 +245,9 @@ GraphicsStateGuardian(CoordinateSystem internal_coordinate_system,
   _supports_geometry_instancing = false;
   _supports_indirect_draw = false;
 
+  // We are safe assuming it has luminance support
+  _supports_luminance_texture = true;
+
   // Assume a maximum of 1 render target in absence of MRT.
   _max_color_targets = 1;
   _supports_dual_source_blending = false;

--- a/panda/src/display/graphicsStateGuardian.h
+++ b/panda/src/display/graphicsStateGuardian.h
@@ -153,6 +153,7 @@ PUBLISHED:
   INLINE bool get_supports_generate_mipmap() const;
   INLINE bool get_supports_depth_texture() const;
   INLINE bool get_supports_depth_stencil() const;
+  INLINE bool get_supports_luminance_texture() const;
   INLINE bool get_supports_shadow_filter() const;
   INLINE bool get_supports_sampler_objects() const;
   INLINE bool get_supports_basic_shaders() const;
@@ -202,6 +203,7 @@ PUBLISHED:
   MAKE_PROPERTY(supports_generate_mipmap, get_supports_generate_mipmap);
   MAKE_PROPERTY(supports_depth_texture, get_supports_depth_texture);
   MAKE_PROPERTY(supports_depth_stencil, get_supports_depth_stencil);
+  MAKE_PROPERTY(supports_luminance_texture, get_supports_luminance_texture);
   MAKE_PROPERTY(supports_shadow_filter, get_supports_shadow_filter);
   MAKE_PROPERTY(supports_sampler_objects, get_supports_sampler_objects);
   MAKE_PROPERTY(supports_basic_shaders, get_supports_basic_shaders);
@@ -593,6 +595,7 @@ protected:
   bool _supports_generate_mipmap;
   bool _supports_depth_texture;
   bool _supports_depth_stencil;
+  bool _supports_luminance_texture;
   bool _supports_shadow_filter;
   bool _supports_sampler_objects;
   bool _supports_basic_shaders;

--- a/panda/src/glstuff/glCgShaderContext_src.cxx
+++ b/panda/src/glstuff/glCgShaderContext_src.cxx
@@ -762,25 +762,27 @@ disable_shader_vertex_arrays() {
       _glgsg->disable_vertex_attrib_array(p);
     } else {
 #ifdef SUPPORT_FIXED_FUNCTION
-      switch (p) {
-      case CA_unknown:
-        break;
-      case CA_vertex:
-        glDisableClientState(GL_VERTEX_ARRAY);
-        break;
-      case CA_normal:
-        glDisableClientState(GL_NORMAL_ARRAY);
-        break;
-      case CA_color:
-        glDisableClientState(GL_COLOR_ARRAY);
-        break;
-      case CA_secondary_color:
-        glDisableClientState(GL_SECONDARY_COLOR_ARRAY);
-        break;
-      default:
-        _glgsg->_glClientActiveTexture(GL_TEXTURE0 + (p - CA_texcoord));
-        glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-        break;
+      if(_glgsg->has_fixed_function_pipeline()) {
+        switch (p) {
+        case CA_unknown:
+          break;
+        case CA_vertex:
+          glDisableClientState(GL_VERTEX_ARRAY);
+          break;
+        case CA_normal:
+          glDisableClientState(GL_NORMAL_ARRAY);
+          break;
+        case CA_color:
+          glDisableClientState(GL_COLOR_ARRAY);
+          break;
+        case CA_secondary_color:
+          glDisableClientState(GL_SECONDARY_COLOR_ARRAY);
+          break;
+        default:
+          _glgsg->_glClientActiveTexture(GL_TEXTURE0 + (p - CA_texcoord));
+          glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+          break;
+        }
       }
 #endif  // SUPPORT_FIXED_FUNCTION
     }
@@ -876,40 +878,42 @@ update_shader_vertex_arrays(ShaderContext *prev, bool force) {
         } else {
           // It's a conventional vertex attribute.  Ugh.
 #ifdef SUPPORT_FIXED_FUNCTION
-          switch (p) {
-          case CA_unknown:
-            break;
+          if(_glgsg->has_fixed_function_pipeline()) {
+            switch (p) {
+            case CA_unknown:
+              break;
 
-          case CA_vertex:
-            glVertexPointer(num_values, type, stride, client_pointer);
-            glEnableClientState(GL_VERTEX_ARRAY);
-            break;
+            case CA_vertex:
+              glVertexPointer(num_values, type, stride, client_pointer);
+              glEnableClientState(GL_VERTEX_ARRAY);
+              break;
 
-          case CA_normal:
-            glNormalPointer(type, stride, client_pointer);
-            glEnableClientState(GL_NORMAL_ARRAY);
-            break;
+            case CA_normal:
+              glNormalPointer(type, stride, client_pointer);
+              glEnableClientState(GL_NORMAL_ARRAY);
+              break;
 
-          case CA_color:
-            if (numeric_type == GeomEnums::NT_packed_dabc) {
-              glColorPointer(GL_BGRA, GL_UNSIGNED_BYTE, stride, client_pointer);
-            } else {
-              glColorPointer(num_values, type, stride, client_pointer);
+            case CA_color:
+              if (numeric_type == GeomEnums::NT_packed_dabc) {
+                glColorPointer(GL_BGRA, GL_UNSIGNED_BYTE, stride, client_pointer);
+              } else {
+                glColorPointer(num_values, type, stride, client_pointer);
+              }
+              glEnableClientState(GL_COLOR_ARRAY);
+              break;
+
+            case CA_secondary_color:
+              _glgsg->_glSecondaryColorPointer(num_values, type,
+                                               stride, client_pointer);
+              glEnableClientState(GL_SECONDARY_COLOR_ARRAY);
+              break;
+
+            default:
+              _glgsg->_glClientActiveTexture(GL_TEXTURE0 + (p - CA_texcoord));
+              glTexCoordPointer(num_values, type, stride, client_pointer);
+              glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+              break;
             }
-            glEnableClientState(GL_COLOR_ARRAY);
-            break;
-
-          case CA_secondary_color:
-            _glgsg->_glSecondaryColorPointer(num_values, type,
-                                             stride, client_pointer);
-            glEnableClientState(GL_SECONDARY_COLOR_ARRAY);
-            break;
-
-          default:
-            _glgsg->_glClientActiveTexture(GL_TEXTURE0 + (p - CA_texcoord));
-            glTexCoordPointer(num_values, type, stride, client_pointer);
-            glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-            break;
           }
 #endif  // SUPPORT_FIXED_FUNCTION
         }
@@ -917,7 +921,7 @@ update_shader_vertex_arrays(ShaderContext *prev, bool force) {
         // There is no vertex column with this name; disable the attribute
         // array.
 #ifdef SUPPORT_FIXED_FUNCTION
-        if (p == 0) {
+        if (_glgsg->has_fixed_function_pipeline() && (p == 0)) {
           // NOTE: if we disable attribute 0 in compatibility profile, the
           // object will disappear.  In GLSL we fix this by forcing the vertex
           // column to be at 0, but we don't have control over that with Cg.
@@ -944,30 +948,32 @@ update_shader_vertex_arrays(ShaderContext *prev, bool force) {
           }
         } else {
 #ifdef SUPPORT_FIXED_FUNCTION
-          switch (p) {
-          case CA_unknown:
-            break;
-          case CA_vertex:
-            glDisableClientState(GL_VERTEX_ARRAY);
-            break;
-          case CA_normal:
-            glDisableClientState(GL_NORMAL_ARRAY);
-            break;
-          case CA_color:
-            glDisableClientState(GL_COLOR_ARRAY);
+          if(_glgsg->has_fixed_function_pipeline()) {
+            switch (p) {
+            case CA_unknown:
+              break;
+            case CA_vertex:
+              glDisableClientState(GL_VERTEX_ARRAY);
+              break;
+            case CA_normal:
+              glDisableClientState(GL_NORMAL_ARRAY);
+              break;
+            case CA_color:
+              glDisableClientState(GL_COLOR_ARRAY);
 #ifdef STDFLOAT_DOUBLE
-            glColor4dv(_glgsg->_scene_graph_color.get_data());
+              glColor4dv(_glgsg->_scene_graph_color.get_data());
 #else
-            glColor4fv(_glgsg->_scene_graph_color.get_data());
+              glColor4fv(_glgsg->_scene_graph_color.get_data());
 #endif
-            break;
-          case CA_secondary_color:
-            glDisableClientState(GL_SECONDARY_COLOR_ARRAY);
-            break;
-          default:
-            _glgsg->_glClientActiveTexture(GL_TEXTURE0 + (p - CA_texcoord));
-            glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-            break;
+              break;
+            case CA_secondary_color:
+              glDisableClientState(GL_SECONDARY_COLOR_ARRAY);
+              break;
+            default:
+              _glgsg->_glClientActiveTexture(GL_TEXTURE0 + (p - CA_texcoord));
+              glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+              break;
+            }
           }
 #endif  // SUPPORT_FIXED_FUNCTION
         }

--- a/panda/src/glstuff/glGraphicsStateGuardian_src.I
+++ b/panda/src/glstuff/glGraphicsStateGuardian_src.I
@@ -131,6 +131,38 @@ get_gl_version_minor() const {
 }
 
 /**
+ * Returns whether a core profile or a compatibility mode is considered.
+ */
+INLINE bool CLP(GraphicsStateGuardian)::
+has_core_profile() const {
+  return _core_profile;
+}
+
+/**
+ * Returns whether the fixed function pipeline is supported.
+ */
+INLINE bool CLP(GraphicsStateGuardian)::
+has_fixed_function_pipeline() const {
+#ifndef SUPPORT_FIXED_FUNCTION
+  return false;
+#else
+  // In OpenGL 3.1 the fixed function pipeline was declared deprecated, and
+  // theoretically all the pipeline should gone. However, some implementations
+  // kept them, "out of the law". After that, In OpenGL >= 3.2 the concept of
+  // core profile and compatibility mode where introduced. Therefore, since it
+  // is not possible to check whether those functions are implemented in GL 3.1
+  // or not, we should not try to use them.
+  if ((_gl_version_major == 3) && (_gl_version_minor == 1)) {
+    return false;
+  }
+  // Otherwise, we can just check whether we are using a core profile or a
+  // compatibility mode. The variable _core_profile is already taking into
+  // account if a GL <= 3.0 is considered (becoming false)
+  return !_core_profile;
+#endif
+}
+
+/**
  * Calls glFinish() if the config variable gl-finish is set True.
  */
 INLINE void CLP(GraphicsStateGuardian)::
@@ -363,7 +395,7 @@ enable_line_smooth(bool val) {
 INLINE void CLP(GraphicsStateGuardian)::
 enable_point_smooth(bool val) {
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (_point_smooth_enabled != val) {
+  if (has_fixed_function_pipeline() && (_point_smooth_enabled != val)) {
     _state_mask.clear_bit(TransparencyAttrib::get_class_slot());
     _point_smooth_enabled = val;
     if (val) {
@@ -529,6 +561,9 @@ enable_depth_test(bool val) {
  */
 INLINE void CLP(GraphicsStateGuardian)::
 enable_fog(bool val) {
+  if (!has_fixed_function_pipeline()){
+    return;
+  }
   if (_fog_enabled != val) {
     _fog_enabled = val;
     if (val) {
@@ -554,6 +589,9 @@ enable_fog(bool val) {
  */
 INLINE void CLP(GraphicsStateGuardian)::
 enable_alpha_test(bool val) {
+  if (!has_fixed_function_pipeline()){
+    return;
+  }
   if (_alpha_test_enabled != val) {
     _alpha_test_enabled = val;
     if (val) {
@@ -631,6 +669,9 @@ clear_color_write_mask() {
  */
 INLINE void CLP(GraphicsStateGuardian)::
 call_glLoadMatrix(const LMatrix4 &mat) {
+  if (!has_fixed_function_pipeline()){
+    return;
+  }
 #if defined(OPENGLES) && defined(STDFLOAT_DOUBLE)
   LMatrix4f matf = LCAST(float, mat);
   glLoadMatrixf(matf.get_data());
@@ -648,6 +689,9 @@ call_glLoadMatrix(const LMatrix4 &mat) {
  */
 INLINE void CLP(GraphicsStateGuardian)::
 call_glFogfv(GLenum pname, const LColor &color) {
+  if (!has_fixed_function_pipeline()){
+    return;
+  }
 #ifndef STDFLOAT_DOUBLE
   glFogfv(pname, color.get_data());
 #else  // STDFLOAT_DOUBLE
@@ -663,6 +707,9 @@ call_glFogfv(GLenum pname, const LColor &color) {
  */
 INLINE void CLP(GraphicsStateGuardian)::
 call_glMaterialfv(GLenum face, GLenum pname, const LColor &color) {
+  if (!has_fixed_function_pipeline()){
+    return;
+  }
 #ifndef STDFLOAT_DOUBLE
   glMaterialfv(face, pname, color.get_data());
 #else  // STDFLOAT_DOUBLE
@@ -678,6 +725,9 @@ call_glMaterialfv(GLenum face, GLenum pname, const LColor &color) {
  */
 INLINE void CLP(GraphicsStateGuardian)::
 call_glLightfv(GLenum light, GLenum pname, const LVecBase4 &value) {
+  if (!has_fixed_function_pipeline()){
+    return;
+  }
 #ifndef STDFLOAT_DOUBLE
   glLightfv(light, pname, value.get_data());
 #else  // STDFLOAT_DOUBLE
@@ -693,6 +743,9 @@ call_glLightfv(GLenum light, GLenum pname, const LVecBase4 &value) {
  */
 INLINE void CLP(GraphicsStateGuardian)::
 call_glLightfv(GLenum light, GLenum pname, const LVecBase3 &value) {
+  if (!has_fixed_function_pipeline()){
+    return;
+  }
 #ifndef STDFLOAT_DOUBLE
   glLightfv(light, pname, value.get_data());
 #else  // STDFLOAT_DOUBLE
@@ -708,6 +761,9 @@ call_glLightfv(GLenum light, GLenum pname, const LVecBase3 &value) {
  */
 INLINE void CLP(GraphicsStateGuardian)::
 call_glLightModelfv(GLenum pname, const LVecBase4 &value) {
+  if (!has_fixed_function_pipeline()){
+    return;
+  }
 #ifndef STDFLOAT_DOUBLE
   glLightModelfv(pname, value.get_data());
 #else  // STDFLOAT_DOUBLE
@@ -723,6 +779,9 @@ call_glLightModelfv(GLenum pname, const LVecBase4 &value) {
  */
 INLINE void CLP(GraphicsStateGuardian)::
 call_glTexEnvfv(GLenum target, GLenum pname, const LVecBase4 &value) {
+  if (!has_fixed_function_pipeline()){
+    return;
+  }
 #ifndef STDFLOAT_DOUBLE
   glTexEnvfv(target, pname, value.get_data());
 #else  // STDFLOAT_DOUBLE

--- a/panda/src/glstuff/glGraphicsStateGuardian_src.cxx
+++ b/panda/src/glstuff/glGraphicsStateGuardian_src.cxx
@@ -1265,6 +1265,7 @@ reset() {
   _supports_depth_stencil = has_extension("GL_OES_packed_depth_stencil");
   _supports_depth24 = has_extension("GL_OES_depth24");
   _supports_depth32 = has_extension("GL_OES_depth32");
+  _supports_luminance_texture = true;
 
 #elif defined(OPENGLES)
   if (is_at_least_gles_version(3, 0)) {
@@ -1285,12 +1286,15 @@ reset() {
     _supports_depth24 = has_extension("GL_OES_depth24");
     _supports_depth32 = has_extension("GL_OES_depth32");
   }
+  _supports_luminance_texture = true;
 #else
   _supports_depth_texture = (is_at_least_gl_version(1, 4) ||
                              has_extension("GL_ARB_depth_texture"));
   _supports_depth_stencil = (is_at_least_gl_version(3, 0) ||
                              has_extension("GL_ARB_framebuffer_object") ||
                              has_extension("GL_EXT_packed_depth_stencil"));
+  _supports_luminance_texture = (!is_at_least_gl_version(4, 0) ||
+                                 !core_profile);
 #endif
 
 #ifdef OPENGLES_2
@@ -12693,9 +12697,8 @@ get_texture_memory_size(CLP(TextureContext) *gtc) {
   }
 
   // OK, get the noncompressed size.
-  GLint red_size, green_size, blue_size, alpha_size,
-    luminance_size, intensity_size;
-  GLint depth_size = 0;
+  GLint red_size, green_size, blue_size, alpha_size;
+  GLint depth_size = 0, luminance_size = 0, intensity_size = 0;
   glGetTexLevelParameteriv(page_target, 0,
                            GL_TEXTURE_RED_SIZE, &red_size);
   glGetTexLevelParameteriv(page_target, 0,
@@ -12704,10 +12707,12 @@ get_texture_memory_size(CLP(TextureContext) *gtc) {
                            GL_TEXTURE_BLUE_SIZE, &blue_size);
   glGetTexLevelParameteriv(page_target, 0,
                            GL_TEXTURE_ALPHA_SIZE, &alpha_size);
-  glGetTexLevelParameteriv(page_target, 0,
-                           GL_TEXTURE_LUMINANCE_SIZE, &luminance_size);
-  glGetTexLevelParameteriv(page_target, 0,
-                           GL_TEXTURE_INTENSITY_SIZE, &intensity_size);
+  if (_supports_luminance_texture) {
+    glGetTexLevelParameteriv(page_target, 0,
+                             GL_TEXTURE_LUMINANCE_SIZE, &luminance_size);
+    glGetTexLevelParameteriv(page_target, 0,
+                             GL_TEXTURE_INTENSITY_SIZE, &intensity_size);
+  }
   if (_supports_depth_texture) {
     glGetTexLevelParameteriv(page_target, 0,
                              GL_TEXTURE_DEPTH_SIZE, &depth_size);

--- a/panda/src/glstuff/glGraphicsStateGuardian_src.cxx
+++ b/panda/src/glstuff/glGraphicsStateGuardian_src.cxx
@@ -369,6 +369,10 @@ CLP(GraphicsStateGuardian)(GraphicsEngine *engine, GraphicsPipe *pipe) :
   _gl_shadlang_ver_major = 0;
   _gl_shadlang_ver_minor = 0;
 
+  // Let's say we have a core profile, to be checked later (Otherwise, if we are
+  // wrong the user may ask for some non-available functions)
+  _core_profile = true;
+
   // Hack.  Turn on the flag that we turned off at a higher level, since we
   // know this works properly in OpenGL, and we want the performance benefit
   // it gives us.
@@ -552,6 +556,7 @@ reset() {
 #else
   static const bool core_profile = true;
 #endif
+  _core_profile = core_profile;
 
   // Print out a list of all extensions.
   report_extensions();
@@ -723,7 +728,7 @@ reset() {
 #endif
 
 #if !defined(OPENGLES) && defined(SUPPORT_FIXED_FUNCTION)
-  if (is_at_least_gl_version(1, 4)) {
+  if (has_fixed_function_pipeline() && is_at_least_gl_version(1, 4)) {
     _glSecondaryColorPointer = (PFNGLSECONDARYCOLORPOINTERPROC)
       get_extension_func("glSecondaryColorPointer");
 
@@ -1105,12 +1110,13 @@ reset() {
   _supports_rescale_normal = true;
 #else
   _supports_rescale_normal =
-    !core_profile && gl_support_rescale_normal &&
+    has_fixed_function_pipeline() && gl_support_rescale_normal &&
     (is_at_least_gl_version(1, 2) || has_extension("GL_EXT_rescale_normal"));
 #endif
 
 #ifndef OPENGLES
-  _use_separate_specular_color = gl_separate_specular_color &&
+  _use_separate_specular_color =
+    has_fixed_function_pipeline() && gl_separate_specular_color &&
     (is_at_least_gl_version(1, 2) || has_extension("GL_EXT_separate_specular_color"));
 #endif
 #endif  // SUPPORT_FIXED_FUNCTION
@@ -1162,8 +1168,10 @@ reset() {
       get_extension_func("glActiveTexture");
 
 #ifdef SUPPORT_FIXED_FUNCTION
-    _glClientActiveTexture = (PFNGLACTIVETEXTUREPROC)
-      get_extension_func("glClientActiveTexture");
+    if (has_fixed_function_pipeline()) {
+      _glClientActiveTexture = (PFNGLACTIVETEXTUREPROC)
+        get_extension_func("glClientActiveTexture");
+    }
 #endif
 
 #ifdef SUPPORT_IMMEDIATE_MODE
@@ -1192,8 +1200,10 @@ reset() {
       get_extension_func("glActiveTextureARB");
 
 #ifdef SUPPORT_FIXED_FUNCTION
-    _glClientActiveTexture = (PFNGLACTIVETEXTUREPROC)
-      get_extension_func("glClientActiveTextureARB");
+    if (has_fixed_function_pipeline()) {
+      _glClientActiveTexture = (PFNGLACTIVETEXTUREPROC)
+        get_extension_func("glClientActiveTextureARB");
+    }
 #endif
 
 #ifdef SUPPORT_IMMEDIATE_MODE
@@ -1219,10 +1229,14 @@ reset() {
   }
 
   if (supports_multitexture) {
-    if (_glActiveTexture == NULL
 #ifdef SUPPORT_FIXED_FUNCTION
-        || _glClientActiveTexture == NULL
+    if (has_fixed_function_pipeline() && (_glClientActiveTexture == NULL)){
+      GLCAT.warning()
+        << "Multitexture advertised as supported by OpenGL runtime, but could not get pointers to extension functions.\n";
+      supports_multitexture = false;
+    }
 #endif
+    if (_glActiveTexture == NULL
 #ifdef SUPPORT_IMMEDIATE_MODE
         || GLf(_glMultiTexCoord1) == NULL || GLf(_glMultiTexCoord2) == NULL
         || GLf(_glMultiTexCoord3) == NULL || GLf(_glMultiTexCoord4) == NULL
@@ -1240,7 +1254,7 @@ reset() {
   }
 
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (!supports_multitexture || core_profile) {
+  if (!supports_multitexture || !has_fixed_function_pipeline()) {
     _glClientActiveTexture = null_glActiveTexture;
   }
 #endif
@@ -1305,7 +1319,7 @@ reset() {
   _supports_texture_saved_result = false;
   _supports_texture_dot3 = false;
 #else
-  if (!core_profile) {
+  if (has_fixed_function_pipeline()) {
     _supports_texture_combine =
       is_at_least_gl_version(1, 3) ||
       is_at_least_gles_version(1, 1) ||
@@ -1783,11 +1797,7 @@ reset() {
   // to have a shader applied, or if it failed to compile.  This default
   // shader just outputs a red color, indicating that something went wrong.
 #ifndef SUPPORT_FIXED_FUNCTION
-  if (_default_shader == NULL) {
-    _default_shader = Shader::make(Shader::SL_GLSL, default_vshader, default_fshader);
-  }
-#elif !defined(OPENGLES)
-  if (_default_shader == NULL && core_profile) {
+  if (_default_shader == NULL && !has_fixed_function_pipeline()) {
     _default_shader = Shader::make(Shader::SL_GLSL, default_vshader, default_fshader);
   }
 #endif
@@ -2884,7 +2894,7 @@ reset() {
     _supports_stencil = support_stencil;
   }
 #ifdef SUPPORT_FIXED_FUNCTION
-  else if (support_stencil) {
+  else if (has_fixed_function_pipeline() && support_stencil) {
     GLint num_stencil_bits;
     glGetIntegerv(GL_STENCIL_BITS, &num_stencil_bits);
     _supports_stencil = (num_stencil_bits != 0);
@@ -2921,7 +2931,7 @@ reset() {
   glDisable(GL_LINE_SMOOTH);
 #endif
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (!core_profile) {
+  if (has_fixed_function_pipeline()) {
     glDisable(GL_POINT_SMOOTH);
   }
 #endif
@@ -2973,7 +2983,7 @@ reset() {
   // Count the max number of lights
   _max_lights = 0;
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (!core_profile) {
+  if (has_fixed_function_pipeline()) {
     GLint max_lights = 0;
     glGetIntegerv(GL_MAX_LIGHTS, &max_lights);
     _max_lights = max_lights;
@@ -2988,7 +2998,7 @@ reset() {
   // Count the max number of clipping planes
   _max_clip_planes = 0;
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (!core_profile) {
+  if (has_fixed_function_pipeline()) {
     GLint max_clip_planes = 0;
     glGetIntegerv(GL_MAX_CLIP_PLANES, &max_clip_planes);
     _max_clip_planes = max_clip_planes;
@@ -3002,7 +3012,7 @@ reset() {
 
   _max_texture_stages = 1;
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (supports_multitexture && !core_profile) {
+  if (supports_multitexture && has_fixed_function_pipeline()) {
     GLint max_texture_stages = 0;
     glGetIntegerv(GL_MAX_TEXTURE_UNITS, &max_texture_stages);
     _max_texture_stages = max_texture_stages;
@@ -3032,7 +3042,7 @@ reset() {
   report_my_gl_errors();
 
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (!core_profile) {
+  if (has_fixed_function_pipeline()) {
     if (gl_cheap_textures) {
       GLCAT.info()
         << "Setting glHint() for fastest textures.\n";
@@ -3045,7 +3055,7 @@ reset() {
 #endif
 
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (!core_profile) {
+  if (has_fixed_function_pipeline()) {
     GLint num_red_bits = 0;
     glGetIntegerv(GL_RED_BITS, &num_red_bits);
     if (num_red_bits < 8) {
@@ -3528,7 +3538,9 @@ clear_before_callback() {
   // is still set to stage 0.  CEGUI, in particular, makes this assumption.
   set_active_texture_stage(0);
 #ifdef SUPPORT_FIXED_FUNCTION
-  _glClientActiveTexture(GL_TEXTURE0);
+  if (has_fixed_function_pipeline()) {
+    _glClientActiveTexture(GL_TEXTURE0);
+  }
 #endif
 
   // Clear the bound sampler object, so that we do not inadvertently override
@@ -3595,16 +3607,18 @@ calc_projection_mat(const Lens *lens) {
 bool CLP(GraphicsStateGuardian)::
 prepare_lens() {
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (GLCAT.is_spam()) {
-    GLCAT.spam()
-      << "glMatrixMode(GL_PROJECTION): " << _projection_mat->get_mat() << endl;
+  if (has_fixed_function_pipeline()) {
+    if (GLCAT.is_spam()) {
+      GLCAT.spam()
+        << "glMatrixMode(GL_PROJECTION): " << _projection_mat->get_mat() << endl;
+    }
+
+    glMatrixMode(GL_PROJECTION);
+    call_glLoadMatrix(_projection_mat->get_mat());
+    report_my_gl_errors();
+
+    do_point_size();
   }
-
-  glMatrixMode(GL_PROJECTION);
-  call_glLoadMatrix(_projection_mat->get_mat());
-  report_my_gl_errors();
-
-  do_point_size();
 #endif
 
 #ifndef OPENGLES_1
@@ -3788,7 +3802,7 @@ end_frame(Thread *current_thread) {
   // Now is a good time to delete any pending display lists.
 #ifndef OPENGLES
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (display_lists) {
+  if (has_fixed_function_pipeline() && display_lists) {
     LightMutexHolder holder(_lock);
     if (!_deleted_display_lists.empty()) {
       DeletedNames::iterator ddli;
@@ -3898,10 +3912,12 @@ begin_draw_primitives(const GeomPipelineReader *geom_reader,
 #endif  // NDEBUG
 
 #ifndef SUPPORT_FIXED_FUNCTION
-  // We can't draw without a shader bound in OpenGL ES 2.  This shouldn't
-  // happen anyway unless the default shader failed to compile somehow.
-  if (_current_shader_context == NULL) {
-    return false;
+  if (!has_fixed_function_pipeline()) {
+    // We can't draw without a shader bound in OpenGL ES 2.  This shouldn't
+    // happen anyway unless the default shader failed to compile somehow.
+    if (_current_shader_context == NULL) {
+      return false;
+    }
   }
 #endif
 
@@ -3942,7 +3958,7 @@ begin_draw_primitives(const GeomPipelineReader *geom_reader,
   }
 
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (_data_reader->is_vertex_transformed()) {
+  if (has_fixed_function_pipeline() && _data_reader->is_vertex_transformed()) {
     // If the vertex data claims to be already transformed into clip
     // coordinates, wipe out the current projection and modelview matrix (so
     // we don't attempt to transform it again).
@@ -3956,7 +3972,8 @@ begin_draw_primitives(const GeomPipelineReader *geom_reader,
 #endif
 
 #if !defined(OPENGLES) && defined(SUPPORT_FIXED_FUNCTION)  // Display lists not supported by OpenGL ES.
-  if (/*geom_reader->get_usage_hint() == Geom::UH_static &&*/
+  if (has_fixed_function_pipeline() &&
+      /*geom_reader->get_usage_hint() == Geom::UH_static &&*/
       _data_reader->get_usage_hint() == Geom::UH_static &&
       display_lists) {
     // If the geom claims to be totally static, try to build it into a display
@@ -4047,33 +4064,35 @@ begin_draw_primitives(const GeomPipelineReader *geom_reader,
         _vertex_array_shader_context->disable_shader_vertex_arrays();
       }
 #ifdef SUPPORT_FIXED_FUNCTION
-      if (!update_standard_vertex_arrays(force)) {
+      if (has_fixed_function_pipeline() && !update_standard_vertex_arrays(force)) {
         return false;
       }
 #endif
     } else {
 #ifdef SUPPORT_FIXED_FUNCTION
-      // Shader.
-      if (_vertex_array_shader_context == 0 ||
-          _vertex_array_shader_context->uses_standard_vertex_arrays()) {
-        // Previous shader used standard arrays.
-        if (_current_shader_context->uses_standard_vertex_arrays()) {
-          // So does the current, so update them.
-          if (!update_standard_vertex_arrays(force)) {
-            return false;
+      if (has_fixed_function_pipeline()) {
+        // Shader.
+        if (_vertex_array_shader_context == 0 ||
+            _vertex_array_shader_context->uses_standard_vertex_arrays()) {
+          // Previous shader used standard arrays.
+          if (_current_shader_context->uses_standard_vertex_arrays()) {
+            // So does the current, so update them.
+            if (!update_standard_vertex_arrays(force)) {
+              return false;
+            }
+          } else {
+            // The current shader does not, so disable them entirely.
+            disable_standard_vertex_arrays();
           }
-        } else {
-          // The current shader does not, so disable them entirely.
-          disable_standard_vertex_arrays();
         }
-      }
 #ifdef HAVE_CG
-      else if (_vertex_array_shader_context->is_of_type(CLP(CgShaderContext)::get_class_type())) {
-        // The previous shader was a Cg shader, which can leave a messy
-        // situation.
-        _vertex_array_shader_context->disable_shader_vertex_arrays();
-      }
+        else if (_vertex_array_shader_context->is_of_type(CLP(CgShaderContext)::get_class_type())) {
+          // The previous shader was a Cg shader, which can leave a messy
+          // situation.
+          _vertex_array_shader_context->disable_shader_vertex_arrays();
+        }
 #endif
+      }
 #endif  // SUPPORT_FIXED_FUNCTION
       // Now update the vertex arrays for the current shader.
       if (!_current_shader_context->
@@ -4102,6 +4121,9 @@ begin_draw_primitives(const GeomPipelineReader *geom_reader,
  */
 bool CLP(GraphicsStateGuardian)::
 update_standard_vertex_arrays(bool force) {
+  if(!has_fixed_function_pipeline()) {
+    return false;
+  }
 #ifdef SUPPORT_IMMEDIATE_MODE
   if (_use_sender) {
     // We must use immediate mode to render primitives.
@@ -4322,6 +4344,9 @@ unbind_buffers() {
  */
 void CLP(GraphicsStateGuardian)::
 disable_standard_vertex_arrays() {
+  if(!has_fixed_function_pipeline()) {
+    return;
+  }
 #ifdef SUPPORT_IMMEDIATE_MODE
   if (_use_sender) return;
 #endif
@@ -5015,7 +5040,7 @@ draw_points(const GeomPrimitivePipelineReader *reader, bool force) {
 void CLP(GraphicsStateGuardian)::
 end_draw_primitives() {
 #if !defined(OPENGLES) && defined(SUPPORT_FIXED_FUNCTION)  // Display lists not supported by OpenGL ES.
-  if (_geom_display_list != 0) {
+  if (has_fixed_function_pipeline() && (_geom_display_list != 0)) {
     // If we were building a display list, close it now.
     glEndList();
     _load_display_list_pcollector.stop();
@@ -5029,12 +5054,12 @@ end_draw_primitives() {
 #endif
 
 #ifdef SUPPORT_FIXED_FUNCTION
-  if (_transform_stale) {
+  if (has_fixed_function_pipeline() && _transform_stale) {
     glMatrixMode(GL_MODELVIEW);
     call_glLoadMatrix(_internal_transform->get_mat());
   }
 
-  if (_data_reader->is_vertex_transformed()) {
+  if (has_fixed_function_pipeline() && _data_reader->is_vertex_transformed()) {
     // Restore the matrices that we pushed above.
     glMatrixMode(GL_PROJECTION);
     glPopMatrix();
@@ -5411,7 +5436,9 @@ prepare_geom(Geom *geom) {
 void CLP(GraphicsStateGuardian)::
 release_geom(GeomContext *gc) {
   CLP(GeomContext) *ggc = DCAST(CLP(GeomContext), gc);
-  ggc->release_display_lists();
+  if(has_fixed_function_pipeline()) {
+    ggc->release_display_lists();
+  }
   report_my_gl_errors();
 
   delete ggc;
@@ -6434,6 +6461,9 @@ framebuffer_copy_to_ram(Texture *tex, int view, int z,
  */
 void CLP(GraphicsStateGuardian)::
 apply_fog(Fog *fog) {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   Fog::Mode fmode = fog->get_mode();
   glFogf(GL_FOG_MODE, get_fog_mode_type(fmode));
 
@@ -6463,17 +6493,19 @@ apply_fog(Fog *fog) {
 void CLP(GraphicsStateGuardian)::
 do_issue_transform() {
 #ifdef SUPPORT_FIXED_FUNCTION
-  // OpenGL ES 2 does not support glLoadMatrix.
+  if (has_fixed_function_pipeline()) {
+    // OpenGL ES 2 does not support glLoadMatrix.
 
-  const TransformState *transform = _internal_transform;
-  if (GLCAT.is_spam()) {
-    GLCAT.spam()
-      << "glLoadMatrix(GL_MODELVIEW): " << transform->get_mat() << endl;
+    const TransformState *transform = _internal_transform;
+    if (GLCAT.is_spam()) {
+      GLCAT.spam()
+        << "glLoadMatrix(GL_MODELVIEW): " << transform->get_mat() << endl;
+    }
+
+    DO_PSTATS_STUFF(_transform_state_pcollector.add_level(1));
+    glMatrixMode(GL_MODELVIEW);
+    call_glLoadMatrix(transform->get_mat());
   }
-
-  DO_PSTATS_STUFF(_transform_state_pcollector.add_level(1));
-  glMatrixMode(GL_MODELVIEW);
-  call_glLoadMatrix(transform->get_mat());
 #endif
   _transform_stale = false;
 
@@ -6486,6 +6518,9 @@ do_issue_transform() {
  */
 void CLP(GraphicsStateGuardian)::
 do_issue_shade_model() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   const ShadeModelAttrib *target_shade_model;
   _target_rs->get_attrib_def(target_shade_model);
 
@@ -6514,7 +6549,7 @@ do_issue_shader() {
 
 #ifndef SUPPORT_FIXED_FUNCTION
   // If we don't have a shader, apply the default shader.
-  if (!shader) {
+  if (!has_fixed_function_pipeline() && !shader) {
     shader = _default_shader;
     nassertv(shader != NULL);
   }
@@ -6524,11 +6559,13 @@ do_issue_shader() {
     context = shader->prepare_now(get_prepared_objects(), this);
   }
 #ifndef SUPPORT_FIXED_FUNCTION
-  // If it failed, try applying the default shader.
-  if (shader != _default_shader && (context == 0 || !context->valid())) {
-    shader = _default_shader;
-    nassertv(shader != NULL);
-    context = shader->prepare_now(get_prepared_objects(), this);
+  if (!has_fixed_function_pipeline()) {
+    // If it failed, try applying the default shader.
+    if (shader != _default_shader && (context == 0 || !context->valid())) {
+      shader = _default_shader;
+      nassertv(shader != NULL);
+      context = shader->prepare_now(get_prepared_objects(), this);
+    }
   }
 #endif
 
@@ -6693,6 +6730,9 @@ do_issue_antialias() {
  */
 void CLP(GraphicsStateGuardian)::
 do_issue_rescale_normal() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   RescaleNormalAttrib::Mode mode = RescaleNormalAttrib::M_none;
 
   const RescaleNormalAttrib *target_rescale_normal;
@@ -6759,6 +6799,9 @@ do_issue_depth_test() {
  */
 void CLP(GraphicsStateGuardian)::
 do_issue_alpha_test() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
 #ifndef OPENGLES_1
   if (_target_shader->get_flag(ShaderAttrib::F_subsume_alpha_test)) {
     enable_alpha_test(false);
@@ -6841,6 +6884,9 @@ do_issue_cull_face() {
  */
 void CLP(GraphicsStateGuardian)::
 do_issue_fog() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   const FogAttrib *target_fog;
   _target_rs->get_attrib_def(target_fog);
 
@@ -6899,6 +6945,9 @@ do_issue_depth_offset() {
  */
 void CLP(GraphicsStateGuardian)::
 do_issue_material() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   static Material empty;
   const Material *material;
 
@@ -7228,6 +7277,9 @@ do_issue_blending() {
  */
 void CLP(GraphicsStateGuardian)::
 bind_light(PointLight *light_obj, const NodePath &light, int light_id) {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // static PStatCollector
   // _draw_set_state_light_bind_point_pcollector("Draw:Set
   // State:Light:Bind:Point"); PStatGPUTimer timer(this,
@@ -7272,6 +7324,9 @@ bind_light(PointLight *light_obj, const NodePath &light, int light_id) {
  */
 void CLP(GraphicsStateGuardian)::
 bind_light(DirectionalLight *light_obj, const NodePath &light, int light_id) {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // static PStatCollector
   // _draw_set_state_light_bind_directional_pcollector("Draw:Set
   // State:Light:Bind:Directional"); PStatGPUTimer timer(this,
@@ -7323,6 +7378,9 @@ bind_light(DirectionalLight *light_obj, const NodePath &light, int light_id) {
  */
 void CLP(GraphicsStateGuardian)::
 bind_light(Spotlight *light_obj, const NodePath &light, int light_id) {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // static PStatCollector
   // _draw_set_state_light_bind_spotlight_pcollector("Draw:Set
   // State:Light:Bind:Spotlight"); PStatGPUTimer timer(this,
@@ -8557,10 +8615,15 @@ get_external_image_format(Texture *tex) const {
 #endif
 
   case Texture::F_alpha:
-#if defined(SUPPORT_FIXED_FUNCTION) || defined(OPENGLES)
+#ifdef OPENGLES
     return GL_ALPHA;
 #else
-    return GL_RED;
+    if (has_fixed_function_pipeline()) {
+      return GL_ALPHA;
+    }
+    else {
+      return GL_RED;
+    }
 #endif
 
 #ifndef OPENGLES_1
@@ -8600,18 +8663,28 @@ get_external_image_format(Texture *tex) const {
 
   case Texture::F_luminance:
   case Texture::F_sluminance:
-#if defined(SUPPORT_FIXED_FUNCTION) || defined(OPENGLES)
+#ifdef OPENGLES
     return GL_LUMINANCE;
 #else
-    return GL_RED;
+    if (has_fixed_function_pipeline()) {
+      return GL_LUMINANCE;
+    }
+    else {
+      return GL_RED;
+    }
 #endif
   case Texture::F_luminance_alphamask:
   case Texture::F_luminance_alpha:
   case Texture::F_sluminance_alpha:
-#if defined(SUPPORT_FIXED_FUNCTION) || defined(OPENGLES)
+#ifdef OPENGLES
     return GL_LUMINANCE_ALPHA;
 #else
-    return GL_RG;
+    if (has_fixed_function_pipeline()) {
+      return GL_LUMINANCE_ALPHA;
+    }
+    else {
+      return GL_RG;
+    }
 #endif
 
 #ifndef OPENGLES_1
@@ -9258,42 +9331,51 @@ get_internal_image_format(Texture *tex, bool force_sized) const {
 #endif
 
   case Texture::F_alpha:
-#if defined(SUPPORT_FIXED_FUNCTION) || defined(OPENGLES)
+#ifdef OPENGLES
     return force_sized ? GL_ALPHA8 : GL_ALPHA;
 #else
-    return force_sized ? GL_R8 : GL_RED;
+    if (has_fixed_function_pipeline()) {
+      return force_sized ? GL_ALPHA8 : GL_ALPHA;
+    }
+    else {
+      return force_sized ? GL_R8 : GL_RED;
+    }
 #endif
 
   case Texture::F_luminance:
-#if defined(SUPPORT_FIXED_FUNCTION) || defined(OPENGLES)
-#ifndef OPENGLES
-    if (tex->get_component_type() == Texture::T_float) {
-      return GL_LUMINANCE16F_ARB;
-    } else if (tex->get_component_type() == Texture::T_short) {
-      return GL_LUMINANCE16_SNORM;
-    } else if (tex->get_component_type() == Texture::T_unsigned_short) {
-      return GL_LUMINANCE16;
-    } else
-#endif  // OPENGLES
-    {
-      return force_sized ? GL_LUMINANCE8 : GL_LUMINANCE;
-    }
+#ifdef OPENGLES
+    return force_sized ? GL_LUMINANCE8 : GL_LUMINANCE;
 #else
-    return force_sized ? GL_R8 : GL_RED;
+    if (has_fixed_function_pipeline()) {
+      if (tex->get_component_type() == Texture::T_float) {
+        return GL_LUMINANCE16F_ARB;
+      } else if (tex->get_component_type() == Texture::T_short) {
+        return GL_LUMINANCE16_SNORM;
+      } else if (tex->get_component_type() == Texture::T_unsigned_short) {
+        return GL_LUMINANCE16;
+      } else {
+        return force_sized ? GL_LUMINANCE8 : GL_LUMINANCE;
+      }
+    }
+    else {
+      return force_sized ? GL_R8 : GL_RED;
+    }
 #endif
   case Texture::F_luminance_alpha:
   case Texture::F_luminance_alphamask:
-#if defined(SUPPORT_FIXED_FUNCTION) || defined(OPENGLES)
-#ifndef OPENGLES
-    if (tex->get_component_type() == Texture::T_float || tex->get_component_type() == Texture::T_unsigned_short) {
-      return GL_LUMINANCE_ALPHA16F_ARB;
-    } else
-#endif  // OPENGLES
-    {
-      return force_sized ? GL_LUMINANCE8_ALPHA8 : GL_LUMINANCE_ALPHA;
-    }
+#ifdef OPENGLES
+    return force_sized ? GL_LUMINANCE8_ALPHA8 : GL_LUMINANCE_ALPHA;
 #else
-    return force_sized ? GL_RG8 : GL_RG;
+    if (has_fixed_function_pipeline()) {
+        if (tex->get_component_type() == Texture::T_float || tex->get_component_type() == Texture::T_unsigned_short) {
+        return GL_LUMINANCE_ALPHA16F_ARB;
+      } else {
+        return force_sized ? GL_LUMINANCE8_ALPHA8 : GL_LUMINANCE_ALPHA;
+      }
+    }
+    else {
+      return force_sized ? GL_RG8 : GL_RG;
+    }
 #endif
 
 #ifndef OPENGLES_1
@@ -9408,24 +9490,31 @@ is_compressed_format(GLenum format) {
 GLint CLP(GraphicsStateGuardian)::
 get_texture_apply_mode_type(TextureStage::Mode am) {
 #ifdef SUPPORT_FIXED_FUNCTION
-  switch (am) {
-  case TextureStage::M_modulate: return GL_MODULATE;
-  case TextureStage::M_decal: return GL_DECAL;
-  case TextureStage::M_blend: return GL_BLEND;
-  case TextureStage::M_replace: return GL_REPLACE;
-  case TextureStage::M_add: return GL_ADD;
-  case TextureStage::M_combine: return GL_COMBINE;
-  case TextureStage::M_blend_color_scale: return GL_BLEND;
-  case TextureStage::M_modulate_glow: return GL_MODULATE;
-  case TextureStage::M_modulate_gloss: return GL_MODULATE;
-  default:
-    // Other modes shouldn't get here.  Fall through and error.
-    break;
-  }
+  // This method requires to know if the fixed pipeline is supported, and
+  // therefore it cannot be static anymore
+  if (has_fixed_function_pipeline()) {
+    switch (am) {
+    case TextureStage::M_modulate: return GL_MODULATE;
+    case TextureStage::M_decal: return GL_DECAL;
+    case TextureStage::M_blend: return GL_BLEND;
+    case TextureStage::M_replace: return GL_REPLACE;
+    case TextureStage::M_add: return GL_ADD;
+    case TextureStage::M_combine: return GL_COMBINE;
+    case TextureStage::M_blend_color_scale: return GL_BLEND;
+    case TextureStage::M_modulate_glow: return GL_MODULATE;
+    case TextureStage::M_modulate_gloss: return GL_MODULATE;
+    default:
+      // Other modes shouldn't get here.  Fall through and error.
+      break;
+    }
 
-  GLCAT.error()
-    << "Invalid TextureStage::Mode value" << endl;
-  return GL_MODULATE;
+    GLCAT.error()
+      << "Invalid TextureStage::Mode value" << endl;
+    return GL_MODULATE;
+  }
+  else {
+    return 0;
+  }
 #else
   return 0;
 #endif
@@ -9438,19 +9527,26 @@ get_texture_apply_mode_type(TextureStage::Mode am) {
 GLint CLP(GraphicsStateGuardian)::
 get_texture_combine_type(TextureStage::CombineMode cm) {
 #ifdef SUPPORT_FIXED_FUNCTION
-  switch (cm) {
-  case TextureStage::CM_undefined: // fall through
-  case TextureStage::CM_replace: return GL_REPLACE;
-  case TextureStage::CM_modulate: return GL_MODULATE;
-  case TextureStage::CM_add: return GL_ADD;
-  case TextureStage::CM_add_signed: return GL_ADD_SIGNED;
-  case TextureStage::CM_interpolate: return GL_INTERPOLATE;
-  case TextureStage::CM_subtract: return GL_SUBTRACT;
-  case TextureStage::CM_dot3_rgb: return GL_DOT3_RGB;
-  case TextureStage::CM_dot3_rgba: return GL_DOT3_RGBA;
+  // This method requires to know if the fixed pipeline is supported, and
+  // therefore it cannot be static anymore
+  if (has_fixed_function_pipeline()) {
+    switch (cm) {
+    case TextureStage::CM_undefined: // fall through
+    case TextureStage::CM_replace: return GL_REPLACE;
+    case TextureStage::CM_modulate: return GL_MODULATE;
+    case TextureStage::CM_add: return GL_ADD;
+    case TextureStage::CM_add_signed: return GL_ADD_SIGNED;
+    case TextureStage::CM_interpolate: return GL_INTERPOLATE;
+    case TextureStage::CM_subtract: return GL_SUBTRACT;
+    case TextureStage::CM_dot3_rgb: return GL_DOT3_RGB;
+    case TextureStage::CM_dot3_rgba: return GL_DOT3_RGBA;
+    }
+    GLCAT.error()
+      << "Invalid TextureStage::CombineMode value" << endl;
   }
-  GLCAT.error()
-    << "Invalid TextureStage::CombineMode value" << endl;
+  else {
+    return GL_REPLACE;
+  }
 #endif
   return GL_REPLACE;
 }
@@ -9464,42 +9560,47 @@ get_texture_src_type(TextureStage::CombineSource cs,
                      int last_stage, int last_saved_result,
                      int this_stage) const {
 #ifdef SUPPORT_FIXED_FUNCTION
-  switch (cs) {
-  case TextureStage::CS_undefined: // fall through
-  case TextureStage::CS_texture: return GL_TEXTURE;
-  case TextureStage::CS_constant: return GL_CONSTANT;
-  case TextureStage::CS_primary_color: return GL_PRIMARY_COLOR;
-  case TextureStage::CS_constant_color_scale: return GL_CONSTANT;
+  if (has_fixed_function_pipeline()) {
+    switch (cs) {
+    case TextureStage::CS_undefined: // fall through
+    case TextureStage::CS_texture: return GL_TEXTURE;
+    case TextureStage::CS_constant: return GL_CONSTANT;
+    case TextureStage::CS_primary_color: return GL_PRIMARY_COLOR;
+    case TextureStage::CS_constant_color_scale: return GL_CONSTANT;
 
-  case TextureStage::CS_previous:
-    if (last_stage == this_stage - 1) {
-      return GL_PREVIOUS;
-    } else if (last_stage == -1) {
-      return GL_PRIMARY_COLOR;
-    } else if (_supports_texture_saved_result) {
-      return GL_TEXTURE0 + last_stage;
-    } else {
-      GLCAT.warning()
-        << "Current OpenGL driver does not support texture crossbar blending.\n";
-      return GL_PRIMARY_COLOR;
+    case TextureStage::CS_previous:
+      if (last_stage == this_stage - 1) {
+        return GL_PREVIOUS;
+      } else if (last_stage == -1) {
+        return GL_PRIMARY_COLOR;
+      } else if (_supports_texture_saved_result) {
+        return GL_TEXTURE0 + last_stage;
+      } else {
+        GLCAT.warning()
+          << "Current OpenGL driver does not support texture crossbar blending.\n";
+        return GL_PRIMARY_COLOR;
+      }
+
+    case TextureStage::CS_last_saved_result:
+      if (last_saved_result == this_stage - 1) {
+        return GL_PREVIOUS;
+      } else if (last_saved_result == -1) {
+        return GL_PRIMARY_COLOR;
+      } else if (_supports_texture_saved_result) {
+        return GL_TEXTURE0 + last_saved_result;
+      } else {
+        GLCAT.warning()
+          << "Current OpenGL driver does not support texture crossbar blending.\n";
+        return GL_PRIMARY_COLOR;
+      }
     }
 
-  case TextureStage::CS_last_saved_result:
-    if (last_saved_result == this_stage - 1) {
-      return GL_PREVIOUS;
-    } else if (last_saved_result == -1) {
-      return GL_PRIMARY_COLOR;
-    } else if (_supports_texture_saved_result) {
-      return GL_TEXTURE0 + last_saved_result;
-    } else {
-      GLCAT.warning()
-        << "Current OpenGL driver does not support texture crossbar blending.\n";
-      return GL_PRIMARY_COLOR;
-    }
+    GLCAT.error()
+      << "Invalid TextureStage::CombineSource value" << endl;
   }
-
-  GLCAT.error()
-    << "Invalid TextureStage::CombineSource value" << endl;
+  else {
+    return GL_TEXTURE;
+  }
 #endif
   return GL_TEXTURE;
 }
@@ -9875,6 +9976,9 @@ reissue_transforms() {
  */
 void CLP(GraphicsStateGuardian)::
 enable_lighting(bool enable) {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // static PStatCollector
   // _draw_set_state_light_enable_lighting_pcollector("Draw:Set
   // State:Light:Enable lighting"); PStatGPUTimer timer(this,
@@ -9896,6 +10000,9 @@ enable_lighting(bool enable) {
  */
 void CLP(GraphicsStateGuardian)::
 set_ambient_light(const LColor &color) {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // static PStatCollector _draw_set_state_light_ambient_pcollector("Draw:Set
   // State:Light:Ambient"); PStatGPUTimer timer(this,
   // _draw_set_state_light_ambient_pcollector);
@@ -9917,6 +10024,9 @@ set_ambient_light(const LColor &color) {
  */
 void CLP(GraphicsStateGuardian)::
 enable_light(int light_id, bool enable) {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // static PStatCollector
   // _draw_set_state_light_enable_light_pcollector("Draw:Set
   // State:Light:Enable light"); PStatGPUTimer timer(this,
@@ -9941,6 +10051,9 @@ enable_light(int light_id, bool enable) {
  */
 void CLP(GraphicsStateGuardian)::
 begin_bind_lights() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // static PStatCollector
   // _draw_set_state_light_begin_bind_pcollector("Draw:Set State:Light:Begin
   // bind"); PStatGPUTimer timer(this,
@@ -9971,6 +10084,9 @@ begin_bind_lights() {
  */
 void CLP(GraphicsStateGuardian)::
 end_bind_lights() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // static PStatCollector _draw_set_state_light_end_bind_pcollector("Draw:Set
   // State:Light:End bind"); PStatGPUTimer timer(this,
   // _draw_set_state_light_end_bind_pcollector);
@@ -9988,6 +10104,9 @@ end_bind_lights() {
  */
 void CLP(GraphicsStateGuardian)::
 enable_clip_plane(int plane_id, bool enable) {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   if (enable) {
     glEnable(get_clip_plane_id(plane_id));
   } else {
@@ -10007,6 +10126,9 @@ enable_clip_plane(int plane_id, bool enable) {
  */
 void CLP(GraphicsStateGuardian)::
 begin_bind_clip_planes() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // We need to temporarily load a new matrix so we can define the clip_plane
   // in a known coordinate system.  We pick the transform of the root.
   // (Alternatively, we could leave the current transform where it is and
@@ -10031,6 +10153,9 @@ begin_bind_clip_planes() {
  */
 void CLP(GraphicsStateGuardian)::
 bind_clip_plane(const NodePath &plane, int plane_id) {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   GLenum id = get_clip_plane_id(plane_id);
 
   CPT(TransformState) transform = plane.get_transform(_scene_setup->get_scene_root().get_parent());
@@ -10061,6 +10186,9 @@ bind_clip_plane(const NodePath &plane, int plane_id) {
  */
 void CLP(GraphicsStateGuardian)::
 end_bind_clip_planes() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   glMatrixMode(GL_MODELVIEW);
   glPopMatrix();
 }
@@ -10116,7 +10244,7 @@ set_state_and_transform(const RenderState *target,
     _state_mask.clear_bit(TextureAttrib::get_class_slot());
   }
 #ifndef SUPPORT_FIXED_FUNCTION
-  else if (_current_shader == NULL) { // In the case of OpenGL ES 2.x, we need to glUseShader before we draw anything.
+  else if (!has_fixed_function_pipeline() && _current_shader == NULL) { // In the case of OpenGL ES 2.x, we need to glUseShader before we draw anything.
     do_issue_shader();
     _state_mask.clear_bit(TextureAttrib::get_class_slot());
   }
@@ -10128,17 +10256,19 @@ set_state_and_transform(const RenderState *target,
 #endif
 
 #ifdef SUPPORT_FIXED_FUNCTION
-  int alpha_test_slot = AlphaTestAttrib::get_class_slot();
-  if (_target_rs->get_attrib(alpha_test_slot) != _state_rs->get_attrib(alpha_test_slot) ||
-      !_state_mask.get_bit(alpha_test_slot)
+  if (has_fixed_function_pipeline()) {
+    int alpha_test_slot = AlphaTestAttrib::get_class_slot();
+    if (_target_rs->get_attrib(alpha_test_slot) != _state_rs->get_attrib(alpha_test_slot) ||
+        !_state_mask.get_bit(alpha_test_slot)
 #ifndef OPENGLES_1
-      || (_target_shader->get_flag(ShaderAttrib::F_subsume_alpha_test) !=
-          _state_shader->get_flag(ShaderAttrib::F_subsume_alpha_test))
+        || (_target_shader->get_flag(ShaderAttrib::F_subsume_alpha_test) !=
+            _state_shader->get_flag(ShaderAttrib::F_subsume_alpha_test))
 #endif
-      ) {
-    // PStatGPUTimer timer(this, _draw_set_state_alpha_test_pcollector);
-    do_issue_alpha_test();
-    _state_mask.set_bit(alpha_test_slot);
+        ) {
+      // PStatGPUTimer timer(this, _draw_set_state_alpha_test_pcollector);
+      do_issue_alpha_test();
+      _state_mask.set_bit(alpha_test_slot);
+    }
   }
 #endif
 
@@ -10212,22 +10342,22 @@ set_state_and_transform(const RenderState *target,
   }
 
 #ifdef SUPPORT_FIXED_FUNCTION
-  int rescale_normal_slot = RescaleNormalAttrib::get_class_slot();
-  if (_target_rs->get_attrib(rescale_normal_slot) != _state_rs->get_attrib(rescale_normal_slot) ||
-      !_state_mask.get_bit(rescale_normal_slot)) {
-    // PStatGPUTimer timer(this, _draw_set_state_rescale_normal_pcollector);
-    do_issue_rescale_normal();
-    _state_mask.set_bit(rescale_normal_slot);
-  }
-#endif
+  if (has_fixed_function_pipeline()) {
+    int rescale_normal_slot = RescaleNormalAttrib::get_class_slot();
+    if (_target_rs->get_attrib(rescale_normal_slot) != _state_rs->get_attrib(rescale_normal_slot) ||
+        !_state_mask.get_bit(rescale_normal_slot)) {
+      // PStatGPUTimer timer(this, _draw_set_state_rescale_normal_pcollector);
+      do_issue_rescale_normal();
+      _state_mask.set_bit(rescale_normal_slot);
+    }
 
-#ifdef SUPPORT_FIXED_FUNCTION
-  int shade_model_slot = ShadeModelAttrib::get_class_slot();
-  if (_target_rs->get_attrib(shade_model_slot) != _state_rs->get_attrib(shade_model_slot) ||
-      !_state_mask.get_bit(shade_model_slot)) {
-    // PStatGPUTimer timer(this, _draw_set_state_shade_model_pcollector);
-    do_issue_shade_model();
-    _state_mask.set_bit(shade_model_slot);
+    int shade_model_slot = ShadeModelAttrib::get_class_slot();
+    if (_target_rs->get_attrib(shade_model_slot) != _state_rs->get_attrib(shade_model_slot) ||
+        !_state_mask.get_bit(shade_model_slot)) {
+      // PStatGPUTimer timer(this, _draw_set_state_shade_model_pcollector);
+      do_issue_shade_model();
+      _state_mask.set_bit(shade_model_slot);
+    }
   }
 #endif
 
@@ -10299,7 +10429,9 @@ set_state_and_transform(const RenderState *target,
       !_state_mask.get_bit(tex_matrix_slot)) {
     // PStatGPUTimer timer(this, _draw_set_state_tex_matrix_pcollector);
 #ifdef SUPPORT_FIXED_FUNCTION
-    do_issue_tex_matrix();
+    if (has_fixed_function_pipeline()) {
+      do_issue_tex_matrix();
+    }
 #endif
     _state_mask.set_bit(tex_matrix_slot);
 #ifndef OPENGLES_1
@@ -10310,13 +10442,15 @@ set_state_and_transform(const RenderState *target,
   }
 
 #ifdef SUPPORT_FIXED_FUNCTION
-  int tex_gen_slot = TexGenAttrib::get_class_slot();
-  if (_target_tex_gen != _state_tex_gen ||
-      !_state_mask.get_bit(tex_gen_slot)) {
-    // PStatGPUTimer timer(this, _draw_set_state_tex_gen_pcollector);
-    do_issue_tex_gen();
-    _state_tex_gen = _target_tex_gen;
-    _state_mask.set_bit(tex_gen_slot);
+  if (has_fixed_function_pipeline()) {
+    int tex_gen_slot = TexGenAttrib::get_class_slot();
+    if (_target_tex_gen != _state_tex_gen ||
+        !_state_mask.get_bit(tex_gen_slot)) {
+      // PStatGPUTimer timer(this, _draw_set_state_tex_gen_pcollector);
+      do_issue_tex_gen();
+      _state_tex_gen = _target_tex_gen;
+      _state_mask.set_bit(tex_gen_slot);
+    }
   }
 #endif
 
@@ -10325,7 +10459,9 @@ set_state_and_transform(const RenderState *target,
       !_state_mask.get_bit(material_slot)) {
     // PStatGPUTimer timer(this, _draw_set_state_material_pcollector);
 #ifdef SUPPORT_FIXED_FUNCTION
-    do_issue_material();
+    if (has_fixed_function_pipeline()) {
+      do_issue_material();
+    }
 #endif
     _state_mask.set_bit(material_slot);
   }
@@ -10335,7 +10471,9 @@ set_state_and_transform(const RenderState *target,
       !_state_mask.get_bit(light_slot)) {
     // PStatGPUTimer timer(this, _draw_set_state_light_pcollector);
 #ifdef SUPPORT_FIXED_FUNCTION
-    do_issue_light();
+    if (has_fixed_function_pipeline()) {
+      do_issue_light();
+    }
 #endif
     _state_mask.set_bit(light_slot);
   }
@@ -10353,7 +10491,9 @@ set_state_and_transform(const RenderState *target,
       !_state_mask.get_bit(fog_slot)) {
     // PStatGPUTimer timer(this, _draw_set_state_fog_pcollector);
 #ifdef SUPPORT_FIXED_FUNCTION
-    do_issue_fog();
+    if (has_fixed_function_pipeline()) {
+      do_issue_fog();
+    }
 #endif
     _state_mask.set_bit(fog_slot);
   }
@@ -10401,12 +10541,16 @@ do_issue_texture() {
       _texture_binding_shader_context->disable_shader_texture_bindings();
     }
 #ifdef SUPPORT_FIXED_FUNCTION
-    update_standard_texture_bindings();
+    if (has_fixed_function_pipeline()) {
+      update_standard_texture_bindings();
+    }
 #endif
   } else {
     if (_texture_binding_shader_context == 0) {
 #ifdef SUPPORT_FIXED_FUNCTION
-      disable_standard_texture_bindings();
+      if (has_fixed_function_pipeline()) {
+        disable_standard_texture_bindings();
+      }
 #endif
       _current_shader_context->update_shader_texture_bindings(NULL);
     } else {
@@ -10427,6 +10571,9 @@ do_issue_texture() {
  */
 void CLP(GraphicsStateGuardian)::
 update_standard_texture_bindings() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
 #ifndef NDEBUG
   if (_show_texture_usage) {
     update_show_usage_texture_bindings(-1);
@@ -10736,20 +10883,22 @@ update_show_usage_texture_bindings(int show_stage_index) {
   }
 
 #ifdef SUPPORT_FIXED_FUNCTION
-  // Disable all texture stages.
-  for (i = 0; i < _num_active_texture_stages; i++) {
-    set_active_texture_stage(i);
+  if (has_fixed_function_pipeline()) {
+    // Disable all texture stages.
+    for (i = 0; i < _num_active_texture_stages; i++) {
+      set_active_texture_stage(i);
 #ifndef OPENGLES
-    glDisable(GL_TEXTURE_1D);
+      glDisable(GL_TEXTURE_1D);
 #endif  // OPENGLES
-    glDisable(GL_TEXTURE_2D);
-    if (_supports_3d_texture) {
+      glDisable(GL_TEXTURE_2D);
+      if (_supports_3d_texture) {
 #ifndef OPENGLES_1
-      glDisable(GL_TEXTURE_3D);
+        glDisable(GL_TEXTURE_3D);
 #endif  // OPENGLES_1
-    }
-    if (_supports_cube_map) {
-      glDisable(GL_TEXTURE_CUBE_MAP);
+      }
+      if (_supports_cube_map) {
+        glDisable(GL_TEXTURE_CUBE_MAP);
+      }
     }
   }
 #endif
@@ -10772,7 +10921,9 @@ update_show_usage_texture_bindings(int show_stage_index) {
     // Choose the corresponding usage texture and apply it.
     set_active_texture_stage(i);
 #ifdef SUPPORT_FIXED_FUNCTION
-    glEnable(GL_TEXTURE_2D);
+    if (has_fixed_function_pipeline()) {
+      glEnable(GL_TEXTURE_2D);
+    }
 #endif
 
     UsageTextureKey key(texture->get_x_size(), texture->get_y_size());
@@ -10879,6 +11030,9 @@ upload_usage_texture(int width, int height) {
  */
 void CLP(GraphicsStateGuardian)::
 disable_standard_texture_bindings() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   // Disable the texture stages that are no longer used.
   for (int i = 0; i < _num_active_texture_stages; i++) {
     set_active_texture_stage(i);
@@ -10908,6 +11062,9 @@ disable_standard_texture_bindings() {
  */
 void CLP(GraphicsStateGuardian)::
 do_issue_tex_matrix() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   nassertv(_num_active_texture_stages <= _max_texture_stages);
 
   for (int i = 0; i < _num_active_texture_stages; i++) {
@@ -10942,6 +11099,9 @@ do_issue_tex_matrix() {
  */
 void CLP(GraphicsStateGuardian)::
 do_issue_tex_gen() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   nassertv(_num_active_texture_stages <= _max_texture_stages);
 
   // These are passed in for the four OBJECT_PLANE or EYE_PLANE values; they
@@ -11299,9 +11459,9 @@ specify_texture(CLP(TextureContext) *gtc, const SamplerState &sampler) {
       tex->get_format() == Texture::F_depth_component16 ||
       tex->get_format() == Texture::F_depth_component24 ||
       tex->get_format() == Texture::F_depth_component32) {
-#ifdef SUPPORT_FIXED_FUNCTION
-    glTexParameteri(target, GL_DEPTH_TEXTURE_MODE_ARB, GL_INTENSITY);
-#endif
+    if (has_fixed_function_pipeline()) {
+      glTexParameteri(target, GL_DEPTH_TEXTURE_MODE_ARB, GL_INTENSITY);
+    }
     if (_supports_shadow_filter) {
       if ((sampler.get_magfilter() == SamplerState::FT_shadow) ||
           (sampler.get_minfilter() == SamplerState::FT_shadow)) {
@@ -11749,32 +11909,34 @@ upload_texture(CLP(TextureContext) *gtc, bool force, bool uses_mipmaps) {
 #endif
 
 #if !defined(SUPPORT_FIXED_FUNCTION) && !defined(OPENGLES)
-    // Do we need to apply a swizzle mask to emulate these deprecated texture
-    // formats?
-    switch (tex->get_format()) {
-    case Texture::F_alpha:
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_R, GL_ZERO);
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_G, GL_ZERO);
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_B, GL_ZERO);
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_A, GL_RED);
-      break;
+    if (!has_fixed_function_pipeline()) {
+      // Do we need to apply a swizzle mask to emulate these deprecated texture
+      // formats?
+      switch (tex->get_format()) {
+      case Texture::F_alpha:
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_R, GL_ZERO);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_G, GL_ZERO);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_B, GL_ZERO);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_A, GL_RED);
+        break;
 
-    case Texture::F_luminance:
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_R, GL_RED);
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_G, GL_RED);
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_B, GL_RED);
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_A, GL_ONE);
-      break;
+      case Texture::F_luminance:
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_R, GL_RED);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_G, GL_RED);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_B, GL_RED);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_A, GL_ONE);
+        break;
 
-    case Texture::F_luminance_alpha:
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_R, GL_RED);
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_G, GL_RED);
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_B, GL_RED);
-      glTexParameteri(target, GL_TEXTURE_SWIZZLE_A, GL_GREEN);
-      break;
+      case Texture::F_luminance_alpha:
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_R, GL_RED);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_G, GL_RED);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_B, GL_RED);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_A, GL_GREEN);
+        break;
 
-    default:
-      break;
+      default:
+        break;
+      }
     }
 #endif
 
@@ -12579,33 +12741,35 @@ get_texture_memory_size(CLP(TextureContext) *gtc) {
 void CLP(GraphicsStateGuardian)::
 check_nonresident_texture(BufferContextChain &chain) {
 #if defined(SUPPORT_FIXED_FUNCTION) && !defined(OPENGLES)  // Residency queries not supported by OpenGL ES.
-  size_t num_textures = chain.get_count();
-  if (num_textures == 0) {
-    return;
-  }
+  if (has_fixed_function_pipeline()) {
+    size_t num_textures = chain.get_count();
+    if (num_textures == 0) {
+      return;
+    }
 
-  CLP(TextureContext) **gtc_list = (CLP(TextureContext) **)alloca(num_textures * sizeof(CLP(TextureContext) *));
-  GLuint *texture_list = (GLuint *)alloca(num_textures * sizeof(GLuint));
-  size_t ti = 0;
-  BufferContext *node = chain.get_first();
-  while (node != (BufferContext *)NULL) {
-    CLP(TextureContext) *gtc = DCAST(CLP(TextureContext), node);
-    gtc_list[ti] = gtc;
-    texture_list[ti] = gtc->_index;
-    node = node->get_next();
-    ++ti;
-  }
-  nassertv(ti == num_textures);
-  GLboolean *results = (GLboolean *)alloca(num_textures * sizeof(GLboolean));
-  bool all_resident = (glAreTexturesResident(num_textures, texture_list, results) != 0);
+    CLP(TextureContext) **gtc_list = (CLP(TextureContext) **)alloca(num_textures * sizeof(CLP(TextureContext) *));
+    GLuint *texture_list = (GLuint *)alloca(num_textures * sizeof(GLuint));
+    size_t ti = 0;
+    BufferContext *node = chain.get_first();
+    while (node != (BufferContext *)NULL) {
+      CLP(TextureContext) *gtc = DCAST(CLP(TextureContext), node);
+      gtc_list[ti] = gtc;
+      texture_list[ti] = gtc->_index;
+      node = node->get_next();
+      ++ti;
+    }
+    nassertv(ti == num_textures);
+    GLboolean *results = (GLboolean *)alloca(num_textures * sizeof(GLboolean));
+    bool all_resident = (glAreTexturesResident(num_textures, texture_list, results) != 0);
 
-  report_my_gl_errors();
+    report_my_gl_errors();
 
-  if (!all_resident) {
-    // Some are now nonresident.
-    for (ti = 0; ti < num_textures; ++ti) {
-      if (!results[ti]) {
-        gtc_list[ti]->set_resident(false);
+    if (!all_resident) {
+      // Some are now nonresident.
+      for (ti = 0; ti < num_textures; ++ti) {
+        if (!results[ti]) {
+          gtc_list[ti]->set_resident(false);
+        }
       }
     }
   }
@@ -13298,6 +13462,9 @@ extract_texture_image(PTA_uchar &image, size_t &page_size,
 #ifdef SUPPORT_FIXED_FUNCTION
 void CLP(GraphicsStateGuardian)::
 do_point_size() {
+  if (!has_fixed_function_pipeline()) {
+    return;
+  }
   if (!_point_perspective) {
     // Normal, constant-sized points.  Here _point_size is a width in pixels.
     static LVecBase3f constant(1.0f, 0.0f, 0.0f);

--- a/panda/src/glstuff/glGraphicsStateGuardian_src.h
+++ b/panda/src/glstuff/glGraphicsStateGuardian_src.h
@@ -394,6 +394,8 @@ public:
   INLINE const string &get_gl_version() const;
   INLINE int get_gl_version_major() const;
   INLINE int get_gl_version_minor() const;
+  INLINE bool has_core_profile() const;
+  INLINE bool has_fixed_function_pipeline() const;
 
   virtual void set_state_and_transform(const RenderState *state,
                                        const TransformState *transform);
@@ -535,8 +537,8 @@ protected:
   GLint get_internal_image_format(Texture *tex, bool force_sized=false) const;
   static bool is_mipmap_filter(GLenum min_filter);
   static bool is_compressed_format(GLenum format);
-  static GLint get_texture_apply_mode_type(TextureStage::Mode am);
-  static GLint get_texture_combine_type(TextureStage::CombineMode cm);
+  GLint get_texture_apply_mode_type(TextureStage::Mode am);
+  GLint get_texture_combine_type(TextureStage::CombineMode cm);
   GLint get_texture_src_type(TextureStage::CombineSource cs,
                              int last_stage, int last_saved_result,
                              int this_stage) const;
@@ -710,6 +712,8 @@ protected:
   int _gl_shadlang_ver_major, _gl_shadlang_ver_minor;
 
   pset<string> _extensions;
+  // Core profile storage
+  bool _core_profile;
 
 public:
   bool _supports_point_parameters;

--- a/panda/src/wgldisplay/wglGraphicsStateGuardian.cxx
+++ b/panda/src/wgldisplay/wglGraphicsStateGuardian.cxx
@@ -611,8 +611,10 @@ make_context(HDC hdc) {
       attrib_list[n++] = WGL_CONTEXT_DEBUG_BIT_ARB;
     }
 #ifndef SUPPORT_FIXED_FUNCTION
-    attrib_list[n++] = WGL_CONTEXT_PROFILE_MASK_ARB;
-    attrib_list[n++] = WGL_CONTEXT_CORE_PROFILE_BIT_ARB;
+    if(!has_fixed_function_pipeline()) {
+      attrib_list[n++] = WGL_CONTEXT_PROFILE_MASK_ARB;
+      attrib_list[n++] = WGL_CONTEXT_CORE_PROFILE_BIT_ARB;
+    }
 #endif
     attrib_list[n] = NULL;
 


### PR DESCRIPTION
The possibility of removing the fixed functions pipeline in compilation time is quite nice. However, the engine should be able to automatically detect when they are not available in runtime as well.
Otherwise the core profile OpenGL implementations will not properly work, for instance, in generic binary distributed packages of the engine
