### PR TITLE
Add additional Windows SDK path to enviroment variable

### DIFF
--- a/makepanda/makepandacore.py
+++ b/makepanda/makepandacore.py
@@ -2422,6 +2422,7 @@ def SetupVisualStudioEnviron():
     winsdk_ver = SDK["MSPLATFORM_VERSION"]
     if winsdk_ver.startswith('10.'):
         AddToPathEnv("PATH",    SDK["MSPLATFORM"] + "bin\\" + arch)
+        AddToPathEnv("PATH",    SDK["MSPLATFORM"] + "bin\\" + winsdk_ver + "\\" + arch)
 
         # Windows Kit 10 introduces the "universal CRT".
         inc_dir = SDK["MSPLATFORM"] + "Include\\" + winsdk_ver + "\\"


### PR DESCRIPTION
Windows 10 SDK binary files are installed in versioned folder from Creator Update (10.0.15063.0)
This fixes the issue that 'rc.exe' file cannot be found.