### PR TITLE
Remove PiratesMagicWordManager VR Studio code reference

### DIFF
--- a/direct/src/distributed/DistributedObjectGlobalUD.py
+++ b/direct/src/distributed/DistributedObjectGlobalUD.py
@@ -26,11 +26,7 @@ class DistributedObjectGlobalUD(DistributedObjectUD):
 
     def execCommand(self, command, mwMgrId, avId, zoneId):
         text = str(self.__execMessage(command))[:config.GetInt("ai-debug-length",300)]
-
-        dclass = uber.air.dclassesByName.get("PiratesMagicWordManagerAI")
-        dg = dclass.aiFormatUpdate(
-            "setMagicWordResponse", mwMgrId, (1<<32)+avId, uber.air.ourChannel, [text])
-        uber.air.send(dg)
+        self.notify.info(text)
 
     def __execMessage(self, message):
         if not self.ExecNamespace:


### PR DESCRIPTION
This code has references to the VR Studio game called Pirates Online of the Caribbean. Unfortunately, this code is not compatible with the current server repository. Calling execCommand throws an error.

I have replaced the proprietary code with a notify call instead.