### PR TITLE
Buffer protocol support for (Const)PointerToArray of vectors and matr…

### DIFF
--- a/panda/src/express/pointerToArray_ext.I
+++ b/panda/src/express/pointerToArray_ext.I
@@ -12,6 +12,64 @@
  */
 
 /**
+ * This is a helper function to set most attributes of a Py_buffer in a manner
+ * that accommodates square matrices (in accordance with PEP 3118). It is tested
+ * for use with NumPy. The resulting array will be of shape
+ * (num_matrices, size, size) where size is the number of matrix rows (=columns)
+ */
+INLINE void set_matrix_view(Py_buffer &view, int flags, int length, int size, bool double_prec, bool read_only) {
+  int item_size, mat_size;
+  const char *format;
+
+  if (double_prec) {
+    item_size = sizeof(double);
+    format = get_format_code(double);
+  } else {
+    item_size = sizeof(float);
+    format = get_format_code(float);
+  }
+
+  if (size == 3 && !double_prec) {
+    mat_size = sizeof(LMatrix3f);
+  } else if (size == 3 && double_prec) {
+    mat_size = sizeof(LMatrix3d);
+  } else if (size == 4 && !double_prec) {
+    mat_size = sizeof(UnalignedLMatrix4f);
+  } else if (size == 4 && double_prec) {
+    mat_size = sizeof(UnalignedLMatrix4d);
+  }
+
+  view.len = length * mat_size;
+  view.readonly = (read_only ? 1 : 0);
+  view.itemsize = item_size;
+  view.format = NULL;
+  if ((flags & PyBUF_FORMAT) == PyBUF_FORMAT) {
+    view.format = (char*) format;
+  }
+  view.ndim = 3;
+  view.shape = NULL;
+  if ((flags & PyBUF_ND) == PyBUF_ND) {
+    // This leaks, which sucks, but __releasebuffer__ doesn't give us the same
+    // pointer, so we would need to store it elsewhere if we wanted to delete
+    // it there.  Eh, it's just an int, who cares.
+    Py_ssize_t* shape = new Py_ssize_t[3];
+    shape[0] = length;
+    shape[1] = size;
+    shape[2] = size;
+    view.shape = shape;
+  }
+  view.strides = NULL;
+  if ((flags & PyBUF_STRIDES) == PyBUF_STRIDES) {
+    Py_ssize_t* strides = new Py_ssize_t[3];
+    strides[0] = mat_size;
+    strides[1] = item_size * size;
+    strides[2] = item_size;
+    view.strides = strides;
+  }
+  view.suboffsets = NULL;
+}
+
+/**
  * This special constructor accepts a Python list of elements, or a Python
  * string (or a bytes object, in Python 3), or any object that supports the
  * Python buffer protocol.
@@ -227,6 +285,110 @@ __getbuffer__(PyObject *self, Py_buffer *view, int flags) {
 }
 
 /**
+ * This is used to implement the buffer protocol, in order to allow efficient
+ * access to the array data through a Python memoryview object.
+ */
+template<>
+INLINE int Extension<PointerToArray<LMatrix3f> >::
+__getbuffer__(PyObject *self, Py_buffer *view, int flags) {
+#if PY_VERSION_HEX >= 0x02060000
+  if (self != NULL) {
+    Py_INCREF(self);
+  }
+  view->obj = self;
+  view->buf = (void*) this->_this->p();
+  set_matrix_view(*view, flags, this->_this->size(), 3, false, false);
+
+  // Store a reference to ourselves on the Py_buffer object as a reminder that
+  // we have increased our refcount.
+  this->_this->ref();
+  view->internal = (void*) this->_this;
+
+  return 0;
+#else
+  return -1;
+#endif
+}
+
+/**
+ * This is used to implement the buffer protocol, in order to allow efficient
+ * access to the array data through a Python memoryview object.
+ */
+template<>
+INLINE int Extension<PointerToArray<LMatrix3d> >::
+__getbuffer__(PyObject *self, Py_buffer *view, int flags) {
+#if PY_VERSION_HEX >= 0x02060000
+  if (self != NULL) {
+    Py_INCREF(self);
+  }
+  view->obj = self;
+  view->buf = (void*) this->_this->p();
+  set_matrix_view(*view, flags, this->_this->size(), 3, true, false);
+
+  // Store a reference to ourselves on the Py_buffer object as a reminder that
+  // we have increased our refcount.
+  this->_this->ref();
+  view->internal = (void*) this->_this;
+
+  return 0;
+#else
+  return -1;
+#endif
+}
+
+/**
+ * This is used to implement the buffer protocol, in order to allow efficient
+ * access to the array data through a Python memoryview object.
+ */
+template<>
+INLINE int Extension<PointerToArray<UnalignedLMatrix4f> >::
+__getbuffer__(PyObject *self, Py_buffer *view, int flags) {
+#if PY_VERSION_HEX >= 0x02060000
+  if (self != NULL) {
+    Py_INCREF(self);
+  }
+  view->obj = self;
+  view->buf = (void*) this->_this->p();
+  set_matrix_view(*view, flags, this->_this->size(), 4, false, false);
+
+  // Store a reference to ourselves on the Py_buffer object as a reminder that
+  // we have increased our refcount.
+  this->_this->ref();
+  view->internal = (void*) this->_this;
+
+  return 0;
+#else
+  return -1;
+#endif
+}
+
+/**
+ * This is used to implement the buffer protocol, in order to allow efficient
+ * access to the array data through a Python memoryview object.
+ */
+template<>
+INLINE int Extension<PointerToArray<UnalignedLMatrix4d> >::
+__getbuffer__(PyObject *self, Py_buffer *view, int flags) {
+#if PY_VERSION_HEX >= 0x02060000
+  if (self != NULL) {
+    Py_INCREF(self);
+  }
+  view->obj = self;
+  view->buf = (void*) this->_this->p();
+  set_matrix_view(*view, flags, this->_this->size(), 4, true, false);
+
+  // Store a reference to ourselves on the Py_buffer object as a reminder that
+  // we have increased our refcount.
+  this->_this->ref();
+  view->internal = (void*) this->_this;
+
+  return 0;
+#else
+  return -1;
+#endif
+}
+
+/**
  * Releases the buffer allocated by __getbuffer__.
  */
 template<class Element>
