### PR TITLE
Clean up OpenAL (and fix some Apple bugs)

### DIFF
--- a/panda/src/audiotraits/config_openalAudio.cxx
+++ b/panda/src/audiotraits/config_openalAudio.cxx
@@ -30,6 +30,23 @@ ConfigVariableString openal_device
  PRC_DESC("Specify the OpenAL device string for audio playback (no quotes).  If this "
           "is not specified, the OpenAL default device is used."));
 
+ConfigVariableInt openal_buffer_delete_reattempts
+("openal-buffer-delete-reattempts", 5,
+ PRC_DESC("If deleting a buffer fails due to still being in use, the OpenAL "
+          "sound plugin will wait a moment and reattempt deletion, with an "
+          "exponentially-increasing delay for each attempt.  This number "
+          "specifies how many repeat attempts (not counting the initial attempt) "
+          "should be made before giving up and raising an error."));
+
+ConfigVariableDouble openal_buffer_delete_delay
+("openal-buffer-delete-delay", 0.001,
+ PRC_DESC("If deleting a buffer fails due to still being in use, the OpenAL "
+          "sound plugin will wait a moment and reattempt deletion, with an "
+          "exponentially-increasing delay for each attempt.  This number "
+          "specifies how long, in seconds, the OpenAL plugin will wait after "
+          "its first failed attempt.  The second attempt will be double this "
+          "delay, the third quadruple, and so on."));
+
 
 /**
  * Initializes the library.  This must be called at least once before any of

--- a/panda/src/audiotraits/config_openalAudio.cxx
+++ b/panda/src/audiotraits/config_openalAudio.cxx
@@ -30,21 +30,21 @@ ConfigVariableString openal_device
  PRC_DESC("Specify the OpenAL device string for audio playback (no quotes).  If this "
           "is not specified, the OpenAL default device is used."));
 
-ConfigVariableInt openal_buffer_delete_reattempts
-("openal-buffer-delete-reattempts", 5,
+ConfigVariableInt openal_buffer_delete_retries
+("openal-buffer-delete-retries", 5,
  PRC_DESC("If deleting a buffer fails due to still being in use, the OpenAL "
-          "sound plugin will wait a moment and reattempt deletion, with an "
-          "exponentially-increasing delay for each attempt.  This number "
-          "specifies how many repeat attempts (not counting the initial attempt) "
+          "sound plugin will wait a moment and retry deletion, with an "
+          "exponentially-increasing delay for each try.  This number "
+          "specifies how many repeat tries (not counting the initial try) "
           "should be made before giving up and raising an error."));
 
 ConfigVariableDouble openal_buffer_delete_delay
 ("openal-buffer-delete-delay", 0.001,
  PRC_DESC("If deleting a buffer fails due to still being in use, the OpenAL "
-          "sound plugin will wait a moment and reattempt deletion, with an "
-          "exponentially-increasing delay for each attempt.  This number "
+          "sound plugin will wait a moment and retry deletion, with an "
+          "exponentially-increasing delay for each try.  This number "
           "specifies how long, in seconds, the OpenAL plugin will wait after "
-          "its first failed attempt.  The second attempt will be double this "
+          "its first failed try.  The second try will be double this "
           "delay, the third quadruple, and so on."));
 
 

--- a/panda/src/audiotraits/config_openalAudio.h
+++ b/panda/src/audiotraits/config_openalAudio.h
@@ -26,5 +26,7 @@ extern "C" EXPCL_OPENAL_AUDIO void init_libOpenALAudio();
 extern "C" EXPCL_OPENAL_AUDIO Create_AudioManager_proc *get_audio_manager_func_openal_audio();
 
 extern ConfigVariableString openal_device;
+extern ConfigVariableInt openal_buffer_delete_reattempts;
+extern ConfigVariableDouble openal_buffer_delete_delay;
 
 #endif // CONFIG_OPENALAUDIO_H

--- a/panda/src/audiotraits/config_openalAudio.h
+++ b/panda/src/audiotraits/config_openalAudio.h
@@ -26,7 +26,7 @@ extern "C" EXPCL_OPENAL_AUDIO void init_libOpenALAudio();
 extern "C" EXPCL_OPENAL_AUDIO Create_AudioManager_proc *get_audio_manager_func_openal_audio();
 
 extern ConfigVariableString openal_device;
-extern ConfigVariableInt openal_buffer_delete_reattempts;
+extern ConfigVariableInt openal_buffer_delete_retries;
 extern ConfigVariableDouble openal_buffer_delete_delay;
 
 #endif // CONFIG_OPENALAUDIO_H

--- a/panda/src/audiotraits/openalAudioManager.cxx
+++ b/panda/src/audiotraits/openalAudioManager.cxx
@@ -524,7 +524,7 @@ get_sound(const string &file_name, bool positional, int mode) {
 void OpenALAudioManager::
 uncache_sound(const string& file_name) {
   ReMutexHolder holder(_lock);
-  assert(is_valid());
+  nassertv(is_valid());
   Filename path = file_name;
 
   VirtualFileSystem *vfs = VirtualFileSystem::get_global_ptr();
@@ -910,7 +910,7 @@ reduce_sounds_playing_to(unsigned int count) {
   int limit = _sounds_playing.size() - count;
   while (limit-- > 0) {
     SoundsPlaying::iterator sound = _sounds_playing.begin();
-    assert(sound != _sounds_playing.end());
+    nassertv(sound != _sounds_playing.end());
     // When the user stops a sound, there is still a PT in the user's hand.
     // When we stop a sound here, however, this can remove the last PT.  This
     // can cause an ugly recursion where stop calls the destructor, and the
@@ -1111,8 +1111,8 @@ discard_excess_cache(int sample_limit) {
 
   while (((int)_expiring_samples.size()) > sample_limit) {
     SoundData *sd = (SoundData*)(_expiring_samples.front());
-    assert(sd->_client_count == 0);
-    assert(sd->_expire == _expiring_samples.begin());
+    nassertv(sd->_client_count == 0);
+    nassertv(sd->_expire == _expiring_samples.begin());
     _expiring_samples.pop_front();
     _sample_cache.erase(_sample_cache.find(sd->_movie->get_filename()));
     audio_debug("Expiring: " << sd->_movie->get_filename().get_basename());
@@ -1121,8 +1121,8 @@ discard_excess_cache(int sample_limit) {
 
   while (((int)_expiring_streams.size()) > stream_limit) {
     SoundData *sd = (SoundData*)(_expiring_streams.front());
-    assert(sd->_client_count == 0);
-    assert(sd->_expire == _expiring_streams.begin());
+    nassertv(sd->_client_count == 0);
+    nassertv(sd->_expire == _expiring_streams.begin());
     _expiring_streams.pop_front();
     audio_debug("Expiring: " << sd->_movie->get_filename().get_basename());
     delete sd;

--- a/panda/src/audiotraits/openalAudioManager.cxx
+++ b/panda/src/audiotraits/openalAudioManager.cxx
@@ -1140,7 +1140,7 @@ discard_excess_cache(int sample_limit) {
 void OpenALAudioManager::
 delete_buffer(ALuint buffer) {
   ReMutexHolder holder(_lock);
-  int attempt = 0;
+  int tries = 0;
   ALuint error;
 
   // Keep trying until we succeed (or give up).
@@ -1154,13 +1154,13 @@ delete_buffer(ALuint buffer) {
     } else if (error != AL_INVALID_OPERATION) {
       // We weren't expecting that.  This should be reported.
       break;
-    } else if (attempt >= openal_buffer_delete_reattempts.get_value()) {
-      // We ran out of reattempts.  Give up.
+    } else if (tries >= openal_buffer_delete_retries.get_value()) {
+      // We ran out of retries.  Give up.
       break;
     } else {
-      // Make another attempt after (delay * 2^n) seconds.
-      Thread::sleep(openal_buffer_delete_delay.get_value() * (1 << attempt));
-      attempt++;
+      // Make another try after (delay * 2^n) seconds.
+      Thread::sleep(openal_buffer_delete_delay.get_value() * (1 << tries));
+      tries++;
     }
   }
 

--- a/panda/src/audiotraits/openalAudioManager.h
+++ b/panda/src/audiotraits/openalAudioManager.h
@@ -129,6 +129,8 @@ private:
   void decrement_client_count(SoundData *sd);
   void discard_excess_cache(int limit);
 
+  void delete_buffer(ALuint buffer);
+
   void starting_sound(OpenALAudioSound* audio);
   void stopping_sound(OpenALAudioSound* audio);
 

--- a/panda/src/audiotraits/openalAudioSound.I
+++ b/panda/src/audiotraits/openalAudioSound.I
@@ -40,7 +40,7 @@ get_calibrated_clock(double rtc) const {
  *
  * Returns true on success, false on failure.
  */
