### PR TITLE
Do not throw an assertion when processing a light source shader input…

### DIFF
--- a/panda/src/display/graphicsStateGuardian.cxx
+++ b/panda/src/display/graphicsStateGuardian.cxx
@@ -1363,8 +1363,10 @@ fetch_specified_part(Shader::ShaderMatInput part, InternalName *name,
       }
     }
 
-    // TODO: dummy light
-    nassertr(false, &LMatrix4::ident_mat());
+    // No light for this uniform
+    // TODO: Use a default/dummy light object. For now we use an identity
+    // matrix to avoid an assertion.
+    return &LMatrix4::ident_mat();
   }
   default:
     nassertr(false /*should never get here*/, &LMatrix4::ident_mat());


### PR DESCRIPTION
… that does not have a light

Instead, return an identity matrix. This allows shaders to use an
arbitrary size for p3d_LightSource instead of needing to know the number
of lights ahead of time. Extra lights should not affect the final
shading result.