### PR TITLE
Fix menubar issues on macOS

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -30,6 +30,7 @@
 
 #import "cocoaPandaView.h"
 #import "cocoaPandaWindow.h"
+#import "cocoaPandaAppDelegate.h"
 
 #import <ApplicationServices/ApplicationServices.h>
 #import <Foundation/NSAutoreleasePool.h>
@@ -69,13 +70,32 @@ CocoaGraphicsWindow(GraphicsEngine *engine, GraphicsPipe *pipe,
   // Now that we know for sure we want a window, we can create the Cocoa app.
   // This will cause the application icon to appear and start bouncing.
   if (NSApp == nil) {
+      
     [CocoaPandaApp sharedApplication];
-
+    CocoaPandaAppDelegate *delegate = [[CocoaPandaAppDelegate alloc] init];
+    [NSApp setDelegate:delegate];
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 #endif
+    NSMenu *mainMenu = [[NSMenu alloc] init];
+
+    NSMenuItem *applicationMenuItem = [[NSMenuItem alloc] init];
+    [mainMenu addItem:applicationMenuItem];
+
+    NSMenu *applicationMenu = [[NSMenu alloc] init];
+
+    NSMenuItem *item = [[NSMenuItem alloc] init];
+    item.action = @selector(terminate:);
+    item.keyEquivalent = @"q";
+
+    NSString *appName = [NSRunningApplication currentApplication].localizedName;
+    item.title = [NSString stringWithFormat:@"Quit %@", appName];
+
+    [applicationMenu addItem:item];
+
+    [mainMenu setSubmenu:applicationMenu forItem:applicationMenuItem];
+    [NSApp setMainMenu:mainMenu];
     [NSApp finishLaunching];
-    [NSApp activateIgnoringOtherApps:YES];
   }
 
   GraphicsWindowInputDevice device =

--- a/panda/src/cocoadisplay/cocoaPandaAppDelegate.h
+++ b/panda/src/cocoadisplay/cocoaPandaAppDelegate.h
@@ -1,0 +1,22 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file cocoaPandaWindow.h
+ * @author Donny Lawrence
+ * @date 2018-02-25
+ */
+
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+// Cocoa is picky about where and when certain methods are called in the initialization process.
+@interface CocoaPandaAppDelegate : NSObject<NSApplicationDelegate>
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification;
+
+@end

--- a/panda/src/cocoadisplay/cocoaPandaAppDelegate.mm
+++ b/panda/src/cocoadisplay/cocoaPandaAppDelegate.mm
@@ -1,0 +1,23 @@
+/**
+* PANDA 3D SOFTWARE
+* Copyright (c) Carnegie Mellon University.  All rights reserved.
+*
+* All use of this software is subject to the terms of the revised BSD
+* license.  You should have received a copy of this license along
+* with this source code in a file named "LICENSE."
+*
+* @file cocoaPandaWindow.h
+* @author Donny Lawrence
+* @date 2018-02-25
+*/
+
+#import "cocoaPandaAppDelegate.h"
+
+@implementation CocoaPandaAppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+  // This only seems to work when called here.
+  [NSApp activateIgnoringOtherApps:YES];
+}
+
+@end

--- a/panda/src/cocoadisplay/p3cocoadisplay_composite1.mm
+++ b/panda/src/cocoadisplay/p3cocoadisplay_composite1.mm
@@ -7,3 +7,4 @@
 #include "cocoaPandaView.mm"
 #include "cocoaPandaWindow.mm"
 #include "cocoaPandaWindowDelegate.mm"
+#include "cocoaPandaAppDelegate.mm"


### PR DESCRIPTION
On macOS, I've noticed that the menubar (including the Apple menu) is unresponsive after launching a Panda app. Switching away from the window and back fixes the unresponsiveness, but there are still no items under the application menu. Since it is common for a user to want to quit the app through that menu or through the Cmd+Q keyboard combination, I addressed that as well.

The unresponsive menubar seems to stem from where `[NSApp activateIgnoringOtherApps]` is called. From my research, Cocoa is oddly specific about where certain methods need to be called from, and behavior often differs between each OS release. I moved this call to an AppDelegate event, which is where Apple seems to recommend placing it. I also added a quit button to the application's menu, along with the corresponding keyboard combination.

In the future, we may want to add a way to customize menubar items from the application itself, rather than a developer having to modify the engine source.