### PR TITLE
Fix typo of include guard.

### DIFF
--- a/panda/src/parametrics/parametricCurveCollection.h
+++ b/panda/src/parametrics/parametricCurveCollection.h
@@ -11,8 +11,8 @@
  * @date 2001-03-04
  */
 
-#ifndef NODEPATHCOLLECTION_H
-#define NODEPATHCOLLECTION_H
+#ifndef PARAMETRICCURVECOLLECTION_H
+#define PARAMETRICCURVECOLLECTION_H
 
 #include "pandabase.h"
 


### PR DESCRIPTION
This fixes typo of include guard in parametricCurveCollection.h file.

I found compile error when I included both nodePathCollection.h file and parametricCurveCollection.h file.

