### PR TITLE
Create a simple EventMapper

### DIFF
--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -306,6 +306,8 @@ class ShowBase(DirectObject.DirectObject):
 
         self.AppHasAudioFocus = 1
 
+        self.eventMapper = EventMapper.get_global_ptr()
+
         # Get a pointer to Panda's global ClockObject, used for
         # synchronizing events between Python and C.
         globalClock = ClockObject.getGlobalClock()

--- a/panda/src/device/p3device_composite1.cxx
+++ b/panda/src/device/p3device_composite1.cxx
@@ -1,4 +1,3 @@
-
 #include "clientAnalogDevice.cxx"
 #include "clientBase.cxx"
 #include "clientButtonDevice.cxx"

--- a/panda/src/event/config_event.cxx
+++ b/panda/src/event/config_event.cxx
@@ -21,6 +21,7 @@
 #include "buttonEventList.h"
 #include "event.h"
 #include "eventHandler.h"
+#include "eventMapper.h"
 #include "eventParameter.h"
 #include "genericAsyncTask.h"
 #include "pointerEventList.h"
@@ -43,6 +44,7 @@ ConfigureFn(config_event) {
   PointerEventList::init_type();
   Event::init_type();
   EventHandler::init_type();
+  EventMapper::init_type();
   EventStoreInt::init_type("EventStoreInt");
   EventStoreDouble::init_type("EventStoreDouble");
   GenericAsyncTask::init_type();

--- a/panda/src/event/eventMapper.I
+++ b/panda/src/event/eventMapper.I
@@ -1,4 +1,17 @@
 /**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file eventMapper.I
+ * @author Mitchell Stokes
+ * @date 2018-3-30
+ */
+
+/**
  * Returns the singleton EventMapper instance.
  */
 INLINE EventMapper *EventMapper::

--- a/panda/src/event/eventMapper.I
+++ b/panda/src/event/eventMapper.I
@@ -1,0 +1,12 @@
+/**
+ * Returns the singleton EventMapper instance.
+ */
+INLINE EventMapper *EventMapper::
+get_global_ptr() {
+  if (_global_ptr != nullptr) {
+    return _global_ptr;
+  } else {
+    make_global_ptr();
+    return _global_ptr;
+  }
+}

--- a/panda/src/event/eventMapper.cxx
+++ b/panda/src/event/eventMapper.cxx
@@ -160,3 +160,18 @@ reload_config() {
     );
   }
 }
+
+/**
+ * Description: Return a list of events that will map to the given event.
+ */
+EventMapper::EventSet EventMapper::
+get_inputs_for_event(const string event_name) {
+    EventSet events;
+    for (const auto& map_pair: this->_event_map) {
+        if (map_pair.second.count(event_name) != 0) {
+            events.insert(map_pair.first);
+        }
+    }
+
+    return events;
+}

--- a/panda/src/event/eventMapper.cxx
+++ b/panda/src/event/eventMapper.cxx
@@ -1,0 +1,140 @@
+#include "config_event.h"
+#include "eventMapper.h"
+#include "eventHandler.h"
+#include "throw_event.h"
+#include "configVariableManager.h"
+#include "configVariableCore.h"
+#include "configVariableString.h"
+
+TypeHandle EventMapper::_type_handle;
+EventMapper *EventMapper::_global_ptr = nullptr;
+
+const string g_item_prefix = "event-map-item-";
+const size_t g_item_prefix_len = g_item_prefix.length();
+
+/**
+ * Initializes the event mapper and checks for config variables
+ */
+EventMapper::EventMapper::
+EventMapper() {
+    this->reload_config();
+}
+
+/**
+ * Creates the global event mapper.
+ */
+void EventMapper::
+make_global_ptr() {
+  _global_ptr = new EventMapper();
+}
+
+void EventMapper::
+throw_events(const Event *event, EventSet *events, string suffix) {
+  event_cat->debug() << "throwing mapped events for input: " << event->get_name() << endl;
+
+  for (const string event : *events) {
+    throw_event(event+suffix);
+  }
+}
+
+void EventMapper::
+event_callback(const Event *event, void *data) {
+    EventSet *events = (EventSet*)data;
+    throw_events(event, events, "");
+}
+
+void EventMapper::
+event_callback_up(const Event *event, void *data) {
+    EventSet *events = (EventSet*)data;
+    throw_events(event, events, "-up");
+}
+
+void EventMapper::
+event_callback_down(const Event *event, void *data) {
+    EventSet *events = (EventSet*)data;
+    throw_events(event, events, "-down");
+}
+  
+
+/**
+ * Description: Clear mappings and rebuild them from config variables
+ */
+void EventMapper::
+reload_config() {
+  EventHandler *event_handler = EventHandler::get_global_event_handler();
+  ConfigVariableManager *cvmgr = ConfigVariableManager::get_global_ptr();
+
+  // Remove previous hooks
+  for (const auto& map_pair : this->_event_map) {
+    event_handler->remove_hook(
+      map_pair.first,
+      EventMapper::event_callback,
+      (void*)&map_pair.second
+    );
+    event_handler->remove_hook(
+      map_pair.first,
+      EventMapper::event_callback_up,
+      (void*)&map_pair.second
+    );
+    event_handler->remove_hook(
+      map_pair.first,
+      EventMapper::event_callback_down,
+      (void*)&map_pair.second
+    );
+  }
+
+  // Clear out all mappings
+  this->_event_map.clear();
+
+  // Build mappings from ConfigVariables
+  for (size_t i = 0; i < cvmgr->get_num_variables(); ++i) {
+    ConfigVariableCore *var = cvmgr->get_variable(i);
+    string confname = var->get_name();
+
+    if (confname.find(g_item_prefix) == 0) { 
+      ConfigVariableString cvar = ConfigVariableString(confname);
+      string outevent = confname.substr(g_item_prefix_len, confname.length());
+
+      for (size_t j = 0; j < cvar.get_num_words(); ++j) {
+        string inevent = cvar.get_word(j);
+        auto search = this->_event_map.find(inevent);
+
+        if (search != this->_event_map.end()) {
+          search->second.insert(outevent);
+        }
+        else {
+          EventSet events;
+          events.insert(outevent);
+          this->_event_map[inevent] = events;
+        }
+      }
+    }
+  }
+
+  event_cat->info() << "Event Map" << endl;
+  for (const auto& map_pair : this->_event_map) {
+    event_cat->info() << "Input: " << map_pair.first << endl;
+    for (const auto& input : map_pair.second) {
+      event_cat->info() << "  Output: " << input << endl;
+    }
+  }
+
+  // Add hooks based on mappings
+  for (const auto& map_pair : this->_event_map) {
+    event_handler->add_hook(
+      map_pair.first,
+      EventMapper::event_callback,
+      (void*)&map_pair.second
+    );
+    event_handler->add_hook(
+      map_pair.first+"-up",
+      EventMapper::event_callback_up,
+      (void*)&map_pair.second
+    );
+    event_handler->add_hook(
+      map_pair.first+"-down",
+      EventMapper::event_callback_down,
+      (void*)&map_pair.second
+    );
+  }
+}