-bool OpenALAudioSound::
+INLINE bool OpenALAudioSound::
 require_sound_data() {
   if (_sd==0) {
     _sd = _manager->get_sound_data(_movie, _desired_mode);
@@ -61,7 +61,7 @@ require_sound_data() {
  * so.  The `force` argument overrides this, indicating we don't intend to
  * reacquire the sound data.
  */
-void OpenALAudioSound::
+INLINE void OpenALAudioSound::
 release_sound_data(bool force) {
   if (!has_sound_data()) return;
 
@@ -74,7 +74,7 @@ release_sound_data(bool force) {
 /**
  * Checks if the sound has NOT been cleaned up yet.
  */
-bool OpenALAudioSound::
+INLINE bool OpenALAudioSound::
 is_valid() const {
   return _manager != NULL;
 }
@@ -85,7 +85,7 @@ is_valid() const {
  *
  * This is mainly intended for use in asserts.
  */
-bool OpenALAudioSound::
+INLINE bool OpenALAudioSound::
 is_playing() const {
   // Manager only gives us a _source if we need it (to talk to OpenAL), so:
   return _source != 0;
@@ -96,7 +96,7 @@ is_playing() const {
  *
  * This is mainly intended for use in asserts.
  */
-bool OpenALAudioSound::
+INLINE bool OpenALAudioSound::
 has_sound_data() const {
   return _sd != 0;
 }

--- a/panda/src/audiotraits/openalAudioSound.I
+++ b/panda/src/audiotraits/openalAudioSound.I
@@ -63,3 +63,33 @@ release_sound_data() {
     _sd = 0;
   }
 }
+
+/**
+ * Checks if the sound has NOT been cleaned up yet.
+ */
+bool OpenALAudioSound::
+is_valid() const {
+  return _manager != NULL;
+}
+
+/**
+ * Checks if the sound is playing.  This is per the OpenALAudioManager's
+ * definition of "playing" -- as in, "will be called upon every update"
+ *
+ * This is mainly intended for use in asserts.
+ */
+bool OpenALAudioSound::
+is_playing() const {
+  // Manager only gives us a _source if we need it (to talk to OpenAL), so:
+  return _source != 0;
+}
+
+/**
+ * Checks if the sound has its SoundData structure open at the moment.
+ *
+ * This is mainly intended for use in asserts.
+ */
+bool OpenALAudioSound::
+has_sound_data() const {
+  return _sd != 0;
+}

--- a/panda/src/audiotraits/openalAudioSound.I
+++ b/panda/src/audiotraits/openalAudioSound.I
@@ -55,10 +55,17 @@ require_sound_data() {
 /**
  * Checks if the sound data record is present and releasable, and if so,
  * releases it.
+ *
+ * The sound data is "releasable" if it's from an ordinary, local file.  Remote
+ * streams cannot necessarily be reopened if lost, so we'll hold onto them if
+ * so.  The `force` argument overrides this, indicating we don't intend to
+ * reacquire the sound data.
  */
 void OpenALAudioSound::
-release_sound_data() {
-  if ((_sd!=0) && (!_movie->get_filename().empty())) {
+release_sound_data(bool force) {
+  if (!has_sound_data()) return;
+
+  if (force || !_movie->get_filename().empty()) {
     _manager->decrement_client_count(_sd);
     _sd = 0;
   }

--- a/panda/src/audiotraits/openalAudioSound.I
+++ b/panda/src/audiotraits/openalAudioSound.I
@@ -98,5 +98,5 @@ is_playing() const {
  */
 INLINE bool OpenALAudioSound::
 has_sound_data() const {
-  return _sd != 0;
+  return _sd != NULL;
 }

--- a/panda/src/audiotraits/openalAudioSound.cxx
+++ b/panda/src/audiotraits/openalAudioSound.cxx
@@ -434,6 +434,7 @@ correct_calibrated_clock(double rtc, double t) {
 void OpenALAudioSound::
 pull_used_buffers() {
   ReMutexHolder holder(OpenALAudioManager::_lock);
+  if (_manager == 0) return;
   while (_stream_queued.size()) {
     ALuint buffer = 0;
     ALint num_buffers = 0;
@@ -488,6 +489,8 @@ void OpenALAudioSound::
 push_fresh_buffers() {
   ReMutexHolder holder(OpenALAudioManager::_lock);
   static unsigned char data[65536];
+
+  if (_manager == 0) return;
 
   if (_sd->_sample) {
     while ((_loops_completed < _playing_loops) &&

--- a/panda/src/audiotraits/openalAudioSound.cxx
+++ b/panda/src/audiotraits/openalAudioSound.cxx
@@ -208,8 +208,7 @@ stop() {
     for (int i=0; i<((int)(_stream_queued.size())); i++) {
       ALuint buffer = _stream_queued[i]._buffer;
       if (buffer != _sd->_sample) {
-        alDeleteBuffers(1, &buffer);
-        al_audio_errcheck("deleting a buffer");
+        _manager->delete_buffer(buffer);
       }
     }
     _stream_queued.resize(0);
@@ -472,7 +471,7 @@ pull_used_buffers() {
           correct_calibrated_clock(rtc, al);
         }
         if (buffer != _sd->_sample) {
-          alDeleteBuffers(1,&buffer);
+          _manager->delete_buffer(buffer);
         }
       }
     } else {

--- a/panda/src/audiotraits/openalAudioSound.cxx
+++ b/panda/src/audiotraits/openalAudioSound.cxx
@@ -80,7 +80,7 @@ OpenALAudioSound(OpenALAudioManager* manager,
       audio_warning("stereo sound " << movie->get_filename() << " will not be spatialized");
     }
   }
-  release_sound_data();
+  release_sound_data(false);
 }
 
 
@@ -106,8 +106,7 @@ cleanup() {
     stop();
   }
   if (has_sound_data()) {
-    _manager->decrement_client_count(_sd);
-    _sd = 0;
+    release_sound_data(true);
   }
   _manager->release_sound(this);
   _manager = 0;
@@ -219,7 +218,7 @@ stop() {
   }
 
   _manager->stopping_sound(this);
-  release_sound_data();
+  release_sound_data(false);
 }
 
 /**

--- a/panda/src/audiotraits/openalAudioSound.cxx
+++ b/panda/src/audiotraits/openalAudioSound.cxx
@@ -201,7 +201,7 @@ stop() {
   if (is_playing()) {
     _manager->make_current();
 
-    assert(has_sound_data());
+    nassertv(has_sound_data());
 
     alGetError(); // clear errors
     alSourceStop(_source);
@@ -290,7 +290,7 @@ restart_stalled_audio() {
   ALenum status;
 
   if (!is_valid()) return;
-  assert(is_playing());
+  nassertv(is_playing());
 
   if (_stream_queued.size() == 0) {
     return;
@@ -310,7 +310,7 @@ void OpenALAudioSound::
 queue_buffer(ALuint buffer, int samples, int loop_index, double time_offset) {
   ReMutexHolder holder(OpenALAudioManager::_lock);
 
-  assert(is_playing());
+  nassertv(is_playing());
 
   // Now push the buffer into the stream queue.
   alGetError();
@@ -336,7 +336,7 @@ ALuint OpenALAudioSound::
 make_buffer(int samples, int channels, int rate, unsigned char *data) {
   ReMutexHolder holder(OpenALAudioManager::_lock);
 
-  assert(is_playing());
+  nassertr(is_playing(), 0);
 
   // Allocate a buffer to hold the data.
   alGetError();
@@ -370,7 +370,7 @@ int OpenALAudioSound::
 read_stream_data(int bytelen, unsigned char *buffer) {
   ReMutexHolder holder(OpenALAudioManager::_lock);
 
-  assert(has_sound_data());
+  nassertr(has_sound_data(), 0);
 
   MovieAudioCursor *cursor = _sd->_stream;
   double length = cursor->length();
@@ -423,7 +423,7 @@ void OpenALAudioSound::
 correct_calibrated_clock(double rtc, double t) {
   ReMutexHolder holder(OpenALAudioManager::_lock);
 
-  assert(is_playing());
+  nassertv(is_playing());
 
   double cc = (rtc - _calibrated_clock_base) * _calibrated_clock_scale;
   double diff = cc-t;
@@ -458,8 +458,8 @@ pull_used_buffers() {
   ReMutexHolder holder(OpenALAudioManager::_lock);
 
   if (!is_valid()) return;
-  assert(is_playing());
-  assert(has_sound_data());
+  nassertv(is_playing());
+  nassertv(has_sound_data());
 
   while (_stream_queued.size()) {
     ALuint buffer = 0;
@@ -517,8 +517,8 @@ push_fresh_buffers() {
   static unsigned char data[65536];
 
   if (!is_valid()) return;
-  assert(is_playing());
-  assert(has_sound_data());
+  nassertv(is_playing());
+  nassertv(has_sound_data());
 
   if (_sd->_sample) {
     while ((_loops_completed < _playing_loops) &&
@@ -545,7 +545,7 @@ push_fresh_buffers() {
         break;
       }
       ALuint buffer = make_buffer(samples, channels, rate, data);
-      if (!is_valid()) return;
+      if (!is_valid() || !buffer) return;
       queue_buffer(buffer, samples, loop_index, time_offset);
       if (!is_valid()) return;
       fill += samples;
@@ -582,7 +582,7 @@ void OpenALAudioSound::
 cache_time(double rtc) {
   ReMutexHolder holder(OpenALAudioManager::_lock);
 
-  assert(is_playing());
+  nassertv(is_playing());
 
   double t=get_calibrated_clock(rtc);
   double max = _length * _playing_loops;

--- a/panda/src/audiotraits/openalAudioSound.h
+++ b/panda/src/audiotraits/openalAudioSound.h
@@ -119,9 +119,11 @@ private:
   INLINE bool require_sound_data();
   INLINE void release_sound_data();
 
-private:
+  INLINE bool is_valid() const;
+  INLINE bool is_playing() const;
+  INLINE bool has_sound_data() const;
 
-  void do_stop();
+private:
 
   PT(MovieAudio) _movie;
   OpenALAudioManager::SoundData *_sd;

--- a/panda/src/audiotraits/openalAudioSound.h
+++ b/panda/src/audiotraits/openalAudioSound.h
@@ -117,7 +117,7 @@ private:
   void pull_used_buffers();
   void push_fresh_buffers();
   INLINE bool require_sound_data();
-  INLINE void release_sound_data();
+  INLINE void release_sound_data(bool force);
 
   INLINE bool is_valid() const;
   INLINE bool is_playing() const;


### PR DESCRIPTION
The real meat and potatoes of this changeset is in the first two commits; those address some assumptions that the OpenAL plugin makes about the OpenAL implementation's behavior (which are, evidently, guaranteed with OpenAL Soft, but not so much on Apple OpenAL).

The remaining 4 commits are just making the OpenAL code much more robust, including adding more assertions to verify state and generally making the intended behavior of the code much clearer.

Since these are pretty substantial changes, I'm submitting them as a PR so the following can be heavily scrutinized:
* I used `assert` instead of the `nassert` variants, for consistency with the one `assert` that was already there. What's the engine core's standards on asserts? Should these be `nassertv` etc.?
* How did I do with my PRC variables? Are they named succinctly/consistently/clearly?
* The `while (true) {` construct is okay, yes? (Specifically I did *not* make it a `for` so in the common case of "the delete works the first time" there's no performance wasted querying the PRC variables, etc.)
* Did I make proper use of the .I file for inlines?
* Are my additions to the class declarations sorted neatly?
* Are my comments properly-formatted, clear, and correct?
* Does this need tests? (Or *can* this be tested?)

And otherwise please do nitpick and test heavily. I'd rather have strict standards that I have to meet to develop the right coding habits early on. :)