### PR TITLE
Add prc variable to force image bindings as writeonly

### DIFF
--- a/panda/src/glstuff/glShaderContext_src.cxx
+++ b/panda/src/glstuff/glShaderContext_src.cxx
@@ -2487,10 +2487,10 @@ update_shader_texture_bindings(ShaderContext *prev) {
           input._writable = has_write;
 
           if (gl_force_image_bindings_writeonly) {
-              access = GL_WRITE_ONLY;
+            access = GL_WRITE_ONLY;
 
           } else if (has_read && has_write) {
-              access = GL_READ_WRITE;
+            access = GL_READ_WRITE;
 
           } else if (has_read) {
             access = GL_READ_ONLY;

--- a/panda/src/glstuff/glShaderContext_src.cxx
+++ b/panda/src/glstuff/glShaderContext_src.cxx
@@ -2489,20 +2489,18 @@ update_shader_texture_bindings(ShaderContext *prev) {
           if (gl_force_image_bindings_writeonly) {
               access = GL_WRITE_ONLY;
 
-          } else {
-            if (has_read && has_write) {
+          } else if (has_read && has_write) {
               access = GL_READ_WRITE;
 
-            } else if (has_read) {
-              access = GL_READ_ONLY;
+          } else if (has_read) {
+            access = GL_READ_ONLY;
 
-            } else if (has_write) {
-              access = GL_WRITE_ONLY;
+          } else if (has_write) {
+            access = GL_WRITE_ONLY;
 
-            } else {
-              access = GL_READ_ONLY;
-              gl_tex = 0;
-            }
+          } else {
+            access = GL_READ_ONLY;
+            gl_tex = 0;
           }
         }
         _glgsg->_glBindImageTexture(i, gl_tex, bind_level, layered, bind_layer,

--- a/panda/src/glstuff/glShaderContext_src.cxx
+++ b/panda/src/glstuff/glShaderContext_src.cxx
@@ -2486,18 +2486,23 @@ update_shader_texture_bindings(ShaderContext *prev) {
           bool has_write = param->has_write_access();
           input._writable = has_write;
 
-          if (has_read && has_write) {
-            access = GL_READ_WRITE;
-
-          } else if (has_read) {
-            access = GL_READ_ONLY;
-
-          } else if (has_write) {
-            access = GL_WRITE_ONLY;
+          if (gl_force_image_bindings_writeonly) {
+              access = GL_WRITE_ONLY;
 
           } else {
-            access = GL_READ_ONLY;
-            gl_tex = 0;
+            if (has_read && has_write) {
+              access = GL_READ_WRITE;
+
+            } else if (has_read) {
+              access = GL_READ_ONLY;
+
+            } else if (has_write) {
+              access = GL_WRITE_ONLY;
+
+            } else {
+              access = GL_READ_ONLY;
+              gl_tex = 0;
+            }
           }
         }
         _glgsg->_glBindImageTexture(i, gl_tex, bind_level, layered, bind_layer,

--- a/panda/src/glstuff/glmisc_src.cxx
+++ b/panda/src/glstuff/glmisc_src.cxx
@@ -299,6 +299,11 @@ ConfigVariableBool gl_support_shadow_filter
             "cards suffered from a broken implementation of the "
             "shadow map filtering features."));
 
+ConfigVariableBool gl_force_image_bindings_writeonly
+  ("gl-force-image-bindings-writeonly", true,
+   PRC_DESC("Forces all image inputs (not textures!) to be bound as writeonly, "
+            "to read from an image, rebind it as sampler."));
+
 ConfigVariableEnum<CoordinateSystem> gl_coordinate_system
   ("gl-coordinate-system", CS_yup_right,
    PRC_DESC("Which coordinate system to use as the internal "

--- a/panda/src/glstuff/glmisc_src.cxx
+++ b/panda/src/glstuff/glmisc_src.cxx
@@ -300,7 +300,7 @@ ConfigVariableBool gl_support_shadow_filter
             "shadow map filtering features."));
 
 ConfigVariableBool gl_force_image_bindings_writeonly
-  ("gl-force-image-bindings-writeonly", true,
+  ("gl-force-image-bindings-writeonly", false,
    PRC_DESC("Forces all image inputs (not textures!) to be bound as writeonly, "
             "to read from an image, rebind it as sampler."));
 

--- a/panda/src/glstuff/glmisc_src.h
+++ b/panda/src/glstuff/glmisc_src.h
@@ -80,6 +80,7 @@ extern ConfigVariableBool gl_fixed_vertex_attrib_locations;
 extern ConfigVariableBool gl_support_primitive_restart_index;
 extern ConfigVariableBool gl_support_sampler_objects;
 extern ConfigVariableBool gl_support_shadow_filter;
+extern ConfigVariableBool gl_force_image_bindings_writeonly;
 extern ConfigVariableEnum<CoordinateSystem> gl_coordinate_system;
 
 extern EXPCL_GL void CLP(init_classes)();


### PR DESCRIPTION
Usually image inputs are only used as writeonly variables, this pr adds a new prc option `gl-force-image-bindings-writeonly` which forces all those bindings to be writeonly.

This is equivalent to passing `read=False, write=True` on all `set_shader_input` calls for image bindings, and just a more convenient way.