### PR TITLE
Fix DC file reading regression caused by ac8417f

### DIFF
--- a/direct/src/distributed/ConnectionRepository.py
+++ b/direct/src/distributed/ConnectionRepository.py
@@ -333,7 +333,7 @@ class ConnectionRepository(
                         continue
                     classDef = getattr(classDef, className)
 
-                if inspect.isclass(classDef):
+                if not inspect.isclass(classDef):
                     self.notify.error("Symbol %s is not a class name." % (className))
                 else:
                     dclass.setClassDef(classDef)

--- a/direct/src/distributed/ServerRepository.py
+++ b/direct/src/distributed/ServerRepository.py
@@ -280,7 +280,7 @@ class ServerRepository:
                         self.notify.error("Module %s does not define class %s." % (className, className))
                     classDef = getattr(classDef, className)
 
-                if inspect.isclass(classDef):
+                if not inspect.isclass(classDef):
                     self.notify.error("Symbol %s is not a class name." % (className))
                 else:
                     dclass.setClassDef(classDef)


### PR DESCRIPTION
In ac8417ffdf0f253d8c2653b9a27becee1833778c type checks were changed to use Python's inspect module in order to safeguard against any Python 2 and Python 3 differences. However, an inequality check was replaced with an incorrect equality check.

This means that bonafide classes are regarded as non-classes and vice-versa, and as such DC files can no longer load, raising a "Symbol ClassName is not a class name." exception on load.

This commit resolves that issue.