### PR TITLE
Fix 'of of' doc typos

### DIFF
--- a/panda/src/collide/collisionBox.I
+++ b/panda/src/collide/collisionBox.I
@@ -12,7 +12,7 @@
  */
 
 /**
- * Create the Box by giving a Center and distances of of each of the sides of
+ * Create the Box by giving a Center and distances of each of the sides of
  * box from the Center.
  */
 INLINE CollisionBox::

--- a/panda/src/pgraph/clipPlaneAttrib.cxx
+++ b/panda/src/pgraph/clipPlaneAttrib.cxx
@@ -213,7 +213,7 @@ make_default() {
 /**
  * Returns the basic operation type of the ClipPlaneAttrib.  If this is O_set,
  * the planes listed here completely replace any planes that were already on.
- * If this is O_add, the planes here are added to the set of of planes that
+ * If this is O_add, the planes here are added to the set of planes that
  * were already on, and if O_remove, the planes here are removed from the set
  * of planes that were on.
  *

--- a/panda/src/pgraph/lightAttrib.cxx
+++ b/panda/src/pgraph/lightAttrib.cxx
@@ -257,7 +257,7 @@ make_default() {
 /**
  * Returns the basic operation type of the LightAttrib.  If this is O_set, the
  * lights listed here completely replace any lights that were already on.  If
- * this is O_add, the lights here are added to the set of of lights that were
+ * this is O_add, the lights here are added to the set of lights that were
  * already on, and if O_remove, the lights here are removed from the set of
  * lights that were on.
  *


### PR DESCRIPTION
Noticed a typo in the CollisionBox docs that duplicated the word 'of'. Ran grep on the rest of the repo and fixed it in the other locations, too. 