### PR TITLE
multifile: Return vector_uchar from readSubfile

### DIFF
--- a/panda/src/express/multifile.I
+++ b/panda/src/express/multifile.I
@@ -278,12 +278,12 @@ remove_subfile(const string &subfile_name) {
 }
 
 /**
- * Returns a string that contains the entire contents of the indicated
+ * Returns a vector_uchar that contains the entire contents of the indicated
  * subfile.
  */
-INLINE string Multifile::
+INLINE vector_uchar Multifile::
 read_subfile(int index) {
-  string result;
+  vector_uchar result;
   read_subfile(index, result);
   return result;
 }

--- a/panda/src/express/multifile.h
+++ b/panda/src/express/multifile.h
@@ -24,6 +24,7 @@
 #include "indirectLess.h"
 #include "referenceCount.h"
 #include "pvector.h"
+#include "vector_uchar.h"
 
 #ifdef HAVE_OPENSSL
 typedef struct x509_st X509;
@@ -125,7 +126,7 @@ PUBLISHED:
   streampos get_subfile_internal_start(int index) const;
   size_t get_subfile_internal_length(int index) const;
 
-  BLOCKING INLINE string read_subfile(int index);
+  BLOCKING INLINE vector_uchar read_subfile(int index);
   BLOCKING istream *open_read_subfile(int index);
   BLOCKING static void close_read_subfile(istream *stream);
   BLOCKING bool extract_subfile(int index, const Filename &filename);


### PR DESCRIPTION
        - Return vector_uchar from readSubfile instead of
        string. This will correct problems with Python 3 unicode
        strings and will return bytes instead.

Signed-off-by: deflected <deflected@users.noreply.github.com>