### PR TITLE
Add hidden window mode

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -523,9 +523,11 @@ open_window() {
 
     [_window setShowsResizeIndicator: !_properties.get_fixed_size()];
 
-    if (_properties.get_window_mode() == WindowProperties::W_fullscreen) {
+    if (_properties.get_window_mode() == WindowProperties::W_hidden) {
+      [_window orderOut:nil];
+    } else if (_properties.get_window_mode() == WindowProperties::W_fullscreen) {
       [_window makeKeyAndOrderFront:nil];
-     } else if (_properties.get_minimized()) {
+    } else if (_properties.get_minimized()) {
       [_window makeKeyAndOrderFront:nil];
       [_window miniaturize:nil];
     } else if (_properties.get_foreground()) {
@@ -1020,6 +1022,10 @@ set_properties_now(WindowProperties &properties) {
       case WindowProperties::W_undecorated:
       case WindowProperties::W_fullscreen:
         // Assume these were set
+        _properties.set_window_mode(properties.get_window_mode());
+        properties.clear_window_mode();
+        break;
+      case WindowProperties::W_hidden:
         _properties.set_window_mode(properties.get_window_mode());
         properties.clear_window_mode();
         break;

--- a/panda/src/display/config_display.cxx
+++ b/panda/src/display/config_display.cxx
@@ -328,6 +328,11 @@ ConfigVariableBool undecorated
           "property.  When this is true, the default window is created "
           "without a title bar or resizable border."));
 
+ConfigVariableEnum<WindowProperties::WindowMode> win_mode
+("win-mode", WindowProperties::W_regular,
+ PRC_DESC("This specifies the default value of the 'window_mode' window "
+          "property."));
+
 ConfigVariableBool win_fixed_size
 ("win-fixed-size", false,
  PRC_DESC("This specifies the default value of the 'fixed_size' window "

--- a/panda/src/display/config_display.h
+++ b/panda/src/display/config_display.h
@@ -74,6 +74,7 @@ extern EXPCL_PANDA_DISPLAY ConfigVariableInt win_size;
 extern EXPCL_PANDA_DISPLAY ConfigVariableInt win_origin;
 extern EXPCL_PANDA_DISPLAY ConfigVariableBool fullscreen;
 extern EXPCL_PANDA_DISPLAY ConfigVariableBool undecorated;
+extern EXPCL_PANDA_DISPLAY ConfigVariableEnum<WindowProperties::WindowMode> win_mode;
 extern EXPCL_PANDA_DISPLAY ConfigVariableBool win_fixed_size;
 extern EXPCL_PANDA_DISPLAY ConfigVariableBool cursor_hidden;
 extern EXPCL_PANDA_DISPLAY ConfigVariableFilename icon_filename;

--- a/panda/src/display/windowProperties.I
+++ b/panda/src/display/windowProperties.I
@@ -220,11 +220,10 @@ clear_title() {
 INLINE void WindowProperties::
 set_undecorated(bool undecorated) {
   if (undecorated) {
-    _flags |= F_undecorated;
+    set_window_mode(W_undecorated);
   } else {
-    _flags &= ~F_undecorated;
+    set_window_mode(W_regular);
   }
-  _specified |= S_undecorated;
 }
 
 /**
@@ -232,7 +231,7 @@ set_undecorated(bool undecorated) {
  */
 INLINE bool WindowProperties::
 get_undecorated() const {
-  return (_flags & F_undecorated) != 0;
+  return get_window_mode() == W_undecorated;
 }
 
 /**
@@ -240,7 +239,7 @@ get_undecorated() const {
  */
 INLINE bool WindowProperties::
 has_undecorated() const {
-  return ((_specified & S_undecorated) != 0);
+  return has_window_mode();
 }
 
 /**
@@ -248,8 +247,9 @@ has_undecorated() const {
  */
 INLINE void WindowProperties::
 clear_undecorated() {
-  _specified &= ~S_undecorated;
-  _flags &= ~F_undecorated;
+  if (get_undecorated()) {
+    clear_window_mode();
+  }
 }
 
 /**
@@ -297,11 +297,10 @@ clear_fixed_size() {
 INLINE void WindowProperties::
 set_fullscreen(bool fullscreen) {
   if (fullscreen) {
-    _flags |= F_fullscreen;
+    set_window_mode(W_fullscreen);
   } else {
-    _flags &= ~F_fullscreen;
+    set_window_mode(W_regular);
   }
-  _specified |= S_fullscreen;
 }
 
 /**
@@ -309,7 +308,7 @@ set_fullscreen(bool fullscreen) {
  */
 INLINE bool WindowProperties::
 get_fullscreen() const {
-  return (_flags & F_fullscreen) != 0;
+  return get_window_mode() == W_fullscreen;
 }
 
 /**
@@ -317,7 +316,7 @@ get_fullscreen() const {
  */
 INLINE bool WindowProperties::
 has_fullscreen() const {
-  return ((_specified & S_fullscreen) != 0);
+  return has_window_mode();
 }
 
 /**
@@ -325,8 +324,9 @@ has_fullscreen() const {
  */
 INLINE void WindowProperties::
 clear_fullscreen() {
-  _specified &= ~S_fullscreen;
-  _flags &= ~F_fullscreen;
+  if (get_fullscreen()) {
+    clear_window_mode();
+  }
 }
 
 /**
@@ -683,6 +683,47 @@ INLINE void WindowProperties::
 clear_mouse_mode() {
   _specified &= ~S_mouse_mode;
   _mouse_mode = M_absolute;
+}
+
+/**
+ * Specifies the mode in which the window is displayed.
+ *
+ * W_regular: a plain, decorated window
+ *
+ * W_fullscreen: fullscreen the application
+ *
+ * W_undecorated: a window with no decorations (e.g., titlebar, borders, etc.)
+ *
+ */
+INLINE void WindowProperties::
+set_window_mode(WindowMode mode) {
+  _window_mode=mode;
+  _specified |= S_window_mode;
+}
+
+/**
+ * See set_window_mode().
+ */
+INLINE WindowProperties::WindowMode WindowProperties::
+get_window_mode() const {
+ return _window_mode;
+}
+
+/**
+ *
+ */
+INLINE bool WindowProperties::
+has_window_mode() const {
+  return ((_specified & S_window_mode)!=0);
+}
+
+/**
+ * Removes the window_mode specification from the properties.
+ */
+INLINE void WindowProperties::
+clear_window_mode() {
+  _specified &= ~S_window_mode;
+  _window_mode = W_regular;
 }
 
 /**

--- a/panda/src/display/windowProperties.I
+++ b/panda/src/display/windowProperties.I
@@ -694,6 +694,8 @@ clear_mouse_mode() {
  *
  * W_undecorated: a window with no decorations (e.g., titlebar, borders, etc.)
  *
+ * W_hidden: hide the window from the window manager
+ *
  */
 INLINE void WindowProperties::
 set_window_mode(WindowMode mode) {

--- a/panda/src/display/windowProperties.cxx
+++ b/panda/src/display/windowProperties.cxx
@@ -39,6 +39,7 @@ operator = (const WindowProperties &copy) {
   _z_order = copy._z_order;
   _flags = copy._flags;
   _mouse_mode = copy._mouse_mode;
+  _window_mode = copy._window_mode;
   _parent_window = copy._parent_window;
 }
 
@@ -62,8 +63,6 @@ get_config_properties() {
     props.set_origin(win_origin[0], win_origin[1]);
   }
 
-  props.set_fullscreen(fullscreen);
-  props.set_undecorated(undecorated);
   props.set_fixed_size(win_fixed_size);
   props.set_cursor_hidden(cursor_hidden);
   if (!icon_filename.empty()) {
@@ -82,6 +81,7 @@ get_config_properties() {
     props.set_parent_window(NativeWindowHandle::make_subprocess(subprocess_window));
   }
   props.set_mouse_mode(M_absolute);
+  props.set_window_mode(W_regular);
 
   return props;
 }
@@ -153,6 +153,7 @@ operator == (const WindowProperties &other) const {
           _icon_filename == other._icon_filename &&
           _cursor_filename == other._cursor_filename &&
           _mouse_mode == other._mouse_mode &&
+          _window_mode == other._window_mode &&
           _parent_window == other._parent_window);
 }
 
@@ -171,6 +172,7 @@ clear() {
   _z_order = Z_normal;
   _flags = 0;
   _mouse_mode = M_absolute;
+  _window_mode = W_regular;
   _parent_window = NULL;
 }
 
@@ -213,14 +215,8 @@ add_properties(const WindowProperties &other) {
   if (other.has_title()) {
     set_title(other.get_title());
   }
-  if (other.has_undecorated()) {
-    set_undecorated(other.get_undecorated());
-  }
   if (other.has_fixed_size()) {
     set_fixed_size(other.get_fixed_size());
-  }
-  if (other.has_fullscreen()) {
-    set_fullscreen(other.get_fullscreen());
   }
   if (other.has_foreground()) {
     set_foreground(other.get_foreground());
@@ -249,6 +245,9 @@ add_properties(const WindowProperties &other) {
   if (other.has_mouse_mode()) {
     set_mouse_mode(other.get_mouse_mode());
   }
+  if (other.has_window_mode()) {
+    set_window_mode(other.get_window_mode());
+  }
   if (other.has_parent_window()) {
     set_parent_window(other.get_parent_window());
   }
@@ -269,14 +268,8 @@ output(ostream &out) const {
   if (has_title()) {
     out << "title=\"" << get_title() << "\"" << " ";
   }
-  if (has_undecorated()) {
-    out << (get_undecorated() ? "undecorated " : "!undecorated ");
-  }
   if (has_fixed_size()) {
     out << (get_fixed_size() ? "fixed_size " : "!fixed_size ");
-  }
-  if (has_fullscreen()) {
-    out << (get_fullscreen() ? "fullscreen " : "!fullscreen ");
   }
   if (has_foreground()) {
     out << (get_foreground() ? "foreground " : "!foreground ");
@@ -304,6 +297,9 @@ output(ostream &out) const {
   }
   if (has_mouse_mode()) {
     out << get_mouse_mode() << " ";
+  }
+  if (has_window_mode()) {
+    out << get_window_mode() << " ";
   }
   if (has_parent_window()) {
     if (get_parent_window() == NULL) {
@@ -383,6 +379,41 @@ operator >> (istream &in, WindowProperties::MouseMode &mode) {
     display_cat.warning()
       << "Unknown mouse mode: " << word << "\n";
     mode = WindowProperties::M_absolute;
+  }
+
+  return in;
+}
+
+// WindowMode operators
+
+ostream &
+operator << (ostream &out, WindowProperties::WindowMode mode) {
+  switch (mode) {
+  case WindowProperties::W_regular:
+    return out << "regular";
+  case WindowProperties::W_fullscreen:
+    return out << "fullscreen";
+  case WindowProperties::W_undecorated:
+    return out << "undecorated";
+  }
+  return out << "**invalid WindowProperties::WindowMode(" << (int)mode << ")**";
+}
+
+istream &
+operator >> (istream &in, WindowProperties::WindowMode &mode) {
+  string word;
+  in >> word;
+
+  if (word == "regular") {
+    mode = WindowProperties::W_regular;
+  } else if (word == "fullscreen") {
+    mode = WindowProperties::W_fullscreen;
+  } else if (word == "undecorated") {
+    mode = WindowProperties::W_undecorated;
+  } else {
+    display_cat.warning()
+      << "Unknown window mode: " << word << "\n";
+    mode = WindowProperties::W_regular;
   }
 
   return in;

--- a/panda/src/display/windowProperties.cxx
+++ b/panda/src/display/windowProperties.cxx
@@ -81,7 +81,9 @@ get_config_properties() {
     props.set_parent_window(NativeWindowHandle::make_subprocess(subprocess_window));
   }
   props.set_mouse_mode(M_absolute);
-  props.set_window_mode(W_regular);
+  if (win_mode.has_value()) {
+    props.set_window_mode(win_mode);
+  }
 
   return props;
 }

--- a/panda/src/display/windowProperties.cxx
+++ b/panda/src/display/windowProperties.cxx
@@ -397,6 +397,8 @@ operator << (ostream &out, WindowProperties::WindowMode mode) {
     return out << "fullscreen";
   case WindowProperties::W_undecorated:
     return out << "undecorated";
+  case WindowProperties::W_hidden:
+    return out << "hidden";
   }
   return out << "**invalid WindowProperties::WindowMode(" << (int)mode << ")**";
 }
@@ -412,6 +414,8 @@ operator >> (istream &in, WindowProperties::WindowMode &mode) {
     mode = WindowProperties::W_fullscreen;
   } else if (word == "undecorated") {
     mode = WindowProperties::W_undecorated;
+  } else if (word == "hidden") {
+    mode = WindowProperties::W_hidden;
   } else {
     display_cat.warning()
       << "Unknown window mode: " << word << "\n";

--- a/panda/src/display/windowProperties.h
+++ b/panda/src/display/windowProperties.h
@@ -40,6 +40,12 @@ PUBLISHED:
     M_confined,
   };
 
+  enum WindowMode {
+    W_regular,
+    W_fullscreen,
+    W_undecorated,
+  };
+
   WindowProperties();
   INLINE WindowProperties(const WindowProperties &copy);
   void operator = (const WindowProperties &copy);
@@ -84,6 +90,13 @@ PUBLISHED:
   INLINE void clear_mouse_mode();
   MAKE_PROPERTY2(mouse_mode, has_mouse_mode, get_mouse_mode,
                              set_mouse_mode, clear_mouse_mode);
+
+  INLINE bool has_window_mode() const;
+  INLINE void set_window_mode(WindowMode mode);
+  INLINE WindowMode get_window_mode() const;
+  INLINE void clear_window_mode();
+  MAKE_PROPERTY2(window_mode, has_window_mode, get_window_mode,
+                             set_window_mode, clear_window_mode);
 
   INLINE void set_title(const string &title);
   INLINE const string &get_title() const;
@@ -183,8 +196,8 @@ private:
     S_origin               = 0x00001,
     S_size                 = 0x00002,
     S_title                = 0x00004,
-    S_undecorated          = 0x00008,
-    S_fullscreen           = 0x00010,
+    // UNUSED              = 0x00008,
+    // UNUSED              = 0x00010,
     S_foreground           = 0x00020,
     S_minimized            = 0x00040,
     S_open                 = 0x00080,
@@ -196,13 +209,12 @@ private:
     S_mouse_mode           = 0x02000,
     S_parent_window        = 0x04000,
     S_raw_mice             = 0x08000,
+    S_window_mode          = 0x10000,
   };
 
   // This bitmask represents the truefalse settings for various boolean flags
   // (assuming the corresponding S_* bit has been set, above).
   enum Flags {
-    F_undecorated    = S_undecorated,
-    F_fullscreen     = S_fullscreen,
     F_foreground     = S_foreground,
     F_minimized      = S_minimized,
     F_open           = S_open,
@@ -215,6 +227,7 @@ private:
   LPoint2i _origin;
   LVector2i _size;
   MouseMode _mouse_mode;
+  WindowMode _window_mode;
   string _title;
   Filename _cursor_filename;
   Filename _icon_filename;
@@ -234,6 +247,11 @@ EXPCL_PANDA_DISPLAY ostream &
 operator << (ostream &out, WindowProperties::MouseMode mode);
 EXPCL_PANDA_DISPLAY istream &
 operator >> (istream &in, WindowProperties::MouseMode &mode);
+
+EXPCL_PANDA_DISPLAY ostream &
+operator << (ostream &out, WindowProperties::WindowMode mode);
+EXPCL_PANDA_DISPLAY istream &
+operator >> (istream &in, WindowProperties::WindowMode &mode);
 
 
 INLINE ostream &operator << (ostream &out, const WindowProperties &properties);

--- a/panda/src/display/windowProperties.h
+++ b/panda/src/display/windowProperties.h
@@ -44,6 +44,7 @@ PUBLISHED:
     W_regular,
     W_fullscreen,
     W_undecorated,
+    W_hidden,
   };
 
   WindowProperties();

--- a/panda/src/windisplay/winGraphicsWindow.cxx
+++ b/panda/src/windisplay/winGraphicsWindow.cxx
@@ -334,19 +334,19 @@ set_properties_now(WindowProperties &properties) {
     properties.clear_minimized();
   }
 
-  if (properties.has_fullscreen()) {
-    if (properties.get_fullscreen() && !is_fullscreen()) {
+  if (properties.has_window_mode()) {
+    if (properties.get_window_mode() == WindowProperties::W_fullscreen && !is_fullscreen()) {
       if (do_fullscreen_switch()){
-        _properties.set_fullscreen(true);
-        properties.clear_fullscreen();
+        _properties.set_window_mode(properties.get_window_mode());
+        properties.clear_window_mode();
       } else {
         windisplay_cat.warning()
           << "Switching to fullscreen mode failed!\n";
       }
-    } else if (!properties.get_fullscreen() && is_fullscreen()){
+    } else if (properties.get_window_mode() != WindowProperties::W_fullscreen && is_fullscreen()){
       if (do_windowed_switch()){
-        _properties.set_fullscreen(false);
-        properties.clear_fullscreen();
+        _properties.set_window_mode(properties.get_window_mode());
+        properties.clear_window_mode();
       } else {
         windisplay_cat.warning()
           << "Switching to windowed mode failed!\n";
@@ -913,7 +913,7 @@ make_style(bool fullscreen) {
 
   if (fullscreen){
     window_style |= WS_SYSMENU;
-  } else if (!_properties.get_undecorated()) {
+  } else if (_properties.get_window_mode() != WindowProperties::W_undecorated) {
     window_style |= (WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX);
 
     if (!_properties.get_fixed_size()) {

--- a/panda/src/x11display/x11GraphicsWindow.cxx
+++ b/panda/src/x11display/x11GraphicsWindow.cxx
@@ -973,7 +973,9 @@ open_window() {
     XDefineCursor(_display, _xwindow, cursor);
   }
 
-  XMapWindow(_display, _xwindow);
+  if (_properties.get_window_mode() != WindowProperties::W_hidden) {
+    XMapWindow(_display, _xwindow);
+  }
 
   if (_properties.get_raw_mice()) {
     open_raw_mice();
@@ -1218,6 +1220,12 @@ set_wm_properties(const WindowProperties &properties, bool already_mapped) {
   }
   if (class_hints_p != (XClassHint *)NULL) {
     XFree(class_hints_p);
+  }
+
+  if (properties.get_window_mode() == WindowProperties::W_hidden) {
+    XUnmapWindow(_display, _xwindow);
+  } else {
+    XMapWindow(_display, _xwindow);
   }
 
   // Also, indicate to the window manager that we'd like to get a chance to


### PR DESCRIPTION
This PR implements an enumerated type for window modes. Support is added for the existing window mode properties as W_regular, W_fullscreen, W_undecorated. Fullscreen and undecorated support is handled by delegating to the existing properties. We can look into removing these to reclaim bits in the Specified bitfield and make the window modes truly mutually exclusive (right now some odd combinations can be set). However, for now I tried to keep the changes to a minimum to reduce the risk of bugs.

A new W_hidden WindowMode is implemented for X11 to hide a window from the window manager. Support for macOS and Windows is still TODO.

The changes were tested using a modified version of the asteroids sample.
[window_mode_test.zip](https://github.com/panda3d/panda3d/files/703519/window_mode_test.zip)



This PR is more of a request for review and feedback than a request for a merge at this point in time.