### PR TITLE
Fix inheritance problem

### DIFF
--- a/panda/src/express/dcast.T
+++ b/panda/src/express/dcast.T
@@ -58,7 +58,7 @@ _dcast(WantType *, TypedObject *ptr) {
     return (WantType *)NULL;
   }
 #endif
-  return static_cast<WantType *>(ptr);
+  return dynamic_cast<WantType *>(ptr);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -80,7 +80,7 @@ _dcast(WantType *, const TypedObject *ptr) {
     return (const WantType *)NULL;
   }
 #endif
-  return static_cast<const WantType *>(ptr);
+  return dynamic_cast<const WantType *>(ptr);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/panda/src/express/dcast.T
+++ b/panda/src/express/dcast.T
@@ -58,7 +58,7 @@ _dcast(WantType *, TypedObject *ptr) {
     return (WantType *)NULL;
   }
 #endif
-  return (WantType *)ptr;
+  return dynamic_cast<WantType *>(ptr);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/panda/src/express/dcast.T
+++ b/panda/src/express/dcast.T
@@ -58,7 +58,7 @@ _dcast(WantType *, TypedObject *ptr) {
     return (WantType *)NULL;
   }
 #endif
-  return dynamic_cast<WantType *>(ptr);
+  return static_cast<WantType *>(ptr);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -80,7 +80,7 @@ _dcast(WantType *, const TypedObject *ptr) {
     return (const WantType *)NULL;
   }
 #endif
-  return (const WantType *)ptr;
+  return static_cast<const WantType *>(ptr);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/panda/src/express/typedReferenceCount.h
+++ b/panda/src/express/typedReferenceCount.h
@@ -28,7 +28,7 @@
  *
  * See also TypedObject for detailed instructions.
  */
-class EXPCL_PANDAEXPRESS TypedReferenceCount : public TypedObject, public ReferenceCount {
+class EXPCL_PANDAEXPRESS TypedReferenceCount : public virtual TypedObject, public ReferenceCount {
 public:
   INLINE TypedReferenceCount();
   INLINE TypedReferenceCount(const TypedReferenceCount &copy);


### PR DESCRIPTION
Interrogate likes to cause errors relating to inheritance if a class inherits a class with TypedReferenceCount it's base and another class with TypedObject as it's base.