### PR TITLE
Do not call expensive BulletDebugNode::sync_b2p() if the node is not in a live scenegraph

### DIFF
--- a/panda/src/bullet/bulletDebugNode.cxx
+++ b/panda/src/bullet/bulletDebugNode.cxx
@@ -180,7 +180,7 @@ draw_mask_changed() {
 void BulletDebugNode::
 sync_b2p(btDynamicsWorld *world) {
 
-  if (is_overall_hidden()) return;
+  if (is_overall_hidden() || !is_under_scene_root()) return;
 
   nassertv(get_num_geoms() == 2);
 


### PR DESCRIPTION
I have some code [here](https://github.com/Moguri/prototype-lithium/blob/master/game/lithium/components.py#L211) that attempts to toggle Bullet debug drawing on/off. To my surprise, the very expensive BulletWorld::sync_b2p() was still being called even though the BulletDebugNode was not visible (or even in the scenegraph).

I've switched my code to use explicit show()/hide() calls, which prevents the debug code from running and killing my frame time. However, this PR may still be useful to others.