### PR TITLE
direct: Fix some NameErrors

### DIFF
--- a/direct/src/interval/MetaInterval.py
+++ b/direct/src/interval/MetaInterval.py
@@ -342,7 +342,6 @@ class MetaInterval(CMetaInterval):
     # with all of their associated Python callbacks:
 
     def setManager(self, manager):
-        rogerroger
         self.__manager = manager
         CMetaInterval.setManager(self, manager)
 

--- a/direct/src/showbase/ObjectPool.py
+++ b/direct/src/showbase/ObjectPool.py
@@ -110,15 +110,6 @@ class ObjectPool:
                 print('TYPE: %s, %s objects' % (repr(typ), len(self._type2objs[typ])))
                 print(getNumberedTypedSortedString(self._type2objs[typ]))
 
-    def containerLenStr(self):
-        s  =   'Object Pool: Container Lengths'
-        s += '\n=============================='
-        lengths = list(self._len2obj.keys())
-        lengths.sort()
-        lengths.reverse()
-        for length in lengths:
-            print(length)
-
     def printReferrers(self, numEach=3):
         """referrers of the first few of each type of object"""
         counts = list(set(self._count2types.keys()))

--- a/direct/src/showbase/ObjectPool.py
+++ b/direct/src/showbase/ObjectPool.py
@@ -116,8 +116,8 @@ class ObjectPool:
         lengths = list(self._len2obj.keys())
         lengths.sort()
         lengths.reverse()
-        for count in counts:
-            pass
+        for length in lengths:
+            print(length)
 
     def printReferrers(self, numEach=3):
         """referrers of the first few of each type of object"""


### PR DESCRIPTION
- Removed undeclared variable `rogerroger` in MetaInterval.
- It appears that the intended functionality of ObjectPool.containerLenStr was to print out the keys of `_len2obj`.  I've implemented this by looping through lengths.