### PR TITLE
controlManager: allow currentControls to setSpeeds

### DIFF
--- a/direct/src/controls/ControlManager.py
+++ b/direct/src/controls/ControlManager.py
@@ -139,6 +139,8 @@ class ControlManager:
         for controls in self.controls.values():
             controls.setWalkSpeed(
                 forwardSpeed, jumpForce, reverseSpeed, rotateSpeed)
+            self.currentControls.setSpeeds(
+                forwardSpeed, jumpForce, reverseSpeed, rotateSpeed)
 
     def delete(self):
         assert self.notify.debugCall(id(self))
@@ -342,4 +344,3 @@ class ControlManager:
 
             inputState.set("turnLeft", False, inputSource=inputState.WASD)
             inputState.set("turnRight", False, inputSource=inputState.WASD)
-

--- a/direct/src/controls/ControlManager.py
+++ b/direct/src/controls/ControlManager.py
@@ -133,14 +133,14 @@ class ControlManager:
         else:
             assert self.notify.debug("Unkown controls: %s" % name)
 
-    def setSpeeds(self, forwardSpeed, jumpForce,
-            reverseSpeed, rotateSpeed, strafeLeft=0, strafeRight=0):
+    def setSpeeds(self, forwardSpeed, jumpForce, reverseSpeed, rotateSpeed, strafeLeft=0, strafeRight=0):
         assert self.notify.debugCall(id(self))
+
+        if self.currentControls is not None:
+            self.currentControls.setSpeeds(forwardSpeed, jumpForce, reverseSpeed, rotateSpeed)
+
         for controls in self.controls.values():
-            controls.setWalkSpeed(
-                forwardSpeed, jumpForce, reverseSpeed, rotateSpeed)
-            self.currentControls.setSpeeds(
-                forwardSpeed, jumpForce, reverseSpeed, rotateSpeed)
+            controls.setWalkSpeed(forwardSpeed, jumpForce, reverseSpeed, rotateSpeed)
 
     def delete(self):
         assert self.notify.debugCall(id(self))


### PR DESCRIPTION
This allows the local POTCO/ToonTown gravity walkers to receive updates to speed fluctuations.