### PR TITLE
Fix size_t type warning.

### DIFF
--- a/panda/src/gobj/geomVertexData.h
+++ b/panda/src/gobj/geomVertexData.h
@@ -200,7 +200,7 @@ private:
                             const unsigned char *from, int from_stride,
                             int num_records);
 
-  typedef pmap<const VertexTransform *, int> TransformMap;
+  typedef pmap<const VertexTransform *, size_t> TransformMap;
   INLINE static int
   add_transform(TransformTable *table, const VertexTransform *transform,
                 TransformMap &already_added);


### PR DESCRIPTION
Fix `size_t` to `int` type-conversion warning on `table->get_num_transforms()`.
(https://github.com/panda3d/panda3d/blob/master/panda/src/gobj/geomVertexData.I#L479)