### PR TITLE
Fix assert macros that cause a crash in non-debug

### DIFF
--- a/panda/src/pgraph/renderAttrib.cxx
+++ b/panda/src/pgraph/renderAttrib.cxx
@@ -514,7 +514,7 @@ release_new() {
 
   if (_saved_entry != -1) {
     _saved_entry = -1;
-    nassertv(_attribs->remove(this));
+    nassertv_always(_attribs->remove(this));
   }
 }
 

--- a/panda/src/pgraph/renderState.cxx
+++ b/panda/src/pgraph/renderState.cxx
@@ -1690,7 +1690,7 @@ release_new() {
 
   if (_saved_entry != -1) {
     _saved_entry = -1;
-    nassertv(_states->remove(this));
+    nassertv_always(_states->remove(this));
   }
 }
 

--- a/panda/src/pgraph/transformState.cxx
+++ b/panda/src/pgraph/transformState.cxx
@@ -1900,7 +1900,7 @@ release_new() {
 
   if (_saved_entry != -1) {
     _saved_entry = -1;
-    nassertv(_states->remove(this));
+    nassertv_always(_states->remove(this));
   }
 }
 


### PR DESCRIPTION
In non-debug, the codes do not run and the deleted item is not removed.
So, a crash happens when hash map is cleared.