### PR TITLE
bullet: Fixed deadlock when loading from collision solids

### DIFF
--- a/panda/src/bullet/bulletGhostNode.cxx
+++ b/panda/src/bullet/bulletGhostNode.cxx
@@ -97,7 +97,7 @@ do_transform_changed() {
     if (ts->has_scale()) {
       LVecBase3 scale = ts->get_scale();
       if (!scale.almost_equal(LVecBase3(1.0f, 1.0f, 1.0f))) {
-        for (int i=0; i<get_num_shapes(); i++) {
+        for (int i=0; i < _shapes.size(); i++) {
           PT(BulletShape) shape = _shapes[i];
           shape->do_set_local_scale(scale);
         }


### PR DESCRIPTION
        - Fixed deadlock when loading ghost nodes from collision solids and
        have non-identity scale applied.

Signed-off-by: deflected <deflected@users.noreply.github.com>