### PR TITLE
Remove print() from Messenger.find() and Messenger.findAll()

### DIFF
--- a/direct/src/showbase/Messenger.py
+++ b/direct/src/showbase/Messenger.py
@@ -531,7 +531,6 @@ class Messenger:
         keys.sort()
         for event in keys:
             if repr(event).find(needle) >= 0:
-                print(self.__eventRepr(event))
                 return {event: self.__callbacks[event]}
 
     def findAll(self, needle, limit=None):
@@ -545,7 +544,6 @@ class Messenger:
         keys.sort()
         for event in keys:
             if repr(event).find(needle) >= 0:
-                print(self.__eventRepr(event))
                 matches[event] = self.__callbacks[event]
                 # if the limit is not None, decrement and
                 # check for break:


### PR DESCRIPTION
If one needs to use find() or findAll() not for debugging purposes (like for getting the function or arguments for some binding), then the print functions in these methods are really unwelcome. find() is the only nice way to get this info (other then de-name-mangling __callbacks)