--- a/panda/src/event/eventMapper.cxx
+++ b/panda/src/event/eventMapper.cxx
@@ -1,3 +1,16 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file eventMapper.cxx
+ * @author Mitchell Stokes
+ * @date 2018-3-30
+ */
+
 #include "config_event.h"
 #include "eventMapper.h"
 #include "eventHandler.h"

--- a/panda/src/event/eventMapper.cxx
+++ b/panda/src/event/eventMapper.cxx
@@ -99,6 +99,15 @@ reload_config() {
         string inevent = cvar.get_word(j);
         auto search = this->_event_map.find(inevent);
 
+        if (inevent == outevent) {
+            // Prevent circular reference
+            event_cat->warning()
+              << "skipping circular reference mapping "
+              << inevent << " to " << outevent
+              << endl;
+            continue;
+        }
+
         if (search != this->_event_map.end()) {
           search->second.insert(outevent);
         }

--- a/panda/src/event/eventMapper.h
+++ b/panda/src/event/eventMapper.h
@@ -1,3 +1,15 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file eventMapper.h
+ * @author Mitchell Stokes
+ * @date 2018-3-30
+ */
 #ifndef EVENTMAPPER_H
 #define EVENTMAPPER_H
 

--- a/panda/src/event/eventMapper.h
+++ b/panda/src/event/eventMapper.h
@@ -1,0 +1,55 @@
+#ifndef EVENTMAPPER_H
+#define EVENTMAPPER_H
+
+#include "pandabase.h"
+#include "pmap.h"
+#include "pset.h"
+
+class Event;
+
+/**
+ * A class to map a set of input events to output events. For example, "space"
+ * to "jump".
+ */
+class EXPCL_PANDA_EVENT EventMapper : public TypedObject {
+protected:
+  typedef pset<string> EventSet;
+  typedef pmap<string, EventSet> EventMap;
+
+  EventMap _event_map;;
+
+  static EventMapper *_global_ptr;
+
+  EventMapper();
+  static void make_global_ptr();
+
+  static void throw_events(const Event *event, EventSet *events, string suffix);
+  static void event_callback(const Event *event, void *data);
+  static void event_callback_up(const Event *event, void *data);
+  static void event_callback_down(const Event *event, void *data);
+
+PUBLISHED:
+  INLINE static EventMapper *get_global_ptr();
+  void reload_config();
+
+public:
+  static TypeHandle get_class_type() {
+    return _type_handle;
+  }
+  static void init_type() {
+    TypedObject::init_type();
+    register_type(_type_handle, "EventMapper",
+                  TypedObject::get_class_type());
+  }
+  virtual TypeHandle get_type() const {
+    return get_class_type();
+  }
+  virtual TypeHandle force_init_type() {init_type(); return get_class_type();}
+
+private:
+  static TypeHandle _type_handle;
+};
+
+
+#include "eventMapper.I"
+#endif //EVENTMAPPER_H

--- a/panda/src/event/eventMapper.h
+++ b/panda/src/event/eventMapper.h
@@ -43,6 +43,7 @@ protected:
 PUBLISHED:
   INLINE static EventMapper *get_global_ptr();
   void reload_config();
+  EventSet get_inputs_for_event(const string event_name);
 
 public:
   static TypeHandle get_class_type() {

--- a/panda/src/event/p3event_composite2.cxx
+++ b/panda/src/event/p3event_composite2.cxx
@@ -4,5 +4,6 @@
 #include "eventParameter.cxx"
 #include "eventQueue.cxx"
 #include "eventReceiver.cxx"
+#include "eventMapper.cxx"
 #include "pt_Event.cxx"
 


### PR DESCRIPTION
This new EventMapper generates a map from ConfigVariables that takes an
input event to generate output events. This makes it easier to create
abstract events (e.g., "jump") for inputs (e.g., "space"). The
EventMapper will take any ConfigVariable of the form
"event-map-item-<out_event> <in_event1> ... <in_eventN>" and create a
map where each <in_eventN> will trigger <out_event>.

There are still some TODO items to resolve, but I think there is enough to start some code review to make sure I am going down the right path.

TODO items:

- [x] ~~Allow using keyboard map to have config files be keyboard layout agnostic~~ (this can be done with raw events)
- [x] Add function that returns a list of input events for a given output event (useful for generating instructions such as "press <input> to jump")
- [x] Add license header and Doxygen comments