@@ -287,6 +449,114 @@ __getbuffer__(PyObject *self, Py_buffer *view, int flags) const {
     view->strides = &(view->itemsize);
   }
   view->suboffsets = NULL;
+
+  // Store a reference to ourselves on the Py_buffer object as a reminder that
+  // we have increased our refcount.
+  this->_this->ref();
+  view->internal = (void*) this->_this;
+
+  return 0;
+#else
+  return -1;
+#endif
+}
+
+template<>
+INLINE int Extension<ConstPointerToArray<LMatrix3f> >::
+__getbuffer__(PyObject *self, Py_buffer *view, int flags) const {
+#if PY_VERSION_HEX >= 0x02060000
+  if ((flags & PyBUF_WRITABLE) == PyBUF_WRITABLE) {
+    PyErr_SetString(PyExc_BufferError,
+                    "Object is not writable.");
+    return -1;
+  }
+  if (self != NULL) {
+    Py_INCREF(self);
+  }
+  view->obj = self;
+  view->buf = (void*) this->_this->p();
+  set_matrix_view(*view, flags, this->_this->size(), 3, false, true);
+
+  // Store a reference to ourselves on the Py_buffer object as a reminder that
+  // we have increased our refcount.
+  this->_this->ref();
+  view->internal = (void*) this->_this;
+
+  return 0;
+#else
+  return -1;
+#endif
+}
+
+template<>
+INLINE int Extension<ConstPointerToArray<LMatrix3d> >::
+__getbuffer__(PyObject *self, Py_buffer *view, int flags) const {
+#if PY_VERSION_HEX >= 0x02060000
+  if ((flags & PyBUF_WRITABLE) == PyBUF_WRITABLE) {
+    PyErr_SetString(PyExc_BufferError,
+                    "Object is not writable.");
+    return -1;
+  }
+  if (self != NULL) {
+    Py_INCREF(self);
+  }
+  view->obj = self;
+  view->buf = (void*) this->_this->p();
+  set_matrix_view(*view, flags, this->_this->size(), 3, true, true);
+
+  // Store a reference to ourselves on the Py_buffer object as a reminder that
+  // we have increased our refcount.
+  this->_this->ref();
+  view->internal = (void*) this->_this;
+
+  return 0;
+#else
+  return -1;
+#endif
+}
+
+template<>
+INLINE int Extension<ConstPointerToArray<UnalignedLMatrix4f> >::
+__getbuffer__(PyObject *self, Py_buffer *view, int flags) const {
+#if PY_VERSION_HEX >= 0x02060000
+  if ((flags & PyBUF_WRITABLE) == PyBUF_WRITABLE) {
+    PyErr_SetString(PyExc_BufferError,
+                    "Object is not writable.");
+    return -1;
+  }
+  if (self != NULL) {
+    Py_INCREF(self);
+  }
+  view->obj = self;
+  view->buf = (void*) this->_this->p();
+  set_matrix_view(*view, flags, this->_this->size(), 4, false, true);
+
+  // Store a reference to ourselves on the Py_buffer object as a reminder that
+  // we have increased our refcount.
+  this->_this->ref();
+  view->internal = (void*) this->_this;
+
+  return 0;
+#else
+  return -1;
+#endif
+}
+
+template<>
+INLINE int Extension<ConstPointerToArray<UnalignedLMatrix4d> >::
+__getbuffer__(PyObject *self, Py_buffer *view, int flags) const {
+#if PY_VERSION_HEX >= 0x02060000
+  if ((flags & PyBUF_WRITABLE) == PyBUF_WRITABLE) {
+    PyErr_SetString(PyExc_BufferError,
+                    "Object is not writable.");
+    return -1;
+  }
+  if (self != NULL) {
+    Py_INCREF(self);
+  }
+  view->obj = self;
+  view->buf = (void*) this->_this->p();
+  set_matrix_view(*view, flags, this->_this->size(), 4, true, true);
 
   // Store a reference to ourselves on the Py_buffer object as a reminder that
   // we have increased our refcount.

--- a/panda/src/express/pointerToArray_ext.h
+++ b/panda/src/express/pointerToArray_ext.h
@@ -40,6 +40,15 @@ public:
   INLINE void __releasebuffer__(PyObject *self, Py_buffer *view) const;
 };
 
