### PR TITLE
pgraphnodes: Fixed the type of texture bytes in sceneGraphAnalyzer

### DIFF
--- a/panda/src/pgraphnodes/sceneGraphAnalyzer.I
+++ b/panda/src/pgraphnodes/sceneGraphAnalyzer.I
@@ -224,7 +224,7 @@ get_num_vertices_in_patches() const {
 /**
  *
  */
-int SceneGraphAnalyzer::
+size_t SceneGraphAnalyzer::
 get_texture_bytes() const {
   return _texture_bytes;
 }

--- a/panda/src/pgraphnodes/sceneGraphAnalyzer.cxx
+++ b/panda/src/pgraphnodes/sceneGraphAnalyzer.cxx
@@ -485,7 +485,7 @@ collect_statistics(Texture *texture) {
     _textures.insert(Textures::value_type(texture, 1));
 
     // Attempt to guess how many bytes of texture memory this one requires.
-    int bytes =
+    size_t bytes =
       texture->get_x_size() * texture->get_y_size() *
       texture->get_num_components() * texture->get_component_width();
 

--- a/panda/src/pgraphnodes/sceneGraphAnalyzer.h
+++ b/panda/src/pgraphnodes/sceneGraphAnalyzer.h
@@ -81,7 +81,7 @@ PUBLISHED:
   INLINE int get_num_triangles_in_fans() const;
   INLINE int get_num_vertices_in_patches() const;
 
-  INLINE int get_texture_bytes() const;
+  INLINE size_t get_texture_bytes() const;
 
   INLINE int get_num_long_normals() const;
   INLINE int get_num_short_normals() const;
@@ -150,7 +150,7 @@ private:
   int _num_triangles_in_fans;
   int _num_vertices_in_patches;
 
-  int _texture_bytes;
+  size_t _texture_bytes;
 
   int _num_long_normals;
   int _num_short_normals;


### PR DESCRIPTION
        - Corrected the type of texture bytes variable as it is possible
        to wrap it around

Signed-off-by: deflected <deflected@users.noreply.github.com>