### PR TITLE
Fix compile error by missing header file

### DIFF
--- a/panda/src/pgraph/shaderInput.h
+++ b/panda/src/pgraph/shaderInput.h
@@ -31,6 +31,7 @@
 #include "shader.h"
 #include "texture.h"
 #include "shaderBuffer.h"
+#include "extension.h"
 
 /**
  * This is a small container class that can hold any one of the value types


### PR DESCRIPTION
Hello, I found a compilation error that occurs when building without Python on the following line:

https://github.com/panda3d/panda3d/blob/075cb14cbbb004fb167632b630d35e8d03e92e03/panda/src/pgraph/shaderInput.h#L142

This PR fixes it.