+template<>
+  INLINE int Extension<PointerToArray<LMatrix3f> >::__getbuffer__(PyObject *self, Py_buffer *view, int flags);
+template<>
+  INLINE int Extension<PointerToArray<LMatrix3d> >::__getbuffer__(PyObject *self, Py_buffer *view, int flags);
+template<>
+  INLINE int Extension<PointerToArray<UnalignedLMatrix4f> >::__getbuffer__(PyObject *self, Py_buffer *view, int flags);
+template<>
+  INLINE int Extension<PointerToArray<UnalignedLMatrix4d> >::__getbuffer__(PyObject *self, Py_buffer *view, int flags);
+
 /**
  * This class defines the extension methods for ConstPointerToArray, which are
  * called instead of any C++ methods with the same prototype.
@@ -57,6 +66,15 @@ public:
   INLINE int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const;
   INLINE void __releasebuffer__(PyObject *self, Py_buffer *view) const;
 };
+
+template<>
+  INLINE int Extension<ConstPointerToArray<LMatrix3f> >::__getbuffer__(PyObject *self, Py_buffer *view, int flags) const;
+template<>
+  INLINE int Extension<ConstPointerToArray<LMatrix3d> >::__getbuffer__(PyObject *self, Py_buffer *view, int flags) const;
+template<>
+  INLINE int Extension<ConstPointerToArray<UnalignedLMatrix4f> >::__getbuffer__(PyObject *self, Py_buffer *view, int flags) const;
+template<>
+  INLINE int Extension<ConstPointerToArray<UnalignedLMatrix4d> >::__getbuffer__(PyObject *self, Py_buffer *view, int flags) const;
 
 #ifdef _MSC_VER
 // Ugh... MSVC needs this because they still don't have a decent linker.
@@ -114,10 +132,10 @@ define_format_code("3i", LVecBase3i);
 define_format_code("4f", UnalignedLVecBase4f);
 define_format_code("4d", UnalignedLVecBase4d);
 define_format_code("4i", UnalignedLVecBase4i);
-define_format_code("9f", LMatrix3f);
-define_format_code("9d", LMatrix3d);
-define_format_code("16f", UnalignedLMatrix4f);
-define_format_code("16d", UnalignedLMatrix4d);
+// define_format_code("9f", LMatrix3f);
+// define_format_code("9d", LMatrix3d);
+// define_format_code("16f", UnalignedLMatrix4f);
+// define_format_code("16d", UnalignedLMatrix4d);
 
 #include "pointerToArray_ext.I"
 

--- a/panda/src/express/pointerToArray_ext.h
+++ b/panda/src/express/pointerToArray_ext.h
@@ -19,6 +19,7 @@
 #include "extension.h"
 #include "py_panda.h"
 #include "pointerToArray.h"
+#include "luse.h"
 
 /**
  * This class defines the extension methods for PointerToArray, which are
@@ -103,6 +104,20 @@ define_format_code("q", long long);
 define_format_code("Q", unsigned long long);
 define_format_code("f", float);
 define_format_code("d", double);
+
+define_format_code("2f", LVecBase2f);
+define_format_code("2d", LVecBase2d);
+define_format_code("2i", LVecBase2i);
+define_format_code("3f", LVecBase3f);
+define_format_code("3d", LVecBase3d);
+define_format_code("3i", LVecBase3i);
+define_format_code("4f", UnalignedLVecBase4f);
+define_format_code("4d", UnalignedLVecBase4d);
+define_format_code("4i", UnalignedLVecBase4i);
+define_format_code("9f", LMatrix3f);
+define_format_code("9d", LMatrix3d);
+define_format_code("16f", UnalignedLMatrix4f);
+define_format_code("16d", UnalignedLMatrix4d);
 
 #include "pointerToArray_ext.I"
 


### PR DESCRIPTION
…ices.

Example using numpy:
```
from panda3d.core import LVector3d, PTA_LVecBase3d, CPTA_LVecBase3d
from panda3d.core import LMatrix3f, PTA_LMatrix3f, CPTA_LMatrix3f
from panda3d.core import LMatrix3d, PTA_LMatrix3d, CPTA_LMatrix3d
from panda3d.core import LMatrix4f, PTA_LMatrix4f, CPTA_LMatrix4f
from panda3d.core import LMatrix4d, PTA_LMatrix4d, CPTA_LMatrix4d
import numpy as np

vectors = PTA_LVecBase3d()
vectors.push_back(LVector3d(345., 2221., 0.11))
vectors.push_back(LVector3d(*range(3)))
numpy_vectors = np.asarray(memoryview(vectors))
print(numpy_vectors.shape, numpy_vectors.dtype)
print(numpy_vectors)
print("Const version is equal:", np.array_equal(numpy_vectors,
    np.asarray(memoryview(CPTA_LVecBase3d(vectors)))))

mat3fs = PTA_LMatrix3f()
mat3fs.push_back(LMatrix3f(*range(9)))
mat3fs.push_back(LMatrix3f(*range(3030, 3039)))
numpy_mat3fs = np.asarray(memoryview(mat3fs))
print(numpy_mat3fs.shape, numpy_mat3fs.dtype)
print(numpy_mat3fs)
print("Const version is equal:", np.array_equal(numpy_mat3fs,
    np.asarray(memoryview(CPTA_LMatrix3f(mat3fs)))))

mat3ds = PTA_LMatrix3d()
mat3ds.push_back(LMatrix3d(*range(9)))
mat3ds.push_back(LMatrix3d(*range(3030, 3039)))
numpy_mat3ds = np.asarray(memoryview(mat3ds))
print(numpy_mat3ds.shape, numpy_mat3ds.dtype)
print(numpy_mat3ds)
print("Const version is equal:", np.array_equal(numpy_mat3ds,
    np.asarray(memoryview(CPTA_LMatrix3d(mat3ds)))))

mat4fs = PTA_LMatrix4f()
mat4fs.push_back(LMatrix4f(*range(16)))
mat4fs.push_back(LMatrix4f(*range(8742, 8758)))
numpy_mat4fs = np.asarray(memoryview(mat4fs))
print(numpy_mat4fs.shape, numpy_mat4fs.dtype)
print(numpy_mat4fs)
print("Const version is equal:", np.array_equal(numpy_mat4fs,
    np.asarray(memoryview(CPTA_LMatrix4f(mat4fs)))))

mat4ds = PTA_LMatrix4d()
mat4ds.push_back(LMatrix4d(*range(16)))
mat4ds.push_back(LMatrix4d(*range(8742, 8758)))
numpy_mat4ds = np.asarray(memoryview(mat4ds))
print(numpy_mat4ds.shape, numpy_mat4ds.dtype)
print(numpy_mat4ds)
print("Const version is equal:", np.array_equal(numpy_mat4ds,
    np.asarray(memoryview(CPTA_LMatrix4d(mat4ds)))))
```
output:
```
(2, 3) float64
[[  3.45000000e+02   2.22100000e+03   1.10000000e-01]
 [  0.00000000e+00   1.00000000e+00   2.00000000e+00]]
Const version is equal: True
(2, 3, 3) float32
[[[  0.00000000e+00   1.00000000e+00   2.00000000e+00]
  [  3.00000000e+00   4.00000000e+00   5.00000000e+00]
  [  6.00000000e+00   7.00000000e+00   8.00000000e+00]]

 [[  3.03000000e+03   3.03100000e+03   3.03200000e+03]
  [  3.03300000e+03   3.03400000e+03   3.03500000e+03]
  [  3.03600000e+03   3.03700000e+03   3.03800000e+03]]]
Const version is equal: True
(2, 3, 3) float64
[[[  0.00000000e+00   1.00000000e+00   2.00000000e+00]
  [  3.00000000e+00   4.00000000e+00   5.00000000e+00]
  [  6.00000000e+00   7.00000000e+00   8.00000000e+00]]

 [[  3.03000000e+03   3.03100000e+03   3.03200000e+03]
  [  3.03300000e+03   3.03400000e+03   3.03500000e+03]
  [  3.03600000e+03   3.03700000e+03   3.03800000e+03]]]
Const version is equal: True
(2, 4, 4) float32
[[[  0.00000000e+00   1.00000000e+00   2.00000000e+00   3.00000000e+00]
  [  4.00000000e+00   5.00000000e+00   6.00000000e+00   7.00000000e+00]
  [  8.00000000e+00   9.00000000e+00   1.00000000e+01   1.10000000e+01]
  [  1.20000000e+01   1.30000000e+01   1.40000000e+01   1.50000000e+01]]

 [[  8.74200000e+03   8.74300000e+03   8.74400000e+03   8.74500000e+03]
  [  8.74600000e+03   8.74700000e+03   8.74800000e+03   8.74900000e+03]
  [  8.75000000e+03   8.75100000e+03   8.75200000e+03   8.75300000e+03]
  [  8.75400000e+03   8.75500000e+03   8.75600000e+03   8.75700000e+03]]]
Const version is equal: True
(2, 4, 4) float64
[[[  0.00000000e+00   1.00000000e+00   2.00000000e+00   3.00000000e+00]
  [  4.00000000e+00   5.00000000e+00   6.00000000e+00   7.00000000e+00]
  [  8.00000000e+00   9.00000000e+00   1.00000000e+01   1.10000000e+01]
  [  1.20000000e+01   1.30000000e+01   1.40000000e+01   1.50000000e+01]]

 [[  8.74200000e+03   8.74300000e+03   8.74400000e+03   8.74500000e+03]
  [  8.74600000e+03   8.74700000e+03   8.74800000e+03   8.74900000e+03]
  [  8.75000000e+03   8.75100000e+03   8.75200000e+03   8.75300000e+03]
  [  8.75400000e+03   8.75500000e+03   8.75600000e+03   8.75700000e+03]]]
Const version is equal: True
```