### PR TITLE
Introduce png-compression-level PRC variable

### DIFF
--- a/panda/src/pnmimagetypes/config_pnmimagetypes.cxx
+++ b/panda/src/pnmimagetypes/config_pnmimagetypes.cxx
@@ -81,6 +81,7 @@ ConfigVariableInt img_size
 ("img-size", 0,
  PRC_DESC("If an IMG file without a header is loaded (e.g. img-header-type "
           "is set to 'none', this specifies the fixed x y size of the image."));
+
 ConfigVariableInt jpeg_quality
 ("jpeg-quality", 95,
  PRC_DESC("Set this to the quality percentage for writing JPEG files.  95 is "
@@ -88,10 +89,17 @@ ConfigVariableInt jpeg_quality
           "significantly better quality, but do lead to significantly greater "
           "size)."));
 
+ConfigVariableInt png_compression_level
+("png-compression-level", 6,
+ PRC_DESC("Set this to the desired compression level for writing PNG images.  "
+          "Valid values are 0 (no compression), or 1 (compression, best "
+          "speed) to 9 (best compression).  Default is 6.  PNG compression is "
+          "lossless."));
+
 ConfigVariableBool png_palette
 ("png-palette", true,
- PRC_DESC("Set this true to allow writing palette-based PNG images when possible."));
-
+ PRC_DESC("Set this true to allow writing palette-based PNG images when "
+          "possible."));
 
 ConfigVariableInt bmp_bpp
 ("bmp-bpp", 0,

--- a/panda/src/pnmimagetypes/config_pnmimagetypes.h
+++ b/panda/src/pnmimagetypes/config_pnmimagetypes.h
@@ -57,6 +57,7 @@ extern ConfigVariableBool tga_grayscale;
 
 extern ConfigVariableInt jpeg_quality;
 
+extern ConfigVariableInt png_compression_level;
 extern ConfigVariableBool png_palette;
 
 extern ConfigVariableInt bmp_bpp;

--- a/panda/src/pnmimagetypes/pnmFileTypePNG.cxx
+++ b/panda/src/pnmimagetypes/pnmFileTypePNG.cxx
@@ -526,6 +526,10 @@ write_data(xel *array, xelval *alpha_data) {
 
   png_set_write_fn(_png, (void *)this, png_write_data, png_flush_data);
 
+  // The compression level corresponds directly to the compression levels for
+  // zlib.
+  png_set_compression_level(png_compression_level);
+
   // First, write the header.
 
   int true_bit_depth = pm_maxvaltobits(_maxval);

--- a/panda/src/pnmimagetypes/pnmFileTypePNG.cxx
+++ b/panda/src/pnmimagetypes/pnmFileTypePNG.cxx
@@ -528,7 +528,7 @@ write_data(xel *array, xelval *alpha_data) {
 
   // The compression level corresponds directly to the compression levels for
   // zlib.
-  png_set_compression_level(png_compression_level);
+  png_set_compression_level(_png, png_compression_level);
 
   // First, write the header.
 


### PR DESCRIPTION
This PR adds a _png-compression-level_ PRC variable to Panda. It allows to choose the compression level for writing out PNG images. Valid values are 0 (no compression), or 1 (best speed) to 9 (best compression). The default value is 6 and has been 6 when used in conjunction with libpng+zlib. PNG compression is lossless.

The resulting file size for PNG files could be optimized further by choosing "filters" intelligently as described on http://www.libpng.org/pub/png/book/chapter09.html and in http://www.libpng.org/pub/png/book/LCH-png-chapter.pdf . However, this is out of scope here and several programs like PNGCRUSH and OptiPNG exist that aim to accomplish this task.

For the future, a nice-to-have would be to be able to disable chroma subsampling for writing out JPEG images.