### PR TITLE
makepanda: fix building with HarfBuzz under MSVC

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -643,7 +643,9 @@ if (COMPILER == "MSVC"):
     if (PkgSkip("NVIDIACG")==0): LibName("CGDX9",    GetThirdpartyDir() + "nvidiacg/lib/cgD3D9.lib")
     if (PkgSkip("NVIDIACG")==0): LibName("NVIDIACG", GetThirdpartyDir() + "nvidiacg/lib/cg.lib")
     if (PkgSkip("FREETYPE")==0): LibName("FREETYPE", GetThirdpartyDir() + "freetype/lib/freetype.lib")
-    if (PkgSkip("HARFBUZZ")==0): LibName("HARFBUZZ", GetThirdpartyDir() + "harfbuzz/lib/harfbuzz.lib")
+    if (PkgSkip("HARFBUZZ")==0):
+        LibName("HARFBUZZ", GetThirdpartyDir() + "harfbuzz/lib/harfbuzz.lib")
+        IncDirectory("HARFBUZZ", GetThirdpartyDir() + "harfbuzz/include/harfbuzz")
     if (PkgSkip("FFTW")==0):     LibName("FFTW",     GetThirdpartyDir() + "fftw/lib/rfftw.lib")
     if (PkgSkip("FFTW")==0):     LibName("FFTW",     GetThirdpartyDir() + "fftw/lib/fftw.lib")
     if (PkgSkip("ARTOOLKIT")==0):LibName("ARTOOLKIT",GetThirdpartyDir() + "artoolkit/lib/libAR.lib")


### PR DESCRIPTION
This PR fixes building Panda3D with HarfBuzz under MSVC.

Note: Panda expects that HarfBuzz has been compiled with Freetype (`-DHB_HAVE_FREETYPE=ON` for CMake), otherwise `hb-ft.h` will not be available.


Build error message before this fix:

`[ 33%] Building C++ object built/tmp/p3text_composite1.obj
p3text_composite1.cxx
c:\build-panda\panda3d-master\panda\src\text\dynamicTextFont.cxx(48): fatal erro
r C1083: Cannot open include file: 'hb-ft.h': No such file or directory
Storing dependency cache.
Elapsed Time: 13 min 6 sec
The following command returned a non-zero value: cl /favor:blend /wd4996 /wd4275
 /wd4273 /DWINVER=0x501 /Zc:threadSafeInit- /Fobuilt/tmp/p3text_composite1.obj /
nologo /c /Ipanda/src/text /Ibuilt/tmp /Ibuilt/include /Ithirdparty/win-python3.
6-x64/include /Ithirdparty/win-libs-vc14-x64/zlib/include /Ithirdparty/win-libs-
vc14-x64/freetype/include /Ithirdparty/win-libs-vc14-x64/harfbuzz/include /Ithir
dparty/win-libs-vc14-x64/freetype/include/freetype2 /Ithirdparty/win-libs-vc14-x
64/extras/include /DHAVE_HARFBUZZ= /MD /Zi /GS- /Ox /Ob2 /Oi /Ot /fp:fast /DFORC
E_INLINING /DNDEBUG /GL /Oy /Zp16 /Fdbuilt/tmp/p3text_composite1.pdb /DBUILDING_
PANDA /bigobj /Zm300 /DWIN32_VC /DWIN32 /D_HAS_EXCEPTIONS=0 /GR- /DWIN64_VC /DWI
N64 /W3 panda/src/text/p3text_composite1.cxx
Build terminated.`