### PR TITLE
Add HAVE_PYTHON macro to build without python

### DIFF
--- a/dtool/src/interrogatedb/py_wrappers.cxx
+++ b/dtool/src/interrogatedb/py_wrappers.cxx
@@ -13,6 +13,8 @@
 
 #include "py_wrappers.h"
 
+#ifdef HAVE_PYTHON
+
 #if PY_VERSION_HEX >= 0x03040000
 #define _COLLECTIONS_ABC "_collections_abc"
 #elif PY_VERSION_HEX >= 0x03030000
@@ -1669,3 +1671,5 @@ Dtool_NewStaticProperty(PyTypeObject *type, const PyGetSetDef *getset) {
   }
   return (PyObject *)descr;
 }
+
+#endif  // HAVE_PYTHON

--- a/dtool/src/interrogatedb/py_wrappers.h
+++ b/dtool/src/interrogatedb/py_wrappers.h
@@ -16,6 +16,8 @@
 
 #include "py_panda.h"
 
+#ifdef HAVE_PYTHON
+
 /**
  * These classes are returned from properties that require a subscript
  * interface, ie. something.children[i] = 3.
@@ -71,4 +73,6 @@ EXPCL_INTERROGATEDB Dtool_MappingWrapper *Dtool_NewMutableMappingWrapper(PyObjec
 EXPCL_INTERROGATEDB PyObject *Dtool_NewGenerator(PyObject *self, const char *name, iternextfunc func);
 EXPCL_INTERROGATEDB PyObject *Dtool_NewStaticProperty(PyTypeObject *obj, const PyGetSetDef *getset);
 
-#endif
+#endif  // HAVE_PYTHON
+
+#endif  // PY_WRAPPERS_H


### PR DESCRIPTION
Hello, I added `HAVE_PYTHON` macro to `py_wrappers` source and header files to fix errors occur when building without python library.