### PR TITLE
Fix name of library files for vorbis library in MSVC

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -705,9 +705,9 @@ if (COMPILER == "MSVC"):
         DefSymbol("WX",     "_UNICODE", "")
         DefSymbol("WX",     "UNICODE", "")
     if (PkgSkip("VORBIS")==0):
-        LibName("VORBIS",   GetThirdpartyDir() + "vorbis/lib/libogg_static.lib")
-        LibName("VORBIS",   GetThirdpartyDir() + "vorbis/lib/libvorbis_static.lib")
-        LibName("VORBIS",   GetThirdpartyDir() + "vorbis/lib/libvorbisfile_static.lib")
+        LibName("VORBIS",   GetThirdpartyDir() + "vorbis/lib/ogg.lib")
+        LibName("VORBIS",   GetThirdpartyDir() + "vorbis/lib/vorbis.lib")
+        LibName("VORBIS",   GetThirdpartyDir() + "vorbis/lib/vorbisfile.lib")
     if (PkgSkip("OPUS")==0):
         LibName("OPUS", GetThirdpartyDir() + "opus/lib/libogg_static.lib")
         LibName("OPUS", GetThirdpartyDir() + "opus/lib/libopus_static.lib")


### PR DESCRIPTION
Hello, I found mismatched file names of vorbis library by https://github.com/rdb/panda3d-thirdparty/commit/9447b95aa845ae6170a5bb9e8daf13bae3c4a221 commit. This PR fixes it.

However, these changes will break compatibility with previous thirdparty tools (ex, panda3d-1.9.4-tools or thirdparty-vc14-tools for vs2015)