### PR TITLE
Add simple way to enable overflow on DirectEntry element

### DIFF
--- a/direct/src/gui/DirectEntry.py
+++ b/direct/src/gui/DirectEntry.py
@@ -59,6 +59,8 @@ class DirectEntry(DirectFrame):
             # Text used for the PGEntry text node
             # NOTE: This overrides the DirectFrame text option
             ('initialText',     '',               DGG.INITOPT),
+            # Enable or disable text overflow scrolling
+            ('enableOverflow',  0,                self.setOverflowMode),
             # Command to be called on hitting Enter
             ('command',        None,              None),
             ('extraArgs',      [],                None),
@@ -158,6 +160,9 @@ class DirectEntry(DirectFrame):
 
     def setCursorKeysActive(self):
         PGEntry.setCursorKeysActive(self.guiItem, self['cursorKeys'])
+
+    def setOverflowMode(self):
+        PGEntry.set_overflow_mode(self.guiItem, self['enableOverflow'])
 
     def setObscureMode(self):
         PGEntry.setObscureMode(self.guiItem, self['obscured'])

--- a/direct/src/gui/DirectEntry.py
+++ b/direct/src/gui/DirectEntry.py
@@ -60,7 +60,7 @@ class DirectEntry(DirectFrame):
             # NOTE: This overrides the DirectFrame text option
             ('initialText',     '',               DGG.INITOPT),
             # Enable or disable text overflow scrolling
-            ('enableOverflow',  0,                self.setOverflowMode),
+            ('overflow',        0,                self.setOverflowMode),
             # Command to be called on hitting Enter
             ('command',        None,              None),
             ('extraArgs',      [],                None),
@@ -162,7 +162,7 @@ class DirectEntry(DirectFrame):
         PGEntry.setCursorKeysActive(self.guiItem, self['cursorKeys'])
 
     def setOverflowMode(self):
-        PGEntry.set_overflow_mode(self.guiItem, self['enableOverflow'])
+        PGEntry.set_overflow_mode(self.guiItem, self['overflow'])
 
     def setObscureMode(self):
         PGEntry.setObscureMode(self.guiItem, self['obscured'])


### PR DESCRIPTION
Made set_overflow_mode avail. in DirectEntry via enableOverflow option
This will enable enable the default overflow behaviour on the DirectEntry element. The position where the overflow should be triggered is set via the DirectEntry's 'width' option.