### PR TITLE
Fixes for device button handling

### DIFF
--- a/panda/src/device/evdevInputDevice.cxx
+++ b/panda/src/device/evdevInputDevice.cxx
@@ -574,6 +574,21 @@ process_events() {
     case EV_KEY:
       button = map_button(code);
       _button_events->add_event(ButtonEvent(button, events[i].value ? ButtonEvent::T_down : ButtonEvent::T_up, time));
+      // set the buttons state
+      State state;
+      if (events[i].value) {
+        state = S_down;
+      } else {
+        state = S_up;
+      }
+      for (int i = 0; i < _buttons.size(); ++i) {
+        if (get_button(i).handle == button) {
+          //NOTE: set_button_state doesn't work correct here.
+          //set_button_state(i, state);
+          _buttons[i].state = state;
+          break;
+        }
+      }
       break;
 
     default:

--- a/panda/src/device/inputDevice.h
+++ b/panda/src/device/inputDevice.h
@@ -243,14 +243,13 @@ protected:
   PT(ButtonEventList) _button_events;
   PT(PointerEventList) _pointer_events;
 
-public:
+PUBLISHED:
   enum State {
     S_unknown,
     S_up,
     S_down
   };
 
-PUBLISHED:
   class ButtonState {
   public:
     INLINE ButtonState();


### PR DESCRIPTION
Changes to make the buttons of a device not only usable using events but also the get_button* functions from the python side. Previously button states weren't correctly set by the evdevInputDevice class and the button states enum was not accessible at al from python.