### PR TITLE
Separating strings from blobs in dcparser

### DIFF
--- a/direct/src/dcparser/dcArrayParameter.cxx
+++ b/direct/src/dcparser/dcArrayParameter.cxx
@@ -263,6 +263,38 @@ pack_string(DCPackData &pack_data, const string &value,
 }
 
 /**
+ * Packs the indicated numeric or string value into the stream.
+ */
+void DCArrayParameter::
+pack_blob(DCPackData &pack_data, const vector_uchar &value,
+          bool &pack_error, bool &range_error) const {
+  // We can only pack a string if the array element type is char or int8.
+  DCSimpleParameter *simple_type = _element_type->as_simple_parameter();
+  if (simple_type == (DCSimpleParameter *)NULL) {
+    pack_error = true;
+    return;
+  }
+
+  size_t blob_size = value.size();
+
+  switch (simple_type->get_type()) {
+  case ST_char:
+  case ST_uint8:
+  case ST_int8:
+    _array_size_range.validate(blob_size, range_error);
+    if (_num_length_bytes != 0) {
+      nassertv(_num_length_bytes == 2);
+      do_pack_uint16(pack_data.get_write_pointer(2), blob_size);
+    }
+    pack_data.append_data((const char *)value.data(), blob_size);
+    break;
+
+  default:
+    pack_error = true;
+  }
+}
+
+/**
  * Packs the arrayParameter's specified default value (or a sensible default
  * if no value is specified) into the stream.  Returns true if the default
  * value is packed, false if the arrayParameter doesn't know how to pack its
@@ -332,6 +364,46 @@ unpack_string(const char *data, size_t length, size_t &p, string &value,
     }
     value.assign(data + p, string_length);
     p += string_length;
+    break;
+
+  default:
+    pack_error = true;
+  }
+}
+
+/**
+ * Unpacks the current numeric or string value from the stream.
+ */
+void DCArrayParameter::
+unpack_blob(const char *data, size_t length, size_t &p, vector_uchar &value,
+            bool &pack_error, bool &range_error) const {
+  // We can only unpack a string if the array element type is char or int8.
+  DCSimpleParameter *simple_type = _element_type->as_simple_parameter();
+  if (simple_type == (DCSimpleParameter *)NULL) {
+    pack_error = true;
+    return;
+  }
+
+  size_t blob_size;
+
+  switch (simple_type->get_type()) {
+  case ST_char:
+  case ST_uint8:
+  case ST_int8:
+    if (_num_length_bytes != 0) {
+      blob_size = do_unpack_uint16(data + p);
+      p += 2;
+    } else {
+      nassertv(_array_size >= 0);
+      blob_size = _array_size;
+    }
+    if (p + blob_size > length) {
+      pack_error = true;
+      return;
+    }
+    value = vector_uchar((const unsigned char *)data + p,
+                         (const unsigned char *)data + p + blob_size);
+    p += blob_size;
     break;
 
   default:

--- a/direct/src/dcparser/dcArrayParameter.h
+++ b/direct/src/dcparser/dcArrayParameter.h
@@ -51,9 +51,13 @@ public:
   virtual void generate_hash(HashGenerator &hashgen) const;
   virtual void pack_string(DCPackData &pack_data, const std::string &value,
                            bool &pack_error, bool &range_error) const;
+  virtual void pack_blob(DCPackData &pack_data, const vector_uchar &value,
+                         bool &pack_error, bool &range_error) const;
   virtual bool pack_default_value(DCPackData &pack_data, bool &pack_error) const;
   virtual void unpack_string(const char *data, size_t length, size_t &p,
                              std::string &value, bool &pack_error, bool &range_error) const;
+  virtual void unpack_blob(const char *data, size_t length, size_t &p,
+                           vector_uchar &value, bool &pack_error, bool &range_error) const;
 
 protected:
   virtual bool do_check_match(const DCPackerInterface *other) const;

--- a/direct/src/dcparser/dcAtomicField.cxx
+++ b/direct/src/dcparser/dcAtomicField.cxx
@@ -88,11 +88,11 @@ get_element(int n) const {
  * If the element is an array-type element, the returned value will include
  * the two-byte length preceding the array data.
  *
- * This is deprecated; use get_element() instead.
+ * @deprecated use get_element() instead.
  */
-string DCAtomicField::
+vector_uchar DCAtomicField::
 get_element_default(int n) const {
-  nassertr(n >= 0 && n < (int)_elements.size(), string());
+  nassertr(n >= 0 && n < (int)_elements.size(), vector_uchar());
   return _elements[n]->get_default_value();
 }
 
@@ -100,7 +100,7 @@ get_element_default(int n) const {
  * Returns true if the nth element of the field has a default value specified,
  * false otherwise.
  *
- * This is deprecated; use get_element() instead.
+ * @deprecated use get_element() instead.
  */
 bool DCAtomicField::
 has_element_default(int n) const {
@@ -113,7 +113,7 @@ has_element_default(int n) const {
  * for documentary purposes; it does not generally affect operation.  If a
  * name is not specified, this will be the empty string.
  *
- * This method is deprecated; use get_element()->get_name() instead.
+ * @deprecated use get_element()->get_name() instead.
  */
 string DCAtomicField::
 get_element_name(int n) const {

--- a/direct/src/dcparser/dcAtomicField.h
+++ b/direct/src/dcparser/dcAtomicField.h
@@ -40,7 +40,7 @@ PUBLISHED:
   DCParameter *get_element(int n) const;
 
   // These five methods are deprecated and will be removed soon.
-  std::string get_element_default(int n) const;
+  vector_uchar get_element_default(int n) const;
   bool has_element_default(int n) const;
   std::string get_element_name(int n) const;
   DCSubatomicType get_element_type(int n) const;

--- a/direct/src/dcparser/dcClass.cxx
+++ b/direct/src/dcparser/dcClass.cxx
@@ -587,7 +587,7 @@ receive_update_other(PyObject *distobj, DatagramIterator &di) const {
  */
 void DCClass::
 direct_update(PyObject *distobj, const string &field_name,
-              const string &value_blob) {
+              const vector_uchar &value_blob) {
   DCField *field = get_field_by_name(field_name);
   nassertv_always(field != nullptr);
 
@@ -606,7 +606,14 @@ direct_update(PyObject *distobj, const string &field_name,
 void DCClass::
 direct_update(PyObject *distobj, const string &field_name,
               const Datagram &datagram) {
-  direct_update(distobj, field_name, datagram.get_message());
+  DCField *field = get_field_by_name(field_name);
+  nassertv_always(field != NULL);
+
+  DCPacker packer;
+  packer.set_unpack_data((const char *)datagram.get_data(), datagram.get_length(), false);
+  packer.begin_unpack(field);
+  field->receive_update(packer, distobj);
+  packer.end_unpack();
 }
 #endif  // HAVE_PYTHON
 

--- a/direct/src/dcparser/dcClass.h
+++ b/direct/src/dcparser/dcClass.h
@@ -95,7 +95,7 @@ PUBLISHED:
   void receive_update_other(PyObject *distobj, DatagramIterator &di) const;
 
   void direct_update(PyObject *distobj, const std::string &field_name,
-                     const std::string &value_blob);
+                     const vector_uchar &value_blob);
   void direct_update(PyObject *distobj, const std::string &field_name,
                      const Datagram &datagram);
   bool pack_required_field(Datagram &datagram, PyObject *distobj,

--- a/direct/src/dcparser/dcField.I
+++ b/direct/src/dcparser/dcField.I
@@ -42,7 +42,7 @@ has_default_value() const {
  * explicitly set (e.g.  has_default_value() returns true), returns that
  * value; otherwise, returns an implicit default for the field.
  */
-INLINE const std::string &DCField::
+INLINE const vector_uchar &DCField::
 get_default_value() const {
   if (_default_value_stale) {
     ((DCField *)this)->refresh_default_value();
@@ -172,8 +172,8 @@ set_class(DCClass *dclass) {
  * Establishes a default value for this field.
  */
 INLINE void DCField::
-set_default_value(const std::string &default_value) {
-  _default_value = default_value;
+set_default_value(vector_uchar default_value) {
+  _default_value = std::move(default_value);
   _has_default_value = true;
   _default_value_stale = false;
 }

--- a/direct/src/dcparser/dcField.h
+++ b/direct/src/dcparser/dcField.h
@@ -53,13 +53,13 @@ PUBLISHED:
   virtual DCParameter *as_parameter();
   virtual const DCParameter *as_parameter() const;
 
-  std::string format_data(const std::string &packed_data, bool show_field_names = true);
-  std::string parse_string(const std::string &formatted_string);
+  std::string format_data(const vector_uchar &packed_data, bool show_field_names = true);
+  vector_uchar parse_string(const std::string &formatted_string);
 
-  bool validate_ranges(const std::string &packed_data) const;
+  bool validate_ranges(const vector_uchar &packed_data) const;
 
   INLINE bool has_default_value() const;
-  INLINE const std::string &get_default_value() const;
+  INLINE const vector_uchar &get_default_value() const;
 
   INLINE bool is_bogus_field() const;
 
@@ -98,7 +98,7 @@ public:
 
   INLINE void set_number(int number);
   INLINE void set_class(DCClass *dclass);
-  INLINE void set_default_value(const std::string &default_value);
+  INLINE void set_default_value(vector_uchar default_value);
 
 #ifdef HAVE_PYTHON
   static std::string get_pystr(PyObject *value);
@@ -115,7 +115,7 @@ protected:
   bool _bogus_field;
 
 private:
-  std::string _default_value;
+  vector_uchar _default_value;
 
 #ifdef WITHIN_PANDA
   PStatCollector _field_update_pcollector;

--- a/direct/src/dcparser/dcLexer.cxx.prebuilt
+++ b/direct/src/dcparser/dcLexer.cxx.prebuilt
@@ -1,6 +1,6 @@
-#line 2 "lex.yy.c"
+#line 2 "built/tmp/dcLexer.lxx.cxx"
 
-#line 4 "lex.yy.c"
+#line 4 "built/tmp/dcLexer.lxx.cxx"
 
 #define  YY_INT_ALIGNED short int
 
@@ -28,12 +28,22 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_SUBMINOR_VERSION 37
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
+
+#if defined(__FreeBSD__)
+#ifndef __STDC_LIMIT_MACROS
+#define	__STDC_LIMIT_MACROS
+#endif
+#include <sys/cdefs.h>
+#include <stdint.h>
+#else
+#define	__dead2
+#endif
 
 /* begin standard C headers. */
 #include <stdio.h>
@@ -50,10 +60,11 @@
 
 /* C99 systems have <inttypes.h>. Non-C99 systems may or may not. */
 
-#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#if defined(__FreeBSD__) || \
+    (defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -70,10 +81,9 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -103,6 +113,8 @@ typedef unsigned int flex_uint32_t;
 #ifndef UINT32_MAX
 #define UINT32_MAX             (4294967295U)
 #endif
+
+#endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
@@ -172,7 +184,12 @@ typedef unsigned int flex_uint32_t;
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #endif
 
-extern int dcyyleng;
+#ifndef YY_TYPEDEF_YY_SIZE_T
+#define YY_TYPEDEF_YY_SIZE_T
+typedef size_t yy_size_t;
+#endif
+
+extern yy_size_t dcyyleng;
 
 extern FILE *dcyyin, *dcyyout;
 
@@ -181,7 +198,7 @@ extern FILE *dcyyin, *dcyyout;
 #define EOB_ACT_LAST_MATCH 2
 
     #define YY_LESS_LINENO(n)
-    
+
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -197,11 +214,6 @@ extern FILE *dcyyin, *dcyyout;
 	while ( 0 )
 
 #define unput(c) yyunput( c, (yytext_ptr)  )
-
-#ifndef YY_TYPEDEF_YY_SIZE_T
-#define YY_TYPEDEF_YY_SIZE_T
-typedef size_t yy_size_t;
-#endif
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
@@ -220,7 +232,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -243,7 +255,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -282,6 +294,7 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
+#define yy_current_buffer YY_CURRENT_BUFFER
 
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
@@ -290,8 +303,8 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when dcyytext is formed. */
 static char yy_hold_char;
-static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-int dcyyleng;
+static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
+yy_size_t dcyyleng;
 
 /* Points to current character in buffer. */
 static char *yy_c_buf_p = (char *) 0;
@@ -319,7 +332,7 @@ static void dcyy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
 
 YY_BUFFER_STATE dcyy_scan_buffer (char *base,yy_size_t size  );
 YY_BUFFER_STATE dcyy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE dcyy_scan_bytes (yyconst char *bytes,int len  );
+YY_BUFFER_STATE dcyy_scan_bytes (yyconst char *bytes,yy_size_t len  );
 
 void *dcyyalloc (yy_size_t  );
 void *dcyyrealloc (void *,yy_size_t  );
@@ -365,7 +378,7 @@ extern char *dcyytext;
 static yy_state_type yy_get_previous_state (void );
 static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
 static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  );
+static void yy_fatal_error (yyconst char msg[]  ) __dead2;
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up dcyytext.
@@ -573,14 +586,14 @@ int dcyy_flex_debug = 0;
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
 char *dcyytext;
-#line 1 "dcLexer.lxx"
+#line 1 "direct/src/dcparser/dcLexer.lxx"
 /*
 // Filename: dcLexer.lxx
 // Created by:  drose (05Oct00)
-// 
+//
 ////////////////////////////////////////////////////////////////////
 */
-#line 9 "dcLexer.lxx"
+#line 9 "direct/src/dcparser/dcLexer.lxx"
 #include "dcLexerDefs.h"
 #include "dcParserDefs.h"
 #include "dcParser.h"
@@ -678,12 +691,12 @@ dcyyerror(const std::string &msg) {
   if (!dc_filename.empty()) {
     cerr << " in " << dc_filename;
   }
-  cerr 
+  cerr
     << " at line " << line_number << ", column " << col_number << ":\n"
     << current_line << "\n";
-  indent(cerr, col_number-1) 
+  indent(cerr, col_number-1)
     << "^\n" << msg << "\n\n";
-  
+
   error_count++;
 }
 
@@ -695,10 +708,10 @@ dcyywarning(const std::string &msg) {
   if (!dc_filename.empty()) {
     cerr << " in " << dc_filename;
   }
-  cerr 
+  cerr
     << " at line " << line_number << ", column " << col_number << ":\n"
     << current_line << "\n";
-  indent(cerr, col_number-1) 
+  indent(cerr, col_number-1)
     << "^\n" << msg << "\n\n";
 
   warning_count++;
@@ -708,7 +721,7 @@ dcyywarning(const std::string &msg) {
 // stdio FILE pointer.  This is flex-specific.
 static void
 input_chars(char *buffer, int &result, int max_size) {
-  nassertv(input_p != NULL);
+  nassertv(input_p != nullptr);
   if (*input_p) {
     input_p->read(buffer, max_size);
     result = input_p->gcount();
@@ -729,7 +742,7 @@ input_chars(char *buffer, int &result, int max_size) {
 
       // Truncate it at the newline.
       char *end = strchr(current_line, '\n');
-      if (end != NULL) {
+      if (end != nullptr) {
         *end = '\0';
       }
     }
@@ -888,9 +901,9 @@ scan_quoted_string(char quote_mark) {
 
 // scan_hex_string reads a string of hexadecimal digits delimited by
 // angle brackets and returns the representative string.
-static std::string
+static vector_uchar
 scan_hex_string() {
-  std::string result;
+  vector_uchar result;
 
   // We don't touch the current line number and column number during
   // scanning, so that if we detect an error while scanning the string
@@ -920,24 +933,24 @@ scan_hex_string() {
       line_number = line;
       col_number = col;
       dcyyerror("Invalid hex digit.");
-      return std::string();
+      return vector_uchar();
     }
 
     odd = !odd;
     if (odd) {
       last = value;
     } else {
-      result += (char)((last << 4) | value);
+      result.push_back((unsigned char)((last << 4) | value));
     }
     c = read_char(line, col);
   }
 
   if (c == EOF) {
     dcyyerror("This hex string is unterminated.");
-    return std::string();
+    return vector_uchar();
   } else if (odd) {
     dcyyerror("Odd number of hex digits.");
-    return std::string();
+    return vector_uchar();
   }
 
   line_number = line;
@@ -957,7 +970,7 @@ eat_c_comment() {
   int col = col_number;
 
   int c, last_c;
-  
+
   last_c = '\0';
   c = read_char(line, col);
   while (c != EOF && !(last_c == '*' && c == '/')) {
@@ -984,7 +997,7 @@ inline void accept() {
   col_number += dcyyleng;
 }
 
-#line 984 "lex.yy.c"
+#line 1001 "built/tmp/dcLexer.lxx.cxx"
 
 #define INITIAL 0
 
@@ -993,6 +1006,7 @@ inline void accept() {
  * down here because we want the user's section 1 to have been scanned first.
  * The user has a chance to override it with an option.
  */
+#include <unistd.h>
 #endif
 
 #ifndef YY_EXTRA_TYPE
@@ -1022,7 +1036,7 @@ FILE *dcyyget_out (void );
 
 void dcyyset_out  (FILE * out_str  );
 
-int dcyyget_leng (void );
+yy_size_t dcyyget_leng (void );
 
 char *dcyyget_text (void );
 
@@ -1042,8 +1056,10 @@ extern int dcyywrap (void );
 #endif
 #endif
 
+#ifndef YY_NO_UNPUT
     static void yyunput (int c,char *buf_ptr  );
-    
+#endif
+
 #ifndef yytext_ptr
 static void yy_flex_strncpy (char *,yyconst char *,int );
 #endif
@@ -1072,7 +1088,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO fwrite( dcyytext, dcyyleng, 1, dcyyout )
+#define ECHO do { if (fwrite( dcyytext, dcyyleng, 1, dcyyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -1083,7 +1099,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		int n; \
+		size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( dcyyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -1161,11 +1177,11 @@ extern int dcyylex (void);
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
-    
-#line 415 "dcLexer.lxx"
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
+
+#line 419 "direct/src/dcparser/dcLexer.lxx"
 
 
 
@@ -1176,7 +1192,7 @@ YY_DECL
   }
 
 
-#line 1177 "lex.yy.c"
+#line 1196 "built/tmp/dcLexer.lxx.cxx"
 
 	if ( !(yy_init) )
 		{
@@ -1220,7 +1236,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
 				(yy_last_accepting_state) = yy_current_state;
@@ -1262,7 +1278,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 425 "dcLexer.lxx"
+#line 429 "direct/src/dcparser/dcLexer.lxx"
 {
   // New line.  Save a copy of the line so we can print it out for the
   // benefit of the user in case we get an error.
@@ -1279,32 +1295,32 @@ YY_RULE_SETUP
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 439 "dcLexer.lxx"
-{ 
+#line 443 "direct/src/dcparser/dcLexer.lxx"
+{
   // Eat whitespace.
   accept();
 }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 444 "dcLexer.lxx"
-{ 
+#line 448 "direct/src/dcparser/dcLexer.lxx"
+{
   // Eat C++-style comments.
   accept();
 }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 449 "dcLexer.lxx"
+#line 453 "direct/src/dcparser/dcLexer.lxx"
 {
   // Eat C-style comments.
   accept();
-  eat_c_comment(); 
+  eat_c_comment();
 }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 456 "dcLexer.lxx"
+#line 460 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_DCLASS;
@@ -1312,7 +1328,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 461 "dcLexer.lxx"
+#line 465 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_STRUCT;
@@ -1320,7 +1336,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 466 "dcLexer.lxx"
+#line 470 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_FROM;
@@ -1328,7 +1344,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 471 "dcLexer.lxx"
+#line 475 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_IMPORT;
@@ -1336,7 +1352,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 476 "dcLexer.lxx"
+#line 480 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_KEYWORD;
@@ -1344,7 +1360,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 481 "dcLexer.lxx"
+#line 485 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_TYPEDEF;
@@ -1352,7 +1368,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 486 "dcLexer.lxx"
+#line 490 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_SWITCH;
@@ -1360,7 +1376,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 491 "dcLexer.lxx"
+#line 495 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_CASE;
@@ -1368,7 +1384,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 496 "dcLexer.lxx"
+#line 500 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_DEFAULT;
@@ -1376,7 +1392,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 501 "dcLexer.lxx"
+#line 505 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_BREAK;
@@ -1384,7 +1400,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 506 "dcLexer.lxx"
+#line 510 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_INT8;
@@ -1392,7 +1408,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 511 "dcLexer.lxx"
+#line 515 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_INT16;
@@ -1400,7 +1416,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 516 "dcLexer.lxx"
+#line 520 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_INT32;
@@ -1408,7 +1424,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 521 "dcLexer.lxx"
+#line 525 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_INT64;
@@ -1416,7 +1432,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 526 "dcLexer.lxx"
+#line 530 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_UINT8;
@@ -1424,7 +1440,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 531 "dcLexer.lxx"
+#line 535 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_UINT16;
@@ -1432,7 +1448,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 536 "dcLexer.lxx"
+#line 540 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_UINT32;
@@ -1440,7 +1456,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 541 "dcLexer.lxx"
+#line 545 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_UINT64;
@@ -1448,7 +1464,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 546 "dcLexer.lxx"
+#line 550 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_FLOAT64;
@@ -1456,7 +1472,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 551 "dcLexer.lxx"
+#line 555 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_STRING;
@@ -1464,7 +1480,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 556 "dcLexer.lxx"
+#line 560 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_BLOB;
@@ -1472,7 +1488,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 561 "dcLexer.lxx"
+#line 565 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_BLOB32;
@@ -1480,7 +1496,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 566 "dcLexer.lxx"
+#line 570 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_INT8ARRAY;
@@ -1488,7 +1504,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 571 "dcLexer.lxx"
+#line 575 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_INT16ARRAY;
@@ -1496,7 +1512,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 576 "dcLexer.lxx"
+#line 580 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_INT32ARRAY;
@@ -1504,7 +1520,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 581 "dcLexer.lxx"
+#line 585 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_UINT8ARRAY;
@@ -1512,7 +1528,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 586 "dcLexer.lxx"
+#line 590 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_UINT16ARRAY;
@@ -1520,7 +1536,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 591 "dcLexer.lxx"
+#line 595 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_UINT32ARRAY;
@@ -1528,7 +1544,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 596 "dcLexer.lxx"
+#line 600 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_UINT32UINT8ARRAY;
@@ -1536,7 +1552,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 601 "dcLexer.lxx"
+#line 605 "direct/src/dcparser/dcLexer.lxx"
 {
   accept();
   return KW_CHAR;
@@ -1544,8 +1560,8 @@ YY_RULE_SETUP
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 606 "dcLexer.lxx"
-{ 
+#line 610 "direct/src/dcparser/dcLexer.lxx"
+{
   // An unsigned integer number.
   accept();
 
@@ -1564,14 +1580,14 @@ YY_RULE_SETUP
     dcyylval.u.uint64 = next_value + (*p - '0');
     ++p;
   }
-  
+
   return UNSIGNED_INTEGER;
 }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 629 "dcLexer.lxx"
-{ 
+#line 633 "direct/src/dcparser/dcLexer.lxx"
+{
   // A signed integer number.
   accept();
 
@@ -1612,17 +1628,17 @@ YY_RULE_SETUP
       dcyyerror("Number out of range.");
       dcyylval.u.int64 = 1;
     }
-  }    
-  
+  }
+
   return SIGNED_INTEGER;
 }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 675 "dcLexer.lxx"
+#line 679 "direct/src/dcparser/dcLexer.lxx"
 {
   // A hexadecimal integer number.
-  accept(); 
+  accept();
 
   // As above, we'll decode the hex string by hand.
   dcyylval.str = dcyytext;
@@ -1644,23 +1660,23 @@ YY_RULE_SETUP
     ++p;
   }
 
-  return UNSIGNED_INTEGER; 
+  return UNSIGNED_INTEGER;
 }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 702 "dcLexer.lxx"
-{ 
+#line 706 "direct/src/dcparser/dcLexer.lxx"
+{
   // A floating-point number.
-  accept(); 
-  dcyylval.u.real = patof(dcyytext); 
+  accept();
+  dcyylval.u.real = patof(dcyytext);
   dcyylval.str = dcyytext;
-  return REAL; 
+  return REAL;
 }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 710 "dcLexer.lxx"
+#line 714 "direct/src/dcparser/dcLexer.lxx"
 {
   // Quoted string.
   accept();
@@ -1670,7 +1686,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 717 "dcLexer.lxx"
+#line 721 "direct/src/dcparser/dcLexer.lxx"
 {
   // Single-quoted string.
   accept();
@@ -1680,25 +1696,25 @@ YY_RULE_SETUP
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 724 "dcLexer.lxx"
+#line 728 "direct/src/dcparser/dcLexer.lxx"
 {
   // Long hex string.
   accept();
-  dcyylval.str = scan_hex_string();
+  dcyylval.bytes = scan_hex_string();
   return HEX_STRING;
 }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 731 "dcLexer.lxx"
-{ 
+#line 735 "direct/src/dcparser/dcLexer.lxx"
+{
   // Identifier or keyword.
   accept();
   dcyylval.str = dcyytext;
 
-  if (dc_file != (DCFile *)NULL) {
+  if (dc_file != nullptr) {
     const DCKeyword *keyword = dc_file->get_keyword_by_name(dcyylval.str);
-    if (keyword != (DCKeyword *)NULL) {
+    if (keyword != nullptr) {
       dcyylval.u.keyword = keyword;
       return KEYWORD;
     }
@@ -1708,19 +1724,19 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 747 "dcLexer.lxx"
+#line 751 "direct/src/dcparser/dcLexer.lxx"
 {
   // Send any other printable character as itself.
-  accept(); 
+  accept();
   return dcyytext[0];
 }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 753 "dcLexer.lxx"
+#line 757 "direct/src/dcparser/dcLexer.lxx"
 ECHO;
 	YY_BREAK
-#line 1721 "lex.yy.c"
+#line 1740 "built/tmp/dcLexer.lxx.cxx"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1862,9 +1878,9 @@ case YY_STATE_EOF(INITIAL):
  */
 static int yy_get_next_buffer (void)
 {
-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = (yytext_ptr);
-	register int number_to_move, i;
+    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = (yytext_ptr);
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1906,21 +1922,21 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
 			{ /* Not enough room in the buffer - grow it. */
 
 			/* just a shorter name for the current buffer */
-			YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
+			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
 
 			int yy_c_buf_p_offset =
 				(int) ((yy_c_buf_p) - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1951,7 +1967,7 @@ static int yy_get_next_buffer (void)
 
 		/* Read in more data. */
 		YY_INPUT( (&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move]),
-			(yy_n_chars), (size_t) num_to_read );
+			(yy_n_chars), num_to_read );
 
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
 		}
@@ -1996,14 +2012,14 @@ static int yy_get_next_buffer (void)
 
     static yy_state_type yy_get_previous_state (void)
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
-    
+	yy_state_type yy_current_state;
+	char *yy_cp;
+
 	yy_current_state = (yy_start);
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			(yy_last_accepting_state) = yy_current_state;
@@ -2028,10 +2044,10 @@ static int yy_get_next_buffer (void)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
-	register int yy_is_jam;
-    	register char *yy_cp = (yy_c_buf_p);
+	int yy_is_jam;
+    	char *yy_cp = (yy_c_buf_p);
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		(yy_last_accepting_state) = yy_current_state;
@@ -2046,13 +2062,14 @@ static int yy_get_next_buffer (void)
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 	yy_is_jam = (yy_current_state == 164);
 
-	return yy_is_jam ? 0 : yy_current_state;
+		return yy_is_jam ? 0 : yy_current_state;
 }
 
-    static void yyunput (int c, register char * yy_bp )
+#ifndef YY_NO_UNPUT
+    static void yyunput (int c, char * yy_bp )
 {
-	register char *yy_cp;
-    
+	char *yy_cp;
+
     yy_cp = (yy_c_buf_p);
 
 	/* undo effects of setting up dcyytext */
@@ -2061,10 +2078,10 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register int number_to_move = (yy_n_chars) + 2;
-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+		yy_size_t number_to_move = (yy_n_chars) + 2;
+		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
 
 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -2085,6 +2102,7 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *yy_cp;
 	(yy_c_buf_p) = yy_cp;
 }
+#endif	/* ifndef YY_NO_UNPUT */
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -2095,7 +2113,7 @@ static int yy_get_next_buffer (void)
 
 {
 	int c;
-    
+
 	*(yy_c_buf_p) = (yy_hold_char);
 
 	if ( *(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR )
@@ -2110,7 +2128,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			int offset = (yy_c_buf_p) - (yytext_ptr);
+			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -2162,12 +2180,12 @@ static int yy_get_next_buffer (void)
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.
- * 
+ *
  * @note This function does not reset the start condition to @c INITIAL .
  */
     void dcyyrestart  (FILE * input_file )
 {
-    
+
 	if ( ! YY_CURRENT_BUFFER ){
         dcyyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
@@ -2180,11 +2198,11 @@ static int yy_get_next_buffer (void)
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
- * 
+ *
  */
     void dcyy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
-    
+
 	/* TODO. We should be able to replace this entire function body
 	 * with
 	 *		dcyypop_buffer_state();
@@ -2224,13 +2242,13 @@ static void dcyy_load_buffer_state  (void)
 /** Allocate and initialize an input buffer state.
  * @param file A readable stream.
  * @param size The character buffer size in bytes. When in doubt, use @c YY_BUF_SIZE.
- * 
+ *
  * @return the allocated buffer state.
  */
     YY_BUFFER_STATE dcyy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	b = (YY_BUFFER_STATE) dcyyalloc(sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in dcyy_create_buffer()" );
@@ -2253,11 +2271,11 @@ static void dcyy_load_buffer_state  (void)
 
 /** Destroy the buffer.
  * @param b a buffer created with dcyy_create_buffer()
- * 
+ *
  */
     void dcyy_delete_buffer (YY_BUFFER_STATE  b )
 {
-    
+
 	if ( ! b )
 		return;
 
@@ -2270,10 +2288,6 @@ static void dcyy_load_buffer_state  (void)
 	dcyyfree((void *) b  );
 }
 
-#ifndef __cplusplus
-extern int isatty (int );
-#endif /* __cplusplus */
-    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a dcyyrestart() or at EOF.
@@ -2282,7 +2296,7 @@ extern int isatty (int );
 
 {
 	int oerrno = errno;
-    
+
 	dcyy_flush_buffer(b );
 
 	b->yy_input_file = file;
@@ -2298,13 +2312,13 @@ extern int isatty (int );
     }
 
         b->yy_is_interactive = file ? (isatty( fileno(file) ) > 0) : 0;
-    
+
 	errno = oerrno;
 }
 
 /** Discard all buffered characters. On the next scan, YY_INPUT will be called.
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
- * 
+ *
  */
     void dcyy_flush_buffer (YY_BUFFER_STATE  b )
 {
@@ -2333,7 +2347,7 @@ extern int isatty (int );
  *  the current state. This function will allocate the stack
  *  if necessary.
  *  @param new_buffer The new state.
- *  
+ *
  */
 void dcyypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
@@ -2363,7 +2377,7 @@ void dcyypush_buffer_state (YY_BUFFER_STATE new_buffer )
 
 /** Removes and deletes the top of the stack, if present.
  *  The next element becomes the new top.
- *  
+ *
  */
 void dcyypop_buffer_state (void)
 {
@@ -2386,8 +2400,8 @@ void dcyypop_buffer_state (void)
  */
 static void dcyyensure_buffer_stack (void)
 {
-	int num_to_alloc;
-    
+	yy_size_t num_to_alloc;
+
 	if (!(yy_buffer_stack)) {
 
 		/* First allocation is just for 2 elements, since we don't know if this
@@ -2400,9 +2414,9 @@ static void dcyyensure_buffer_stack (void)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in dcyyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2430,13 +2444,13 @@ static void dcyyensure_buffer_stack (void)
 /** Setup the input buffer state to scan directly from a user-specified character buffer.
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
- * 
- * @return the newly allocated buffer state object. 
+ *
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE dcyy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
@@ -2465,31 +2479,31 @@ YY_BUFFER_STATE dcyy_scan_buffer  (char * base, yy_size_t  size )
 /** Setup the input buffer state to scan a string. The next call to dcyylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
- * 
+ *
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
  *       dcyy_scan_bytes() instead.
  */
 YY_BUFFER_STATE dcyy_scan_string (yyconst char * yystr )
 {
-    
+
 	return dcyy_scan_bytes(yystr,strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to dcyylex() will
  * scan from a @e copy of @a bytes.
- * @param bytes the byte buffer to scan
- * @param len the number of bytes in the buffer pointed to by @a bytes.
- * 
+ * @param yybytes the byte buffer to scan
+ * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
+ *
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE dcyy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len )
+YY_BUFFER_STATE dcyy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	int i;
-    
+	yy_size_t i;
+
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
 	buf = (char *) dcyyalloc(n  );
@@ -2543,16 +2557,16 @@ static void yy_fatal_error (yyconst char* msg )
 /* Accessor  methods (get/set functions) to struct members. */
 
 /** Get the current line number.
- * 
+ *
  */
 int dcyyget_lineno  (void)
 {
-        
+
     return dcyylineno;
 }
 
 /** Get the input stream.
- * 
+ *
  */
 FILE *dcyyget_in  (void)
 {
@@ -2560,7 +2574,7 @@ FILE *dcyyget_in  (void)
 }
 
 /** Get the output stream.
- * 
+ *
  */
 FILE *dcyyget_out  (void)
 {
@@ -2568,15 +2582,15 @@ FILE *dcyyget_out  (void)
 }
 
 /** Get the length of the current token.
- * 
+ *
  */
-int dcyyget_leng  (void)
+yy_size_t dcyyget_leng  (void)
 {
         return dcyyleng;
 }
 
 /** Get the current token.
- * 
+ *
  */
 
 char *dcyyget_text  (void)
@@ -2586,18 +2600,18 @@ char *dcyyget_text  (void)
 
 /** Set the current line number.
  * @param line_number
- * 
+ *
  */
 void dcyyset_lineno (int  line_number )
 {
-    
+
     dcyylineno = line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param in_str A readable stream.
- * 
+ *
  * @see dcyy_switch_to_buffer
  */
 void dcyyset_in (FILE *  in_str )
@@ -2651,7 +2665,7 @@ static int yy_init_globals (void)
 /* dcyylex_destroy is for both reentrant and non-reentrant scanners. */
 int dcyylex_destroy  (void)
 {
-    
+
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
 		dcyy_delete_buffer(YY_CURRENT_BUFFER  );
@@ -2677,7 +2691,7 @@ int dcyylex_destroy  (void)
 #ifndef yytext_ptr
 static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 {
-	register int i;
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
@@ -2686,7 +2700,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #ifdef YY_NEED_STRLEN
 static int yy_flex_strlen (yyconst char * s )
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -2718,4 +2732,4 @@ void dcyyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 753 "dcLexer.lxx"
+#line 757 "direct/src/dcparser/dcLexer.lxx"

--- a/direct/src/dcparser/dcLexer.lxx
+++ b/direct/src/dcparser/dcLexer.lxx
@@ -1,7 +1,7 @@
 /*
 // Filename: dcLexer.lxx
 // Created by:  drose (05Oct00)
-// 
+//
 ////////////////////////////////////////////////////////////////////
 */
 
@@ -103,12 +103,12 @@ dcyyerror(const std::string &msg) {
   if (!dc_filename.empty()) {
     cerr << " in " << dc_filename;
   }
-  cerr 
+  cerr
     << " at line " << line_number << ", column " << col_number << ":\n"
     << current_line << "\n";
-  indent(cerr, col_number-1) 
+  indent(cerr, col_number-1)
     << "^\n" << msg << "\n\n";
-  
+
   error_count++;
 }
 
@@ -120,10 +120,10 @@ dcyywarning(const std::string &msg) {
   if (!dc_filename.empty()) {
     cerr << " in " << dc_filename;
   }
-  cerr 
+  cerr
     << " at line " << line_number << ", column " << col_number << ":\n"
     << current_line << "\n";
-  indent(cerr, col_number-1) 
+  indent(cerr, col_number-1)
     << "^\n" << msg << "\n\n";
 
   warning_count++;
@@ -313,9 +313,9 @@ scan_quoted_string(char quote_mark) {
 
 // scan_hex_string reads a string of hexadecimal digits delimited by
 // angle brackets and returns the representative string.
-static std::string
+static vector_uchar
 scan_hex_string() {
-  std::string result;
+  vector_uchar result;
 
   // We don't touch the current line number and column number during
   // scanning, so that if we detect an error while scanning the string
@@ -345,24 +345,24 @@ scan_hex_string() {
       line_number = line;
       col_number = col;
       dcyyerror("Invalid hex digit.");
-      return std::string();
+      return vector_uchar();
     }
 
     odd = !odd;
     if (odd) {
       last = value;
     } else {
-      result += (char)((last << 4) | value);
+      result.push_back((unsigned char)((last << 4) | value));
     }
     c = read_char(line, col);
   }
 
   if (c == EOF) {
     dcyyerror("This hex string is unterminated.");
-    return std::string();
+    return vector_uchar();
   } else if (odd) {
     dcyyerror("Odd number of hex digits.");
-    return std::string();
+    return vector_uchar();
   }
 
   line_number = line;
@@ -382,7 +382,7 @@ eat_c_comment() {
   int col = col_number;
 
   int c, last_c;
-  
+
   last_c = '\0';
   c = read_char(line, col);
   while (c != EOF && !(last_c == '*' && c == '/')) {
@@ -440,12 +440,12 @@ REALNUM              ([+-]?(([0-9]+[.])|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?)
   yyless(1);
 }
 
-[ \t\r] { 
+[ \t\r] {
   // Eat whitespace.
   accept();
 }
 
-"//".* { 
+"//".* {
   // Eat C++-style comments.
   accept();
 }
@@ -453,7 +453,7 @@ REALNUM              ([+-]?(([0-9]+[.])|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?)
 "/*" {
   // Eat C-style comments.
   accept();
-  eat_c_comment(); 
+  eat_c_comment();
 }
 
 
@@ -607,7 +607,7 @@ REALNUM              ([+-]?(([0-9]+[.])|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?)
   return KW_CHAR;
 }
 
-{UNSIGNED_INTEGERNUM} { 
+{UNSIGNED_INTEGERNUM} {
   // An unsigned integer number.
   accept();
 
@@ -626,11 +626,11 @@ REALNUM              ([+-]?(([0-9]+[.])|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?)
     dcyylval.u.uint64 = next_value + (*p - '0');
     ++p;
   }
-  
+
   return UNSIGNED_INTEGER;
 }
 
-{SIGNED_INTEGERNUM} { 
+{SIGNED_INTEGERNUM} {
   // A signed integer number.
   accept();
 
@@ -671,14 +671,14 @@ REALNUM              ([+-]?(([0-9]+[.])|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?)
       dcyyerror("Number out of range.");
       dcyylval.u.int64 = 1;
     }
-  }    
-  
+  }
+
   return SIGNED_INTEGER;
 }
 
 {UNSIGNED_HEXNUM} {
   // A hexadecimal integer number.
-  accept(); 
+  accept();
 
   // As above, we'll decode the hex string by hand.
   dcyylval.str = dcyytext;
@@ -700,15 +700,15 @@ REALNUM              ([+-]?(([0-9]+[.])|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?)
     ++p;
   }
 
-  return UNSIGNED_INTEGER; 
+  return UNSIGNED_INTEGER;
 }
 
-{REALNUM} { 
+{REALNUM} {
   // A floating-point number.
-  accept(); 
-  dcyylval.u.real = patof(dcyytext); 
+  accept();
+  dcyylval.u.real = patof(dcyytext);
   dcyylval.str = dcyytext;
-  return REAL; 
+  return REAL;
 }
 
 ["] {
@@ -728,11 +728,11 @@ REALNUM              ([+-]?(([0-9]+[.])|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?)
 [<] {
   // Long hex string.
   accept();
-  dcyylval.str = scan_hex_string();
+  dcyylval.bytes = scan_hex_string();
   return HEX_STRING;
 }
 
-[A-Za-z_][A-Za-z_0-9]* { 
+[A-Za-z_][A-Za-z_0-9]* {
   // Identifier or keyword.
   accept();
   dcyylval.str = dcyytext;
@@ -750,7 +750,7 @@ REALNUM              ([+-]?(([0-9]+[.])|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?)
 
 . {
   // Send any other printable character as itself.
-  accept(); 
+  accept();
   return dcyytext[0];
 }
-  
+

--- a/direct/src/dcparser/dcPacker.I
+++ b/direct/src/dcparser/dcPacker.I
@@ -217,16 +217,30 @@ pack_string(const std::string &value) {
 }
 
 /**
+ * Packs the indicated numeric or string value into the stream.
+ */
+INLINE void DCPacker::
+pack_blob(const vector_uchar &value) {
+  nassertv(_mode == M_pack || _mode == M_repack);
+  if (_current_field == NULL) {
+    _pack_error = true;
+  } else {
+    _current_field->pack_blob(_pack_data, value, _pack_error, _range_error);
+    advance();
+  }
+}
+
+/**
  * Adds the indicated string value into the stream, representing a single pre-
  * packed field element, or a whole group of field elements at once.
  */
 INLINE void DCPacker::
-pack_literal_value(const std::string &value) {
+pack_literal_value(const vector_uchar &value) {
   nassertv(_mode == M_pack || _mode == M_repack);
   if (_current_field == nullptr) {
     _pack_error = true;
   } else {
-    _pack_data.append_data(value.data(), value.length());
+    _pack_data.append_data((const char *)value.data(), value.size());
     advance();
   }
 }
@@ -346,15 +360,35 @@ unpack_string() {
 }
 
 /**
+ * Unpacks the current binary data value from the stream.
+ */
+INLINE vector_uchar DCPacker::
+unpack_blob() {
+  vector_uchar value;
+  nassertr(_mode == M_unpack, value);
+  if (_current_field == NULL) {
+    _pack_error = true;
+
+  } else {
+    _current_field->unpack_blob(_unpack_data, _unpack_length, _unpack_p,
+                                 value, _pack_error, _range_error);
+    advance();
+  }
+
+  return value;
+}
+
+/**
  * Returns the literal string that represents the packed value of the current
  * field, and advances the field pointer.
  */
-INLINE std::string DCPacker::
+INLINE vector_uchar DCPacker::
 unpack_literal_value() {
   size_t start = _unpack_p;
   unpack_skip();
-  nassertr(_unpack_p >= start, std::string());
-  return std::string(_unpack_data + start, _unpack_p - start);
+  nassertr(_unpack_p >= start, vector_uchar());
+  return vector_uchar((const unsigned char *)_unpack_data + start,
+                      (const unsigned char *)_unpack_data + _unpack_p);
 }
 
 /**
@@ -454,15 +488,32 @@ unpack_string(std::string &value) {
 }
 
 /**
+ * Unpacks the current numeric or string value from the stream.
+ */
+INLINE void DCPacker::
+unpack_blob(vector_uchar &value) {
+  nassertv(_mode == M_unpack);
+  if (_current_field == NULL) {
+    _pack_error = true;
+
+  } else {
+    _current_field->unpack_blob(_unpack_data, _unpack_length, _unpack_p,
+                                value, _pack_error, _range_error);
+    advance();
+  }
+}
+
+/**
  * Returns the literal string that represents the packed value of the current
  * field, and advances the field pointer.
  */
 INLINE void DCPacker::
-unpack_literal_value(std::string &value) {
+unpack_literal_value(vector_uchar &value) {
   size_t start = _unpack_p;
   unpack_skip();
   nassertv(_unpack_p >= start);
-  value.assign(_unpack_data + start, _unpack_p - start);
+  value = vector_uchar((const unsigned char *)_unpack_data + start,
+                       (const unsigned char *)_unpack_data + _unpack_p);
 }
 
 /**
@@ -542,6 +593,15 @@ get_string() const {
 }
 
 /**
+ * Returns the packed data buffer as a bytes object.  Also see get_data().
+ */
+INLINE vector_uchar DCPacker::
+get_bytes() const {
+  const unsigned char *p = (const unsigned char *)_pack_data.get_data();
+  return vector_uchar(p, p + _pack_data.get_length());
+}
+
+/**
  * Returns the total number of bytes in the unpack data buffer.  This is the
  * buffer used when unpacking; it is separate from the pack data returned by
  * get_length(), which is filled during packing.
@@ -601,9 +661,9 @@ take_data() {
  * between packing sessions.
  */
 INLINE void DCPacker::
-append_data(const char *buffer, size_t size) {
+append_data(const unsigned char *buffer, size_t size) {
   nassertv(_mode == M_idle);
-  _pack_data.append_data(buffer, size);
+  _pack_data.append_data((const char *)buffer, size);
 }
 
 /**
@@ -726,6 +786,16 @@ raw_pack_string(const std::string &value) {
   nassertv(_mode == M_idle);
   DCPackerInterface::do_pack_uint16(_pack_data.get_write_pointer(2), value.length());
   _pack_data.append_data(value.data(), value.length());
+}
+
+/**
+ * Packs the data into the buffer between packing sessions.
+ */
+INLINE void DCPacker::
+raw_pack_blob(const vector_uchar &value) {
+  nassertv(_mode == M_idle);
+  DCPackerInterface::do_pack_uint16(_pack_data.get_write_pointer(2), value.size());
+  _pack_data.append_data((const char *)value.data(), value.size());
 }
 
 /**
@@ -873,6 +943,16 @@ raw_unpack_string() {
 /**
  * Unpacks the data from the buffer between unpacking sessions.
  */
+INLINE vector_uchar DCPacker::
+raw_unpack_blob() {
+  vector_uchar value;
+  raw_unpack_blob(value);
+  return value;
+}
+
+/**
+ * Unpacks the data from the buffer between unpacking sessions.
+ */
 INLINE void DCPacker::
 raw_unpack_int64(int64_t &value) {
   nassertv(_mode == M_idle && _unpack_data != nullptr);
@@ -969,6 +1049,24 @@ raw_unpack_string(std::string &value) {
 
   value.assign(_unpack_data + _unpack_p, string_length);
   _unpack_p += string_length;
+}
+
+/**
+ * Unpacks the data from the buffer between unpacking sessions.
+ */
+INLINE void DCPacker::
+raw_unpack_blob(vector_uchar &value) {
+  nassertv(_mode == M_idle && _unpack_data != NULL);
+  unsigned int blob_size = raw_unpack_uint16();
+
+  if (_unpack_p + blob_size > _unpack_length) {
+    _pack_error = true;
+    return;
+  }
+
+  const unsigned char *p = (const unsigned char *)_unpack_data + _unpack_p;
+  value = vector_uchar(p, p + blob_size);
+  _unpack_p += blob_size;
 }
 
 /**

--- a/direct/src/dcparser/dcPacker.cxx
+++ b/direct/src/dcparser/dcPacker.cxx
@@ -114,12 +114,12 @@ end_pack() {
  * version of begin_unpack() that takes only one parameter.
  */
 void DCPacker::
-set_unpack_data(const string &data) {
+set_unpack_data(const vector_uchar &data) {
   nassertv(_mode == M_idle);
 
-  char *buffer = new char[data.length()];
-  memcpy(buffer, data.data(), data.length());
-  set_unpack_data(buffer, data.length(), true);
+  char *buffer = new char[data.size()];
+  memcpy(buffer, data.data(), data.size());
+  set_unpack_data(buffer, data.size(), true);
 }
 
 /**
@@ -721,11 +721,11 @@ pack_object(PyObject *object) {
       pack_string(string(buffer, length));
     }
   } else if (PyBytes_Check(object)) {
-    char *buffer;
+    const unsigned char *buffer;
     Py_ssize_t length;
-    PyBytes_AsStringAndSize(object, &buffer, &length);
+    PyBytes_AsStringAndSize(object, (char **)&buffer, &length);
     if (buffer) {
-      pack_string(string(buffer, length));
+      pack_blob(vector_uchar(buffer, buffer + length));
     }
 #else
   } else if (PyString_Check(object) || PyUnicode_Check(object)) {
@@ -1118,9 +1118,9 @@ enquote_string(ostream &out, char quote_mark, const string &str) {
  * Outputs the indicated string as a hex constant.
  */
 void DCPacker::
-output_hex_string(ostream &out, const string &str) {
+output_hex_string(ostream &out, const vector_uchar &str) {
   out << '<';
-  for (string::const_iterator pi = str.begin();
+  for (vector_uchar::const_iterator pi = str.begin();
        pi != str.end();
        ++pi) {
     char buffer[10];

--- a/direct/src/dcparser/dcPacker.h
+++ b/direct/src/dcparser/dcPacker.h
@@ -41,7 +41,7 @@ PUBLISHED:
   void begin_pack(const DCPackerInterface *root);
   bool end_pack();
 
-  void set_unpack_data(const std::string &data);
+  void set_unpack_data(const vector_uchar &data);
 public:
   void set_unpack_data(const char *unpack_data, size_t unpack_length,
                        bool owns_unpack_data);
@@ -75,7 +75,8 @@ PUBLISHED:
   INLINE void pack_int64(int64_t value);
   INLINE void pack_uint64(uint64_t value);
   INLINE void pack_string(const std::string &value);
-  INLINE void pack_literal_value(const std::string &value);
+  INLINE void pack_blob(const vector_uchar &value);
+  INLINE void pack_literal_value(const vector_uchar &value);
   void pack_default_value();
 
   INLINE double unpack_double();
@@ -84,7 +85,8 @@ PUBLISHED:
   INLINE int64_t unpack_int64();
   INLINE uint64_t unpack_uint64();
   INLINE std::string unpack_string();
-  INLINE std::string unpack_literal_value();
+  INLINE vector_uchar unpack_blob();
+  INLINE vector_uchar unpack_literal_value();
   void unpack_validate();
   void unpack_skip();
 
@@ -97,7 +99,8 @@ public:
   INLINE void unpack_int64(int64_t &value);
   INLINE void unpack_uint64(uint64_t &value);
   INLINE void unpack_string(std::string &value);
-  INLINE void unpack_literal_value(std::string &value);
+  INLINE void unpack_blob(vector_uchar &value);
+  INLINE void unpack_literal_value(vector_uchar &value);
 
 PUBLISHED:
 
@@ -119,6 +122,7 @@ PUBLISHED:
 
   INLINE size_t get_length() const;
   INLINE std::string get_string() const;
+  INLINE vector_uchar get_bytes() const;
   INLINE size_t get_unpack_length() const;
   INLINE std::string get_unpack_string() const;
 public:
@@ -126,7 +130,7 @@ public:
   INLINE const char *get_data() const;
   INLINE char *take_data();
 
-  INLINE void append_data(const char *buffer, size_t size);
+  INLINE void append_data(const unsigned char *buffer, size_t size);
   INLINE char *get_write_pointer(size_t size);
 
   INLINE const char *get_unpack_data() const;
@@ -148,6 +152,7 @@ PUBLISHED:
   INLINE void raw_pack_uint64(uint64_t value);
   INLINE void raw_pack_float64(double value);
   INLINE void raw_pack_string(const std::string &value);
+  INLINE void raw_pack_blob(const vector_uchar &value);
 
 // this is a hack to allw me to get in and out of 32bit Mode Faster need to
 // agree with channel_type in dcbase.h
@@ -165,6 +170,7 @@ PUBLISHED:
   INLINE uint64_t raw_unpack_uint64();
   INLINE double raw_unpack_float64();
   INLINE std::string raw_unpack_string();
+  INLINE vector_uchar raw_unpack_blob();
 
 public:
   INLINE void raw_unpack_int8(int &value);
@@ -177,10 +183,11 @@ public:
   INLINE void raw_unpack_uint64(uint64_t &value);
   INLINE void raw_unpack_float64(double &value);
   INLINE void raw_unpack_string(std::string &value);
+  INLINE void raw_unpack_blob(vector_uchar &value);
 
 public:
   static void enquote_string(std::ostream &out, char quote_mark, const std::string &str);
-  static void output_hex_string(std::ostream &out, const std::string &str);
+  static void output_hex_string(std::ostream &out, const vector_uchar &str);
 
 private:
   INLINE void advance();

--- a/direct/src/dcparser/dcPackerInterface.cxx
+++ b/direct/src/dcparser/dcPackerInterface.cxx
@@ -249,6 +249,14 @@ pack_string(DCPackData &, const string &, bool &pack_error, bool &) const {
 }
 
 /**
+ * Packs the indicated numeric or string value into the stream.
+ */
+void DCPackerInterface::
+pack_blob(DCPackData &, const vector_uchar &, bool &pack_error, bool &) const {
+  pack_error = true;
+}
+
+/**
  * Packs the field's specified default value (or a sensible default if no
  * value is specified) into the stream.  Returns true if the default value is
  * packed, false if the field doesn't know how to pack its default value.
@@ -303,6 +311,14 @@ unpack_uint64(const char *, size_t, size_t &, uint64_t &, bool &pack_error, bool
  */
 void DCPackerInterface::
 unpack_string(const char *, size_t, size_t &, string &, bool &pack_error, bool &) const {
+  pack_error = true;
+}
+
+/**
+ * Unpacks the current numeric or string value from the stream.
+ */
+void DCPackerInterface::
+unpack_blob(const char *, size_t, size_t &, vector_uchar &, bool &pack_error, bool &) const {
   pack_error = true;
 }
 

--- a/direct/src/dcparser/dcPackerInterface.h
+++ b/direct/src/dcparser/dcPackerInterface.h
@@ -16,6 +16,7 @@
 
 #include "dcbase.h"
 #include "dcSubatomicType.h"
+#include "vector_uchar.h"
 
 class DCFile;
 class DCField;
@@ -37,8 +38,8 @@ enum DCPackType {
 
   // These PackTypes are all fundamental types, and should be packed (or
   // unpacked) with the corresponding call to pack_double(), pack_int(), etc.
-  // PT_blob is the same as PT_string, but implies that the string contains
-  // binary data.
+  // PT_blob is similar to PT_string, except that it contains arbitrary binary
+  // data instead of just UTF-8 text.
   PT_double,
   PT_int,
   PT_uint,
@@ -113,6 +114,8 @@ public:
                            bool &pack_error, bool &range_error) const;
   virtual void pack_string(DCPackData &pack_data, const std::string &value,
                            bool &pack_error, bool &range_error) const;
+  virtual void pack_blob(DCPackData &pack_data, const vector_uchar &value,
+                         bool &pack_error, bool &range_error) const;
   virtual bool pack_default_value(DCPackData &pack_data, bool &pack_error) const;
 
   virtual void unpack_double(const char *data, size_t length, size_t &p,
@@ -127,6 +130,8 @@ public:
                              uint64_t &value, bool &pack_error, bool &range_error) const;
   virtual void unpack_string(const char *data, size_t length, size_t &p,
                              std::string &value, bool &pack_error, bool &range_error) const;
+  virtual void unpack_blob(const char *data, size_t length, size_t &p,
+                           vector_uchar &value, bool &pack_error, bool &range_error) const;
   virtual bool unpack_validate(const char *data, size_t length, size_t &p,
                                bool &pack_error, bool &range_error) const;
   virtual bool unpack_skip(const char *data, size_t length, size_t &p,

--- a/direct/src/dcparser/dcParser.cxx.prebuilt
+++ b/direct/src/dcparser/dcParser.cxx.prebuilt
@@ -1,20 +1,19 @@
-/* A Bison parser, made by GNU Bison 2.4.2.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
-/* Skeleton implementation for Bison's Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2006, 2009-2010 Free Software
-   Foundation, Inc.
-   
+/* Bison implementation for Yacc-like parsers in C
+
+   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -27,7 +26,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -45,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "2.4.2"
+#define YYBISON_VERSION "3.0.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -59,23 +58,19 @@
 /* Pull parsers.  */
 #define YYPULL 1
 
-/* Using locations.  */
-#define YYLSP_NEEDED 0
 
 /* Substitute the variable and function names.  */
 #define yyparse         dcyyparse
 #define yylex           dcyylex
 #define yyerror         dcyyerror
-#define yylval          dcyylval
-#define yychar          dcyychar
 #define yydebug         dcyydebug
 #define yynerrs         dcyynerrs
 
+#define yylval          dcyylval
+#define yychar          dcyychar
 
 /* Copy the first part of user declarations.  */
-
-/* Line 189 of yacc.c  */
-#line 6 "dcParser.yxx"
+#line 7 "direct/src/dcparser/dcParser.yxx" /* yacc.c:339  */
 
 #include "dcLexerDefs.h"
 #include "dcParserDefs.h"
@@ -105,18 +100,18 @@ using std::istream;
 using std::ostringstream;
 using std::string;
 
-DCFile *dc_file = (DCFile *)NULL;
-static DCClass *current_class = (DCClass *)NULL;
-static DCSwitch *current_switch = (DCSwitch *)NULL;
-static DCAtomicField *current_atomic = (DCAtomicField *)NULL;
-static DCMolecularField *current_molecular = (DCMolecularField *)NULL;
-static DCParameter *current_parameter = (DCParameter *)NULL;
+DCFile *dc_file = nullptr;
+static DCClass *current_class = nullptr;
+static DCSwitch *current_switch = nullptr;
+static DCAtomicField *current_atomic = nullptr;
+static DCMolecularField *current_molecular = nullptr;
+static DCParameter *current_parameter = nullptr;
 static DCKeywordList current_keyword_list;
 static DCPacker default_packer;
 static DCPacker *current_packer;
 static DCDoubleRange double_range;
 static DCUnsignedIntRange uint_range;
-static DCField *parameter_description = (DCField *)NULL;
+static DCField *parameter_description = nullptr;
 
 ////////////////////////////////////////////////////////////////////
 // Defining the interface to the parser.
@@ -129,9 +124,9 @@ dc_init_parser(istream &in, const string &filename, DCFile &file) {
 }
 
 void
-dc_init_parser_parameter_value(istream &in, const string &filename, 
+dc_init_parser_parameter_value(istream &in, const string &filename,
                                DCPacker &packer) {
-  dc_file = NULL;
+  dc_file = nullptr;
   current_packer = &packer;
   dc_init_lexer(in, filename);
   dc_start_parameter_value();
@@ -142,7 +137,7 @@ dc_init_parser_parameter_description(istream &in, const string &filename,
                                      DCFile *file) {
   dc_file = file;
   dc_init_lexer(in, filename);
-  parameter_description = NULL;
+  parameter_description = nullptr;
   dc_start_parameter_description();
 }
 
@@ -153,18 +148,19 @@ dc_get_parameter_description() {
 
 void
 dc_cleanup_parser() {
-  dc_file = (DCFile *)NULL;
+  dc_file = nullptr;
 }
 
 
+#line 156 "built/tmp/dcParser.yxx.c" /* yacc.c:339  */
 
-/* Line 189 of yacc.c  */
-#line 159 "y.tab.c"
-
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 0
-#endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus && 201103L <= __cplusplus
+#   define YY_NULLPTR nullptr
+#  else
+#   define YY_NULLPTR 0
+#  endif
+# endif
 
 /* Enabling verbose error messages.  */
 #ifdef YYERROR_VERBOSE
@@ -174,67 +170,72 @@ dc_cleanup_parser() {
 # define YYERROR_VERBOSE 0
 #endif
 
-/* Enabling the token table.  */
-#ifndef YYTOKEN_TABLE
-# define YYTOKEN_TABLE 0
+/* In a future release of Bison, this section will be replaced
+   by #include "dcParser.yxx.h".  */
+#ifndef YY_DCYY_BUILT_TMP_DCPARSER_YXX_H_INCLUDED
+# define YY_DCYY_BUILT_TMP_DCPARSER_YXX_H_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 0
+#endif
+#if YYDEBUG
+extern int dcyydebug;
 #endif
 
-
-/* Tokens.  */
+/* Token type.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     UNSIGNED_INTEGER = 258,
-     SIGNED_INTEGER = 259,
-     REAL = 260,
-     STRING = 261,
-     HEX_STRING = 262,
-     IDENTIFIER = 263,
-     KEYWORD = 264,
-     KW_DCLASS = 265,
-     KW_STRUCT = 266,
-     KW_FROM = 267,
-     KW_IMPORT = 268,
-     KW_TYPEDEF = 269,
-     KW_KEYWORD = 270,
-     KW_SWITCH = 271,
-     KW_CASE = 272,
-     KW_DEFAULT = 273,
-     KW_BREAK = 274,
-     KW_INT8 = 275,
-     KW_INT16 = 276,
-     KW_INT32 = 277,
-     KW_INT64 = 278,
-     KW_UINT8 = 279,
-     KW_UINT16 = 280,
-     KW_UINT32 = 281,
-     KW_UINT64 = 282,
-     KW_FLOAT64 = 283,
-     KW_STRING = 284,
-     KW_BLOB = 285,
-     KW_BLOB32 = 286,
-     KW_INT8ARRAY = 287,
-     KW_INT16ARRAY = 288,
-     KW_INT32ARRAY = 289,
-     KW_UINT8ARRAY = 290,
-     KW_UINT16ARRAY = 291,
-     KW_UINT32ARRAY = 292,
-     KW_UINT32UINT8ARRAY = 293,
-     KW_CHAR = 294,
-     START_DC = 295,
-     START_PARAMETER_VALUE = 296,
-     START_PARAMETER_DESCRIPTION = 297
-   };
+  enum yytokentype
+  {
+    UNSIGNED_INTEGER = 258,
+    SIGNED_INTEGER = 259,
+    REAL = 260,
+    STRING = 261,
+    IDENTIFIER = 262,
+    HEX_STRING = 263,
+    KEYWORD = 264,
+    KW_DCLASS = 265,
+    KW_STRUCT = 266,
+    KW_FROM = 267,
+    KW_IMPORT = 268,
+    KW_TYPEDEF = 269,
+    KW_KEYWORD = 270,
+    KW_SWITCH = 271,
+    KW_CASE = 272,
+    KW_DEFAULT = 273,
+    KW_BREAK = 274,
+    KW_INT8 = 275,
+    KW_INT16 = 276,
+    KW_INT32 = 277,
+    KW_INT64 = 278,
+    KW_UINT8 = 279,
+    KW_UINT16 = 280,
+    KW_UINT32 = 281,
+    KW_UINT64 = 282,
+    KW_FLOAT64 = 283,
+    KW_STRING = 284,
+    KW_BLOB = 285,
+    KW_BLOB32 = 286,
+    KW_INT8ARRAY = 287,
+    KW_INT16ARRAY = 288,
+    KW_INT32ARRAY = 289,
+    KW_UINT8ARRAY = 290,
+    KW_UINT16ARRAY = 291,
+    KW_UINT32ARRAY = 292,
+    KW_UINT32UINT8ARRAY = 293,
+    KW_CHAR = 294,
+    START_DC = 295,
+    START_PARAMETER_VALUE = 296,
+    START_PARAMETER_DESCRIPTION = 297
+  };
 #endif
 /* Tokens.  */
 #define UNSIGNED_INTEGER 258
 #define SIGNED_INTEGER 259
 #define REAL 260
 #define STRING 261
-#define HEX_STRING 262
-#define IDENTIFIER 263
+#define IDENTIFIER 262
+#define HEX_STRING 263
 #define KEYWORD 264
 #define KW_DCLASS 265
 #define KW_STRUCT 266
@@ -270,21 +271,18 @@ dc_cleanup_parser() {
 #define START_PARAMETER_VALUE 296
 #define START_PARAMETER_DESCRIPTION 297
 
+/* Value type.  */
 
 
+extern YYSTYPE dcyylval;
 
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
+int dcyyparse (void);
 
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-#endif
-
+#endif /* !YY_DCYY_BUILT_TMP_DCPARSER_YXX_H_INCLUDED  */
 
 /* Copy the second part of user declarations.  */
 
-
-/* Line 264 of yacc.c  */
-#line 284 "y.tab.c"
+#line 286 "built/tmp/dcParser.yxx.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -298,11 +296,8 @@ typedef unsigned char yytype_uint8;
 
 #ifdef YYTYPE_INT8
 typedef YYTYPE_INT8 yytype_int8;
-#elif (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-typedef signed char yytype_int8;
 #else
-typedef short int yytype_int8;
+typedef signed char yytype_int8;
 #endif
 
 #ifdef YYTYPE_UINT16
@@ -322,8 +317,7 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+# elif ! defined YYSIZE_T
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
@@ -337,38 +331,67 @@ typedef short int yytype_int16;
 # if defined YYENABLE_NLS && YYENABLE_NLS
 #  if ENABLE_NLS
 #   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#   define YY_(msgid) dgettext ("bison-runtime", msgid)
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
 #  endif
 # endif
 # ifndef YY_
-#  define YY_(msgid) msgid
+#  define YY_(Msgid) Msgid
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE
+# if (defined __GNUC__                                               \
+      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
+     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
+#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+# else
+#  define YY_ATTRIBUTE(Spec) /* empty */
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_PURE
+# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
+#endif
+
+#if !defined _Noreturn \
+     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
+# if defined _MSC_VER && 1200 <= _MSC_VER
+#  define _Noreturn __declspec (noreturn)
+# else
+#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(e) ((void) (e))
+# define YYUSE(E) ((void) (E))
 #else
-# define YYUSE(e) /* empty */
+# define YYUSE(E) /* empty */
 #endif
 
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(n) (n)
+#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+    _Pragma ("GCC diagnostic pop")
 #else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int yyi)
-#else
-static int
-YYID (yyi)
-    int yyi;
+# define YY_INITIAL_VALUE(Value) Value
 #endif
-{
-  return yyi;
-}
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
 #endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
+#endif
+
 
 #if ! defined yyoverflow || YYERROR_VERBOSE
 
@@ -387,11 +410,11 @@ YYID (yyi)
 #    define alloca _alloca
 #   else
 #    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
 #     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#     ifndef _STDLIB_H
-#      define _STDLIB_H 1
+      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#     ifndef EXIT_SUCCESS
+#      define EXIT_SUCCESS 0
 #     endif
 #    endif
 #   endif
@@ -399,8 +422,8 @@ YYID (yyi)
 # endif
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -414,25 +437,23 @@ YYID (yyi)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
 #   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
 #  endif
-#  if (defined __cplusplus && ! defined _STDLIB_H \
+#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-	     && (defined YYFREE || defined free)))
+             && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#   ifndef _STDLIB_H
-#    define _STDLIB_H 1
+#   ifndef EXIT_SUCCESS
+#    define EXIT_SUCCESS 0
 #   endif
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined malloc && ! defined EXIT_SUCCESS
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined free && ! defined EXIT_SUCCESS
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
@@ -442,7 +463,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-	 || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+         || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
@@ -460,46 +481,50 @@ union yyalloc
      ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
-/* Copy COUNT objects from FROM to TO.  The source and destination do
-   not overlap.  */
-# ifndef YYCOPY
-#  if defined __GNUC__ && 1 < __GNUC__
-#   define YYCOPY(To, From, Count) \
-      __builtin_memcpy (To, From, (Count) * sizeof (*(From)))
-#  else
-#   define YYCOPY(To, From, Count)		\
-      do					\
-	{					\
-	  YYSIZE_T yyi;				\
-	  for (yyi = 0; yyi < (Count); yyi++)	\
-	    (To)[yyi] = (From)[yyi];		\
-	}					\
-      while (YYID (0))
-#  endif
-# endif
+# define YYCOPY_NEEDED 1
 
 /* Relocate STACK from its old location to the new one.  The
    local variables YYSIZE and YYSTACKSIZE give the old and new number of
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack_alloc, Stack)				\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack_alloc, Stack, yysize);			\
-	Stack = &yyptr->Stack_alloc;					\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYSIZE_T yynewbytes;                                            \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / sizeof (*yyptr);                          \
+      }                                                                 \
+    while (0)
 
 #endif
+
+#if defined YYCOPY_NEEDED && YYCOPY_NEEDED
+/* Copy COUNT objects from SRC to DST.  The source and destination do
+   not overlap.  */
+# ifndef YYCOPY
+#  if defined __GNUC__ && 1 < __GNUC__
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+#  else
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYSIZE_T yyi;                         \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
+#  endif
+# endif
+#endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  57
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   430
+#define YYLAST   431
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  58
@@ -507,17 +532,19 @@ union yyalloc
 #define YYNNTS  82
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  190
-/* YYNRULES -- Number of states.  */
+/* YYNSTATES -- Number of states.  */
 #define YYNSTATES  282
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
+/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
+   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   297
 
-#define YYTRANSLATE(YYX)						\
+#define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, without out-of-bounds checking.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -553,123 +580,39 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const yytype_uint16 yyprhs[] =
-{
-       0,     0,     3,     6,     9,    12,    14,    17,    20,    23,
-      26,    29,    32,    34,    38,    40,    44,    47,    48,    54,
-      56,    58,    60,    64,    67,    70,    72,    75,    78,    80,
-      82,    83,    91,    93,    95,    98,   100,   104,   106,   109,
-     113,   116,   119,   122,   125,   126,   134,   136,   138,   141,
-     143,   147,   149,   152,   156,   159,   162,   165,   168,   169,
-     175,   177,   179,   181,   185,   187,   188,   192,   194,   196,
-     197,   202,   204,   205,   210,   212,   214,   216,   218,   220,
-     222,   225,   228,   231,   233,   238,   242,   246,   248,   250,
-     252,   254,   256,   258,   262,   265,   269,   275,   280,   282,
-     284,   288,   291,   295,   301,   306,   308,   313,   315,   319,
-     323,   328,   330,   332,   334,   336,   338,   340,   342,   344,
-     346,   348,   350,   352,   353,   358,   360,   362,   364,   366,
-     368,   369,   374,   375,   380,   381,   386,   390,   394,   398,
-     402,   404,   407,   409,   411,   413,   417,   419,   421,   423,
-     425,   427,   429,   431,   433,   435,   437,   439,   441,   443,
-     445,   447,   449,   451,   453,   455,   457,   459,   462,   464,
-     465,   470,   472,   474,   478,   480,   482,   483,   493,   495,
-     498,   501,   504,   508,   512,   513,   518,   521,   523,   525,
-     527
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const yytype_int16 yyrhs[] =
-{
-      59,     0,    -1,    40,    60,    -1,    41,   114,    -1,    42,
-     100,    -1,   139,    -1,    60,    43,    -1,    60,    70,    -1,
-      60,   131,    -1,    60,    63,    -1,    60,    67,    -1,    60,
-      68,    -1,     8,    -1,    61,    44,     8,    -1,    61,    -1,
-      62,    45,    61,    -1,    13,    62,    -1,    -1,    12,    62,
-      13,    64,    65,    -1,    66,    -1,    46,    -1,    61,    -1,
-      66,    47,    61,    -1,    14,    98,    -1,    15,    69,    -1,
-     139,    -1,    69,     8,    -1,    69,     9,    -1,    71,    -1,
-      78,    -1,    -1,    10,   130,    72,    74,    48,    76,    49,
-      -1,     8,    -1,   139,    -1,    50,    75,    -1,    73,    -1,
-      75,    47,    73,    -1,   139,    -1,    76,    43,    -1,    76,
-      77,    43,    -1,    85,   124,    -1,   126,   125,    -1,    95,
-     124,    -1,    93,   124,    -1,    -1,    11,   130,    79,    81,
-      48,    83,    49,    -1,     8,    -1,   139,    -1,    50,    82,
-      -1,    80,    -1,    82,    47,    80,    -1,   139,    -1,    83,
-      43,    -1,    83,    84,    43,    -1,    85,   125,    -1,   126,
-     125,    -1,    95,   125,    -1,    93,   125,    -1,    -1,   130,
-      51,    86,    87,    52,    -1,   139,    -1,    88,    -1,    89,
-      -1,    88,    47,    89,    -1,    98,    -1,    -1,   105,    91,
-     106,    -1,   105,    -1,    90,    -1,    -1,    90,    53,    94,
-     114,    -1,    92,    -1,    -1,    92,    53,    96,   114,    -1,
-      90,    -1,    92,    -1,    93,    -1,    95,    -1,    97,    -1,
-      85,    -1,    85,   125,    -1,    95,   125,    -1,    93,   125,
-      -1,   123,    -1,   101,    51,   103,    52,    -1,   101,    44,
-     108,    -1,   101,    54,   112,    -1,   101,    -1,     8,    -1,
-      78,    -1,   131,    -1,   139,    -1,   113,    -1,   113,    55,
-     113,    -1,   113,   112,    -1,   103,    47,   113,    -1,   103,
-      47,   113,    55,   113,    -1,   103,    47,   113,   112,    -1,
-     139,    -1,   107,    -1,   107,    55,   107,    -1,   107,   109,
-      -1,   104,    47,   107,    -1,   104,    47,   107,    55,   107,
-      -1,   104,    47,   107,   109,    -1,   102,    -1,   105,    56,
-     104,    57,    -1,     8,    -1,   106,    44,   108,    -1,   106,
-      54,   112,    -1,   106,    56,   104,    57,    -1,     6,    -1,
-     108,    -1,     3,    -1,     4,    -1,     4,    -1,     3,    -1,
-     111,    -1,   110,    -1,     5,    -1,     6,    -1,   112,    -1,
-     116,    -1,    -1,     8,    53,   115,   116,    -1,   110,    -1,
-     111,    -1,     5,    -1,     6,    -1,     7,    -1,    -1,    48,
-     117,   120,    49,    -1,    -1,    56,   118,   120,    57,    -1,
-      -1,    51,   119,   120,    52,    -1,   110,    46,   108,    -1,
-     111,    46,   108,    -1,     5,    46,   108,    -1,     7,    46,
-     108,    -1,   121,    -1,   122,   121,    -1,   139,    -1,    47,
-      -1,   114,    -1,   122,    47,   114,    -1,    20,    -1,    21,
-      -1,    22,    -1,    23,    -1,    24,    -1,    25,    -1,    26,
-      -1,    27,    -1,    28,    -1,    29,    -1,    30,    -1,    31,
-      -1,    32,    -1,    33,    -1,    34,    -1,    35,    -1,    36,
-      -1,    37,    -1,    38,    -1,    39,    -1,   139,    -1,   124,
-       9,    -1,   124,    -1,    -1,     8,    50,   127,   129,    -1,
-       8,    -1,   128,    -1,   129,    47,   128,    -1,   139,    -1,
-       8,    -1,    -1,    16,   130,    51,    99,    52,    48,   132,
-     133,    49,    -1,   139,    -1,   133,    43,    -1,   133,   134,
-      -1,   133,   136,    -1,   133,   137,    43,    -1,   133,   138,
-      43,    -1,    -1,    17,   135,   114,    50,    -1,    18,    50,
-      -1,    19,    -1,    95,    -1,    93,    -1,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
+  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   168,   168,   169,   170,   177,   178,   179,   190,   196,
-     197,   198,   202,   203,   210,   211,   218,   223,   222,   230,
-     231,   238,   242,   249,   267,   271,   272,   276,   287,   288,
-     293,   292,   304,   327,   328,   332,   338,   352,   353,   354,
-     367,   377,   378,   386,   397,   396,   408,   431,   432,   436,
-     442,   451,   452,   453,   464,   471,   472,   476,   484,   483,
-     501,   502,   506,   507,   511,   521,   520,   531,   535,   537,
-     536,   565,   567,   566,   595,   596,   600,   601,   605,   609,
-     616,   620,   624,   631,   635,   644,   660,   675,   676,   708,
-     724,   743,   747,   754,   761,   770,   776,   782,   793,   797,
-     804,   811,   818,   824,   830,   839,   840,   851,   856,   871,
-     886,   893,   902,   906,   917,   931,   935,   939,   943,   947,
-     951,   960,   965,   969,   968,   983,   987,   991,   995,   999,
-    1004,  1003,  1012,  1011,  1020,  1019,  1027,  1033,  1039,  1045,
-    1054,  1055,  1059,  1060,  1064,  1065,  1069,  1073,  1077,  1081,
-    1085,  1089,  1093,  1097,  1101,  1105,  1109,  1113,  1117,  1121,
-    1125,  1129,  1133,  1137,  1141,  1145,  1152,  1156,  1163,  1173,
-    1172,  1183,  1210,  1216,  1230,  1234,  1239,  1238,  1251,  1252,
-    1253,  1254,  1255,  1256,  1270,  1269,  1290,  1299,  1306,  1310,
-    1316
+       0,   174,   174,   175,   176,   183,   184,   185,   196,   202,
+     203,   204,   208,   209,   216,   217,   224,   229,   228,   236,
+     237,   244,   248,   255,   273,   277,   278,   282,   293,   294,
+     299,   298,   310,   333,   334,   338,   344,   358,   359,   360,
+     373,   383,   384,   392,   403,   402,   414,   437,   438,   442,
+     448,   457,   458,   459,   470,   477,   478,   482,   490,   489,
+     507,   508,   512,   513,   517,   527,   526,   537,   541,   543,
+     542,   571,   573,   572,   601,   602,   606,   607,   611,   615,
+     622,   626,   630,   637,   641,   650,   666,   681,   682,   714,
+     730,   749,   753,   760,   767,   776,   782,   788,   799,   803,
+     810,   817,   824,   830,   836,   845,   846,   857,   862,   877,
+     892,   899,   908,   912,   923,   937,   941,   945,   949,   953,
+     957,   966,   971,   975,   974,   989,   993,   997,  1001,  1005,
+    1010,  1009,  1018,  1017,  1026,  1025,  1033,  1039,  1045,  1051,
+    1060,  1061,  1065,  1066,  1070,  1071,  1075,  1079,  1083,  1087,
+    1091,  1095,  1099,  1103,  1107,  1111,  1115,  1119,  1123,  1127,
+    1131,  1135,  1139,  1143,  1147,  1151,  1158,  1162,  1169,  1179,
+    1178,  1189,  1216,  1222,  1236,  1240,  1245,  1244,  1257,  1258,
+    1259,  1260,  1261,  1262,  1276,  1275,  1296,  1305,  1312,  1316,
+    1322
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || YYTOKEN_TABLE
+#if YYDEBUG || YYERROR_VERBOSE || 0
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
   "$end", "error", "$undefined", "UNSIGNED_INTEGER", "SIGNED_INTEGER",
-  "REAL", "STRING", "HEX_STRING", "IDENTIFIER", "KEYWORD", "KW_DCLASS",
+  "REAL", "STRING", "IDENTIFIER", "HEX_STRING", "KEYWORD", "KW_DCLASS",
   "KW_STRUCT", "KW_FROM", "KW_IMPORT", "KW_TYPEDEF", "KW_KEYWORD",
   "KW_SWITCH", "KW_CASE", "KW_DEFAULT", "KW_BREAK", "KW_INT8", "KW_INT16",
   "KW_INT32", "KW_INT64", "KW_UINT8", "KW_UINT16", "KW_UINT32",
@@ -697,13 +640,13 @@ static const char *const yytname[] =
   "array_def", "type_token", "keyword_list", "no_keyword_list",
   "molecular_field", "$@12", "atomic_name", "molecular_atom_list",
   "optional_name", "switch", "@13", "switch_fields", "switch_case", "$@14",
-  "switch_default", "switch_break", "switch_field", "empty", 0
+  "switch_default", "switch_break", "switch_field", "empty", YY_NULLPTR
 };
 #endif
 
 # ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
+/* YYTOKNUM[NUM] -- (External) token number corresponding to the
+   (internal) symbol number NUM (which must be that of a token).  */
 static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
@@ -715,7 +658,250 @@ static const yytype_uint16 yytoknum[] =
 };
 # endif
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+#define YYPACT_NINF -127
+
+#define yypact_value_is_default(Yystate) \
+  (!!((Yystate) == (-127)))
+
+#define YYTABLE_NINF -176
+
+#define yytable_value_is_error(Yytable_value) \
+  0
+
+  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+     STATE-NUM.  */
+static const yytype_int16 yypact[] =
+{
+      61,  -127,   104,   359,    19,   128,  -127,  -127,  -127,   -23,
+    -127,   -27,    17,  -127,  -127,  -127,    44,    69,  -127,  -127,
+      15,    42,    42,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
+    -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
+    -127,  -127,  -127,  -127,  -127,    46,    76,  -127,  -127,  -127,
+       4,  -127,    27,  -127,    22,  -127,  -127,  -127,    42,    63,
+      63,   392,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
+    -127,   117,  -127,   117,    24,    24,    24,   117,   117,  -127,
+    -127,    96,   142,  -127,  -127,  -127,  -127,  -127,  -127,   117,
+     153,   158,    53,   146,  -127,  -127,  -127,   110,     1,   119,
+    -127,  -127,  -127,  -127,   141,  -127,  -127,  -127,   122,  -127,
+    -127,  -127,   116,  -127,   120,  -127,   114,   111,  -127,  -127,
+     124,   359,  -127,   104,   104,  -127,  -127,  -127,    67,  -127,
+    -127,  -127,    33,  -127,  -127,  -127,   -12,     7,  -127,  -127,
+    -127,    20,   392,   125,   162,  -127,    63,  -127,  -127,  -127,
+    -127,   104,  -127,  -127,  -127,   165,   129,  -127,  -127,  -127,
+    -127,  -127,   130,  -127,  -127,   153,  -127,   153,  -127,    53,
+    -127,  -127,    53,  -127,   117,   158,    53,   131,   133,  -127,
+    -127,  -127,   169,   136,  -127,  -127,    11,   110,  -127,  -127,
+    -127,   134,  -127,   137,    36,  -127,    12,  -127,  -127,  -127,
+      -4,  -127,   392,  -127,  -127,   139,  -127,  -127,   110,  -127,
+     140,   165,   291,  -127,  -127,   153,  -127,    53,  -127,  -127,
+    -127,   169,   325,  -127,    63,  -127,    31,  -127,  -127,   145,
+    -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
+     151,  -127,  -127,  -127,  -127,   110,  -127,  -127,  -127,  -127,
+    -127,  -127,   257,  -127,  -127,   142,   142,   142,  -127,   182,
+    -127,   147,  -127,  -127,  -127,  -127,  -127,  -127,  -127,   155,
+     156,  -127,  -127,   149,   104,  -127,  -127,  -127,   182,   150,
+    -127,  -127
+};
+
+  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+     Performed when YYTABLE does not specify something else to do.  Zero
+     means the default is an error.  */
+static const yytype_uint8 yydefact[] =
+{
+       0,   190,     0,   190,     0,     2,     5,   116,   115,   127,
+     128,     0,   129,   130,   134,   132,   125,   126,     3,   122,
+      88,   190,   190,   146,   147,   148,   149,   150,   151,   152,
+     153,   154,   155,   156,   157,   158,   159,   160,   161,   162,
+     163,   164,   165,    89,   190,    68,    71,   190,   190,     4,
+      87,   105,    67,    83,     0,    90,   174,     1,   190,     0,
+       0,     0,   190,     6,     9,    10,    11,     7,    28,    29,
+       8,     0,   123,     0,   190,   190,   190,     0,     0,   175,
+      44,     0,   168,    80,   166,    69,    72,    82,    81,     0,
+     190,     0,   190,     0,    58,    30,    12,    14,     0,    16,
+      88,    76,    77,    23,    24,    25,   113,   138,     0,   139,
+     143,   144,     0,   140,   190,   142,     0,     0,   136,   137,
+     190,   190,   167,     0,     0,    85,   119,   120,     0,   118,
+     117,   121,    92,    91,    86,   111,     0,    99,   112,    98,
+     107,    66,   190,   190,     0,    17,     0,    26,    27,   124,
+     131,   143,   141,   135,   133,     0,     0,    47,    79,    74,
+      75,    78,     0,    70,    73,     0,    84,     0,    94,     0,
+     106,   114,     0,   101,     0,     0,   190,     0,    61,    62,
+      64,    60,     0,     0,    33,    13,     0,    15,   145,    46,
+      49,    48,   190,     0,    95,    93,   102,   100,   108,   109,
+       0,    59,     0,    32,    35,    34,   190,    20,    21,    18,
+      19,     0,   190,    51,   176,     0,    97,     0,   104,   110,
+      63,     0,   190,    37,     0,    50,    88,    52,    45,     0,
+     190,   190,   190,   190,   190,    96,   103,    36,    38,    31,
+       0,   190,   190,   190,   190,    22,   169,    53,    54,    57,
+      56,    55,     0,   178,    39,    40,    43,    42,    41,     0,
+     184,     0,   187,   179,   177,   189,   188,   180,   181,     0,
+       0,   171,   172,   170,     0,   186,   182,   183,     0,     0,
+     173,   185
+};
+
+  /* YYPGOTO[NTERM-NUM].  */
+static const yytype_int16 yypgoto[] =
+{
+    -127,  -127,  -127,  -126,   143,  -127,  -127,  -127,  -127,  -127,
+    -127,  -127,  -127,  -127,  -127,   -20,  -127,  -127,  -127,  -127,
+     197,  -127,    -6,  -127,  -127,  -127,  -127,  -116,  -127,  -127,
+    -127,     5,    85,  -127,    87,    -1,  -127,     0,  -127,  -127,
+     152,  -127,  -127,  -127,  -127,  -127,    34,  -127,  -127,  -125,
+     -56,    18,   -81,   -78,   -90,  -115,    -2,  -127,   108,  -127,
+    -127,  -127,    60,   103,  -127,  -127,  -110,   -40,    -3,  -127,
+     -60,  -127,    47,   215,  -127,  -127,  -127,  -127,  -127,  -127,
+    -127,     3
+};
+
+  /* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int16 yydefgoto[] =
+{
+      -1,     4,     5,    97,    98,    64,   186,   209,   210,    65,
+      66,   104,    67,    68,   143,   204,   183,   205,   222,   240,
+      43,   120,   190,   156,   191,   212,   229,    44,   142,   177,
+     178,   179,    45,    93,    46,   101,   123,   102,   124,   161,
+     180,   162,    49,    50,    51,   128,   136,    52,   141,   137,
+     138,   173,    16,    17,   131,   132,   111,   108,    19,    74,
+      76,    75,   112,   113,   114,    53,    82,    83,   233,   259,
+     272,   273,    54,    55,   234,   252,   267,   274,   268,   269,
+     270,    84
+};
+
+  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+     positive, shift that token.  If negative, reduce the rule whose
+     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+static const yytype_int16 yytable[] =
+{
+      18,   134,    47,    48,     6,   158,    56,    87,    88,   129,
+     129,   171,   130,   130,   145,   107,   171,   109,    96,    57,
+     187,   118,   119,    71,    56,    56,    72,     7,     8,     9,
+      10,    11,    12,   125,   -65,   169,     7,     8,   126,     7,
+       8,   126,   168,   169,   196,   170,   146,   197,    89,    79,
+     194,   129,   195,   219,   130,    90,   106,   207,    91,   135,
+     208,    56,   172,    73,   174,   105,  -175,   217,    80,    81,
+      96,   110,    13,    94,   175,    14,   176,   115,   115,   115,
+      15,   246,  -175,    92,   129,   199,   129,   130,   167,   130,
+      77,   215,   236,   133,   129,   139,   230,   130,   245,    85,
+     235,     1,     2,     3,   216,    95,   241,     7,     8,     9,
+      10,    11,    12,   129,   165,    78,   130,   115,   198,   166,
+     106,   163,   164,   157,    56,     7,     8,     9,    10,    86,
+      12,   255,   256,   257,   129,   116,   117,   130,    58,    21,
+      59,    60,    61,    62,    22,   181,   184,   121,   147,   188,
+     148,   122,    13,   140,   144,    14,     7,     8,   126,   127,
+      15,     7,     8,   126,   146,   150,   153,   151,   154,   185,
+      13,    63,   189,    14,   155,   182,   203,   192,    15,   139,
+     202,   211,   193,   201,   206,   214,   221,   224,   247,   271,
+     248,   249,   250,   251,   254,   213,   278,   275,   276,   277,
+     281,   237,    69,    99,   258,   225,   159,   220,   160,   223,
+     200,   231,   232,   103,   218,    56,   149,   152,   280,   244,
+      70,   242,   243,     0,     0,    56,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   253,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   265,   266,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   100,     0,     0,     0,    21,     0,
+       0,     0,   279,    22,   260,   261,   262,    23,    24,    25,
+      26,    27,    28,    29,    30,    31,    32,    33,    34,    35,
+      36,    37,    38,    39,    40,    41,    42,     0,   226,     0,
+     263,     0,    21,     0,     0,     0,   264,    22,     0,     0,
+       0,    23,    24,    25,    26,    27,    28,    29,    30,    31,
+      32,    33,    34,    35,    36,    37,    38,    39,    40,    41,
+      42,     0,   226,     0,   227,     0,    21,     0,     0,     0,
+     228,    22,     0,     0,     0,    23,    24,    25,    26,    27,
+      28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
+      38,    39,    40,    41,    42,     0,    20,     0,   238,     0,
+      21,     0,     0,     0,   239,    22,     0,     0,     0,    23,
+      24,    25,    26,    27,    28,    29,    30,    31,    32,    33,
+      34,    35,    36,    37,    38,    39,    40,    41,    42,   100,
+       0,     0,     0,    21,     0,     0,     0,     0,    22,     0,
+       0,     0,    23,    24,    25,    26,    27,    28,    29,    30,
+      31,    32,    33,    34,    35,    36,    37,    38,    39,    40,
+      41,    42
+};
+
+static const yytype_int16 yycheck[] =
+{
+       2,    91,     3,     3,     1,   121,     3,    47,    48,    90,
+      91,     4,    90,    91,    13,    71,     4,    73,     7,     0,
+     146,    77,    78,    46,    21,    22,    53,     3,     4,     5,
+       6,     7,     8,    89,     7,    47,     3,     4,     5,     3,
+       4,     5,   132,    47,   169,    57,    45,   172,    44,     7,
+     165,   132,   167,    57,   132,    51,     3,    46,    54,     6,
+     186,    58,    55,    46,    44,    62,    51,    55,    21,    22,
+       7,    47,    48,    51,    54,    51,    56,    74,    75,    76,
+      56,    50,    51,    56,   165,   175,   167,   165,    55,   167,
+      46,    55,   217,    90,   175,    92,   212,   175,   224,    53,
+     215,    40,    41,    42,   194,    58,   222,     3,     4,     5,
+       6,     7,     8,   194,    47,    46,   194,   114,   174,    52,
+       3,   123,   124,   120,   121,     3,     4,     5,     6,    53,
+       8,   241,   242,   243,   215,    75,    76,   215,    10,    11,
+      12,    13,    14,    15,    16,   142,   143,    51,     7,   151,
+       9,     9,    48,     7,    44,    51,     3,     4,     5,     6,
+      56,     3,     4,     5,    45,    49,    52,    47,    57,     7,
+      48,    43,     7,    51,    50,    50,     7,    48,    56,   176,
+      47,    47,    52,    52,    48,    48,    47,    47,    43,     7,
+     230,   231,   232,   233,    43,   192,    47,    50,    43,    43,
+      50,   221,     5,    60,   244,   211,   121,   202,   121,   206,
+     176,   212,   212,    61,   196,   212,   108,   114,   278,   222,
+       5,   222,   222,    -1,    -1,   222,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   234,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   252,   252,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,     7,    -1,    -1,    -1,    11,    -1,
+      -1,    -1,   274,    16,    17,    18,    19,    20,    21,    22,
+      23,    24,    25,    26,    27,    28,    29,    30,    31,    32,
+      33,    34,    35,    36,    37,    38,    39,    -1,     7,    -1,
+      43,    -1,    11,    -1,    -1,    -1,    49,    16,    -1,    -1,
+      -1,    20,    21,    22,    23,    24,    25,    26,    27,    28,
+      29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
+      39,    -1,     7,    -1,    43,    -1,    11,    -1,    -1,    -1,
+      49,    16,    -1,    -1,    -1,    20,    21,    22,    23,    24,
+      25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
+      35,    36,    37,    38,    39,    -1,     7,    -1,    43,    -1,
+      11,    -1,    -1,    -1,    49,    16,    -1,    -1,    -1,    20,
+      21,    22,    23,    24,    25,    26,    27,    28,    29,    30,
+      31,    32,    33,    34,    35,    36,    37,    38,    39,     7,
+      -1,    -1,    -1,    11,    -1,    -1,    -1,    -1,    16,    -1,
+      -1,    -1,    20,    21,    22,    23,    24,    25,    26,    27,
+      28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
+      38,    39
+};
+
+  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
+     symbol of state STATE-NUM.  */
+static const yytype_uint8 yystos[] =
+{
+       0,    40,    41,    42,    59,    60,   139,     3,     4,     5,
+       6,     7,     8,    48,    51,    56,   110,   111,   114,   116,
+       7,    11,    16,    20,    21,    22,    23,    24,    25,    26,
+      27,    28,    29,    30,    31,    32,    33,    34,    35,    36,
+      37,    38,    39,    78,    85,    90,    92,    93,    95,   100,
+     101,   102,   105,   123,   130,   131,   139,     0,    10,    12,
+      13,    14,    15,    43,    63,    67,    68,    70,    71,    78,
+     131,    46,    53,    46,   117,   119,   118,    46,    46,     7,
+     130,   130,   124,   125,   139,    53,    53,   125,   125,    44,
+      51,    54,    56,    91,    51,   130,     7,    61,    62,    62,
+       7,    93,    95,    98,    69,   139,     3,   108,   115,   108,
+      47,   114,   120,   121,   122,   139,   120,   120,   108,   108,
+      79,    51,     9,    94,    96,   108,     5,     6,   103,   110,
+     111,   112,   113,   139,   112,     6,   104,   107,   108,   139,
+       7,   106,    86,    72,    44,    13,    45,     7,     9,   116,
+      49,    47,   121,    52,    57,    50,    81,   139,    85,    90,
+      92,    97,    99,   114,   114,    47,    52,    55,   112,    47,
+      57,     4,    55,   109,    44,    54,    56,    87,    88,    89,
+      98,   139,    50,    74,   139,     7,    64,    61,   114,     7,
+      80,    82,    48,    52,   113,   113,   107,   107,   108,   112,
+     104,    52,    47,     7,    73,    75,    48,    46,    61,    65,
+      66,    47,    83,   139,    48,    55,   112,    55,   109,    57,
+      89,    47,    76,   139,    47,    80,     7,    43,    49,    84,
+      85,    93,    95,   126,   132,   113,   107,    73,    43,    49,
+      77,    85,    93,    95,   126,    61,    50,    43,   125,   125,
+     125,   125,   133,   139,    43,   124,   124,   124,   125,   127,
+      17,    18,    19,    43,    49,    93,    95,   134,   136,   137,
+     138,     7,   128,   129,   135,    50,    43,    43,    47,   114,
+     128,    50
+};
+
+  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
        0,    58,    59,    59,    59,    60,    60,    60,    60,    60,
@@ -740,7 +926,7 @@ static const yytype_uint8 yyr1[] =
      139
 };
 
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
+  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
        0,     2,     2,     2,     2,     1,     2,     2,     2,     2,
@@ -765,340 +951,41 @@ static const yytype_uint8 yyr2[] =
        0
 };
 
-/* YYDEFACT[STATE-NAME] -- Default rule to reduce with in state
-   STATE-NUM when YYTABLE doesn't specify something else to do.  Zero
-   means the default is an error.  */
-static const yytype_uint8 yydefact[] =
-{
-       0,   190,     0,   190,     0,     2,     5,   116,   115,   127,
-     128,   129,     0,   130,   134,   132,   125,   126,     3,   122,
-      88,   190,   190,   146,   147,   148,   149,   150,   151,   152,
-     153,   154,   155,   156,   157,   158,   159,   160,   161,   162,
-     163,   164,   165,    89,   190,    68,    71,   190,   190,     4,
-      87,   105,    67,    83,     0,    90,   174,     1,   190,     0,
-       0,     0,   190,     6,     9,    10,    11,     7,    28,    29,
-       8,     0,     0,   123,   190,   190,   190,     0,     0,   175,
-      44,     0,   168,    80,   166,    69,    72,    82,    81,     0,
-     190,     0,   190,     0,    58,    30,    12,    14,     0,    16,
-      88,    76,    77,    23,    24,    25,   113,   138,   139,     0,
-     143,   144,     0,   140,   190,   142,     0,     0,   136,   137,
-     190,   190,   167,     0,     0,    85,   119,   120,     0,   118,
-     117,   121,    92,    91,    86,   111,     0,    99,   112,    98,
-     107,    66,   190,   190,     0,    17,     0,    26,    27,   124,
-     131,   143,   141,   135,   133,     0,     0,    47,    79,    74,
-      75,    78,     0,    70,    73,     0,    84,     0,    94,     0,
-     106,   114,     0,   101,     0,     0,   190,     0,    61,    62,
-      64,    60,     0,     0,    33,    13,     0,    15,   145,    46,
-      49,    48,   190,     0,    95,    93,   102,   100,   108,   109,
-       0,    59,     0,    32,    35,    34,   190,    20,    21,    18,
-      19,     0,   190,    51,   176,     0,    97,     0,   104,   110,
-      63,     0,   190,    37,     0,    50,    88,    52,    45,     0,
-     190,   190,   190,   190,   190,    96,   103,    36,    38,    31,
-       0,   190,   190,   190,   190,    22,   169,    53,    54,    57,
-      56,    55,     0,   178,    39,    40,    43,    42,    41,     0,
-     184,     0,   187,   179,   177,   189,   188,   180,   181,     0,
-       0,   171,   172,   170,     0,   186,   182,   183,     0,     0,
-     173,   185
-};
 
-/* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int16 yydefgoto[] =
-{
-      -1,     4,     5,    97,    98,    64,   186,   209,   210,    65,
-      66,   104,    67,    68,   143,   204,   183,   205,   222,   240,
-      43,   120,   190,   156,   191,   212,   229,    44,   142,   177,
-     178,   179,    45,    93,    46,   101,   123,   102,   124,   161,
-     180,   162,    49,    50,    51,   128,   136,    52,   141,   137,
-     138,   173,    16,    17,   131,   132,   111,   109,    19,    74,
-      76,    75,   112,   113,   114,    53,    82,    83,   233,   259,
-     272,   273,    54,    55,   234,   252,   267,   274,   268,   269,
-     270,    84
-};
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+#define YYEMPTY         (-2)
+#define YYEOF           0
 
-/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-   STATE-NUM.  */
-#define YYPACT_NINF -127
-static const yytype_int16 yypact[] =
-{
-       8,  -127,   104,   359,    35,   128,  -127,  -127,  -127,    20,
-    -127,    22,    28,  -127,  -127,  -127,    37,    53,  -127,  -127,
-      54,   139,   139,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
-    -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
-    -127,  -127,  -127,  -127,  -127,    95,    97,  -127,  -127,  -127,
-       2,  -127,    26,  -127,   100,  -127,  -127,  -127,   139,   145,
-     145,   391,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
-    -127,   151,   151,  -127,    24,    24,    24,   151,   151,  -127,
-    -127,   108,   152,  -127,  -127,  -127,  -127,  -127,  -127,   151,
-     127,    98,    64,   154,  -127,  -127,  -127,   119,    13,   120,
-    -127,  -127,  -127,  -127,   106,  -127,  -127,  -127,  -127,   122,
-    -127,  -127,   115,  -127,   121,  -127,   114,   110,  -127,  -127,
-     124,   359,  -127,   104,   104,  -127,  -127,  -127,    12,  -127,
-    -127,  -127,    14,  -127,  -127,  -127,    16,     7,  -127,  -127,
-    -127,     1,   391,   125,   161,  -127,   145,  -127,  -127,  -127,
-    -127,   104,  -127,  -127,  -127,   164,   129,  -127,  -127,  -127,
-    -127,  -127,   130,  -127,  -127,   127,  -127,   127,  -127,    64,
-    -127,  -127,    64,  -127,   151,    98,    64,   131,   133,  -127,
-    -127,  -127,   168,   136,  -127,  -127,     6,   119,  -127,  -127,
-    -127,   134,  -127,   137,    33,  -127,    19,  -127,  -127,  -127,
-      43,  -127,   391,  -127,  -127,   140,  -127,  -127,   119,  -127,
-     141,   164,   291,  -127,  -127,   127,  -127,    64,  -127,  -127,
-    -127,   168,   325,  -127,   145,  -127,    69,  -127,  -127,   143,
-    -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
-     146,  -127,  -127,  -127,  -127,   119,  -127,  -127,  -127,  -127,
-    -127,  -127,   257,  -127,  -127,   152,   152,   152,  -127,   186,
-    -127,   147,  -127,  -127,  -127,  -127,  -127,  -127,  -127,   153,
-     155,  -127,  -127,   156,   104,  -127,  -127,  -127,   186,   149,
-    -127,  -127
-};
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
 
-/* YYPGOTO[NTERM-NUM].  */
-static const yytype_int16 yypgoto[] =
-{
-    -127,  -127,  -127,  -126,   142,  -127,  -127,  -127,  -127,  -127,
-    -127,  -127,  -127,  -127,  -127,   -21,  -127,  -127,  -127,  -127,
-     196,  -127,    -6,  -127,  -127,  -127,  -127,  -116,  -127,  -127,
-    -127,     4,    86,  -127,    87,    -1,  -127,     0,  -127,  -127,
-     157,  -127,  -127,  -127,  -127,  -127,    34,  -127,  -127,  -125,
-     -56,    17,   -81,   -78,   -90,  -124,    -2,  -127,   105,  -127,
-    -127,  -127,    60,   102,  -127,  -127,   -85,   -40,    -5,  -127,
-     -59,  -127,    18,   215,  -127,  -127,  -127,  -127,  -127,  -127,
-    -127,     3
-};
-
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If zero, do what YYDEFACT says.
-   If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -176
-static const yytype_int16 yytable[] =
-{
-      18,   134,    47,    48,     6,   158,    56,    87,    88,   129,
-     129,   171,   130,   130,    96,   107,   108,     7,     8,   126,
-     187,   118,   119,   171,    56,    56,   145,     7,     8,     9,
-      10,    11,    12,   125,   -65,    57,     7,     8,   126,    80,
-      81,   194,   168,   195,   196,   174,    89,   197,     1,     2,
-       3,   129,   207,    90,   130,   175,    91,   176,   146,   165,
-     208,    56,   172,   169,   166,   105,    71,   106,    72,   167,
-     135,   110,    13,   170,   217,    14,    95,   115,   115,   115,
-      15,    73,    92,    77,   129,   199,   129,   130,   215,   130,
-     169,   235,   236,   133,   129,   139,   230,   130,   245,    78,
-     219,     7,     8,   126,   216,  -175,   241,     7,     8,     9,
-      10,    11,    12,   129,   147,   148,   130,   115,   198,   246,
-    -175,   163,   164,   157,    56,     7,     8,     9,    10,    11,
-       7,     8,   126,   127,   129,   116,   117,   130,    58,    21,
-      59,    60,    61,    62,    22,   181,   184,    79,    85,   188,
-      86,    94,    13,    96,   106,    14,   255,   256,   257,   121,
-      15,   122,   140,   144,   150,   146,   153,   154,   151,   185,
-      13,    63,   189,    14,   155,   182,   203,   192,    15,   139,
-     202,   211,   193,   201,   206,   214,   247,   221,   224,   254,
-     248,   249,   250,   251,   271,   213,   276,   275,   277,   281,
-     237,    69,    99,   278,   258,   225,   220,   159,   160,   223,
-     200,   231,   232,   218,   149,    56,   152,   244,   103,   280,
-      70,   242,   243,     0,     0,    56,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   253,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   265,   266,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   100,     0,     0,    21,     0,
-       0,     0,   279,    22,   260,   261,   262,    23,    24,    25,
-      26,    27,    28,    29,    30,    31,    32,    33,    34,    35,
-      36,    37,    38,    39,    40,    41,    42,     0,     0,   226,
-     263,     0,    21,     0,     0,     0,   264,    22,     0,     0,
-       0,    23,    24,    25,    26,    27,    28,    29,    30,    31,
-      32,    33,    34,    35,    36,    37,    38,    39,    40,    41,
-      42,     0,     0,   226,   227,     0,    21,     0,     0,     0,
-     228,    22,     0,     0,     0,    23,    24,    25,    26,    27,
-      28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
-      38,    39,    40,    41,    42,     0,     0,    20,   238,     0,
-      21,     0,     0,     0,   239,    22,     0,     0,     0,    23,
-      24,    25,    26,    27,    28,    29,    30,    31,    32,    33,
-      34,    35,    36,    37,    38,    39,    40,    41,    42,   100,
-       0,     0,    21,     0,     0,     0,     0,    22,     0,     0,
-       0,    23,    24,    25,    26,    27,    28,    29,    30,    31,
-      32,    33,    34,    35,    36,    37,    38,    39,    40,    41,
-      42
-};
-
-static const yytype_int16 yycheck[] =
-{
-       2,    91,     3,     3,     1,   121,     3,    47,    48,    90,
-      91,     4,    90,    91,     8,    71,    72,     3,     4,     5,
-     146,    77,    78,     4,    21,    22,    13,     3,     4,     5,
-       6,     7,     8,    89,     8,     0,     3,     4,     5,    21,
-      22,   165,   132,   167,   169,    44,    44,   172,    40,    41,
-      42,   132,    46,    51,   132,    54,    54,    56,    45,    47,
-     186,    58,    55,    47,    52,    62,    46,     3,    46,    55,
-       6,    47,    48,    57,    55,    51,    58,    74,    75,    76,
-      56,    53,    56,    46,   165,   175,   167,   165,    55,   167,
-      47,   215,   217,    90,   175,    92,   212,   175,   224,    46,
-      57,     3,     4,     5,   194,    51,   222,     3,     4,     5,
-       6,     7,     8,   194,     8,     9,   194,   114,   174,    50,
-      51,   123,   124,   120,   121,     3,     4,     5,     6,     7,
-       3,     4,     5,     6,   215,    75,    76,   215,    10,    11,
-      12,    13,    14,    15,    16,   142,   143,     8,    53,   151,
-      53,    51,    48,     8,     3,    51,   241,   242,   243,    51,
-      56,     9,     8,    44,    49,    45,    52,    57,    47,     8,
-      48,    43,     8,    51,    50,    50,     8,    48,    56,   176,
-      47,    47,    52,    52,    48,    48,    43,    47,    47,    43,
-     230,   231,   232,   233,     8,   192,    43,    50,    43,    50,
-     221,     5,    60,    47,   244,   211,   202,   121,   121,   206,
-     176,   212,   212,   196,   109,   212,   114,   222,    61,   278,
-       5,   222,   222,    -1,    -1,   222,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   234,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   252,   252,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,     8,    -1,    -1,    11,    -1,
-      -1,    -1,   274,    16,    17,    18,    19,    20,    21,    22,
-      23,    24,    25,    26,    27,    28,    29,    30,    31,    32,
-      33,    34,    35,    36,    37,    38,    39,    -1,    -1,     8,
-      43,    -1,    11,    -1,    -1,    -1,    49,    16,    -1,    -1,
-      -1,    20,    21,    22,    23,    24,    25,    26,    27,    28,
-      29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-      39,    -1,    -1,     8,    43,    -1,    11,    -1,    -1,    -1,
-      49,    16,    -1,    -1,    -1,    20,    21,    22,    23,    24,
-      25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
-      35,    36,    37,    38,    39,    -1,    -1,     8,    43,    -1,
-      11,    -1,    -1,    -1,    49,    16,    -1,    -1,    -1,    20,
-      21,    22,    23,    24,    25,    26,    27,    28,    29,    30,
-      31,    32,    33,    34,    35,    36,    37,    38,    39,     8,
-      -1,    -1,    11,    -1,    -1,    -1,    -1,    16,    -1,    -1,
-      -1,    20,    21,    22,    23,    24,    25,    26,    27,    28,
-      29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-      39
-};
-
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
-{
-       0,    40,    41,    42,    59,    60,   139,     3,     4,     5,
-       6,     7,     8,    48,    51,    56,   110,   111,   114,   116,
-       8,    11,    16,    20,    21,    22,    23,    24,    25,    26,
-      27,    28,    29,    30,    31,    32,    33,    34,    35,    36,
-      37,    38,    39,    78,    85,    90,    92,    93,    95,   100,
-     101,   102,   105,   123,   130,   131,   139,     0,    10,    12,
-      13,    14,    15,    43,    63,    67,    68,    70,    71,    78,
-     131,    46,    46,    53,   117,   119,   118,    46,    46,     8,
-     130,   130,   124,   125,   139,    53,    53,   125,   125,    44,
-      51,    54,    56,    91,    51,   130,     8,    61,    62,    62,
-       8,    93,    95,    98,    69,   139,     3,   108,   108,   115,
-      47,   114,   120,   121,   122,   139,   120,   120,   108,   108,
-      79,    51,     9,    94,    96,   108,     5,     6,   103,   110,
-     111,   112,   113,   139,   112,     6,   104,   107,   108,   139,
-       8,   106,    86,    72,    44,    13,    45,     8,     9,   116,
-      49,    47,   121,    52,    57,    50,    81,   139,    85,    90,
-      92,    97,    99,   114,   114,    47,    52,    55,   112,    47,
-      57,     4,    55,   109,    44,    54,    56,    87,    88,    89,
-      98,   139,    50,    74,   139,     8,    64,    61,   114,     8,
-      80,    82,    48,    52,   113,   113,   107,   107,   108,   112,
-     104,    52,    47,     8,    73,    75,    48,    46,    61,    65,
-      66,    47,    83,   139,    48,    55,   112,    55,   109,    57,
-      89,    47,    76,   139,    47,    80,     8,    43,    49,    84,
-      85,    93,    95,   126,   132,   113,   107,    73,    43,    49,
-      77,    85,    93,    95,   126,    61,    50,    43,   125,   125,
-     125,   125,   133,   139,    43,   124,   124,   124,   125,   127,
-      17,    18,    19,    43,    49,    93,    95,   134,   136,   137,
-     138,     8,   128,   129,   135,    50,    43,    43,    47,   114,
-     128,    50
-};
-
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
-
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
-
-
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  However,
-   YYFAIL appears to be in use.  Nevertheless, it is formally deprecated
-   in Bison 2.4.2's NEWS entry, where a plan to phase it out is
-   discussed.  */
-
-#define YYFAIL		goto yyerrlab
-#if defined YYFAIL
-  /* This is here to suppress warnings from the GCC cpp's
-     -Wunused-macros.  Normally we don't worry about that warning, but
-     some users do, and we want to make it easy for users to remove
-     YYFAIL uses, which will produce warnings from Bison 2.5.  */
-#endif
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)					\
-do								\
-  if (yychar == YYEMPTY && yylen == 1)				\
-    {								\
-      yychar = (Token);						\
-      yylval = (Value);						\
-      yytoken = YYTRANSLATE (yychar);				\
-      YYPOPSTACK (1);						\
-      goto yybackup;						\
-    }								\
-  else								\
-    {								\
+#define YYBACKUP(Token, Value)                                  \
+do                                                              \
+  if (yychar == YYEMPTY)                                        \
+    {                                                           \
+      yychar = (Token);                                         \
+      yylval = (Value);                                         \
+      YYPOPSTACK (yylen);                                       \
+      yystate = *yyssp;                                         \
+      goto yybackup;                                            \
+    }                                                           \
+  else                                                          \
+    {                                                           \
       yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;							\
-    }								\
-while (YYID (0))
+      YYERROR;                                                  \
+    }                                                           \
+while (0)
+
+/* Error token number */
+#define YYTERROR        1
+#define YYERRCODE       256
 
 
-#define YYTERROR	1
-#define YYERRCODE	256
-
-
-/* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
-   If N is 0, then set CURRENT to the empty location which ends
-   the previous symbol: RHS[0] (always defined).  */
-
-#define YYRHSLOC(Rhs, K) ((Rhs)[K])
-#ifndef YYLLOC_DEFAULT
-# define YYLLOC_DEFAULT(Current, Rhs, N)				\
-    do									\
-      if (YYID (N))                                                    \
-	{								\
-	  (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;	\
-	  (Current).first_column = YYRHSLOC (Rhs, 1).first_column;	\
-	  (Current).last_line    = YYRHSLOC (Rhs, N).last_line;		\
-	  (Current).last_column  = YYRHSLOC (Rhs, N).last_column;	\
-	}								\
-      else								\
-	{								\
-	  (Current).first_line   = (Current).last_line   =		\
-	    YYRHSLOC (Rhs, 0).last_line;				\
-	  (Current).first_column = (Current).last_column =		\
-	    YYRHSLOC (Rhs, 0).last_column;				\
-	}								\
-    while (YYID (0))
-#endif
-
-
-/* YY_LOCATION_PRINT -- Print the location on the stream.
-   This macro was not mandated originally: define only if we know
-   we won't break user code: when these are the locations we know.  */
-
-#ifndef YY_LOCATION_PRINT
-# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-#  define YY_LOCATION_PRINT(File, Loc)			\
-     fprintf (File, "%d.%d-%d.%d",			\
-	      (Loc).first_line, (Loc).first_column,	\
-	      (Loc).last_line,  (Loc).last_column)
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
-
-
-/* YYLEX -- calling `yylex' with the right arguments.  */
-
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (YYLEX_PARAM)
-#else
-# define YYLEX yylex ()
-#endif
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
@@ -1108,54 +995,46 @@ while (YYID (0))
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
-do {									  \
-  if (yydebug)								  \
-    {									  \
-      YYFPRINTF (stderr, "%s ", Title);					  \
-      yy_symbol_print (stderr,						  \
-		  Type, Value); \
-      YYFPRINTF (stderr, "\n");						  \
-    }									  \
-} while (YYID (0))
+/* This macro is provided for backward compatibility. */
+#ifndef YY_LOCATION_PRINT
+# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
+#endif
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Type, Value); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+
+/*----------------------------------------.
+| Print this symbol's value on YYOUTPUT.  |
+`----------------------------------------*/
+
 static void
 yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
-#else
-static void
-yy_symbol_value_print (yyoutput, yytype, yyvaluep)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-#endif
 {
+  FILE *yyo = yyoutput;
+  YYUSE (yyo);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
     YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
 # endif
-  switch (yytype)
-    {
-      default:
-	break;
-    }
+  YYUSE (yytype);
 }
 
 
@@ -1163,22 +1042,11 @@ yy_symbol_value_print (yyoutput, yytype, yyvaluep)
 | Print this symbol on YYOUTPUT.  |
 `--------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
-#else
-static void
-yy_symbol_print (yyoutput, yytype, yyvaluep)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-#endif
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyoutput, "%s %s (",
+             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
   yy_symbol_value_print (yyoutput, yytype, yyvaluep);
   YYFPRINTF (yyoutput, ")");
@@ -1189,16 +1057,8 @@ yy_symbol_print (yyoutput, yytype, yyvaluep)
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
-#else
-static void
-yy_stack_print (yybottom, yytop)
-    yytype_int16 *yybottom;
-    yytype_int16 *yytop;
-#endif
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -1209,49 +1069,42 @@ yy_stack_print (yybottom, yytop)
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
-} while (YYID (0))
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (YYSTYPE *yyvsp, int yyrule)
-#else
-static void
-yy_reduce_print (yyvsp, yyrule)
-    YYSTYPE *yyvsp;
-    int yyrule;
-#endif
+yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
 {
+  unsigned long int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned long int yylno = yyrline[yyrule];
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-	     yyrule - 1, yylno);
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(yyvsp[(yyi + 1) - (yynrhs)])
-		       		       );
+      yy_symbol_print (stderr,
+                       yystos[yyssp[yyi + 1 - yynrhs]],
+                       &(yyvsp[(yyi + 1) - (yynrhs)])
+                                              );
       YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (yyvsp, Rule); \
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, Rule); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
@@ -1265,7 +1118,7 @@ int yydebug;
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -1280,7 +1133,6 @@ int yydebug;
 # define YYMAXDEPTH 10000
 #endif
 
-
 
 #if YYERROR_VERBOSE
 
@@ -1289,15 +1141,8 @@ int yydebug;
 #   define yystrlen strlen
 #  else
 /* Return the length of YYSTR.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static YYSIZE_T
 yystrlen (const char *yystr)
-#else
-static YYSIZE_T
-yystrlen (yystr)
-    const char *yystr;
-#endif
 {
   YYSIZE_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
@@ -1313,16 +1158,8 @@ yystrlen (yystr)
 #  else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static char *
 yystpcpy (char *yydest, const char *yysrc)
-#else
-static char *
-yystpcpy (yydest, yysrc)
-    char *yydest;
-    const char *yysrc;
-#endif
 {
   char *yyd = yydest;
   const char *yys = yysrc;
@@ -1352,27 +1189,27 @@ yytnamerr (char *yyres, const char *yystr)
       char const *yyp = yystr;
 
       for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
 
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            /* Fall through.  */
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
 
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
     do_not_strip_quotes: ;
     }
 
@@ -1383,161 +1220,160 @@ yytnamerr (char *yyres, const char *yystr)
 }
 # endif
 
-/* Copy into YYRESULT an error message about the unexpected token
-   YYCHAR while in state YYSTATE.  Return the number of bytes copied,
-   including the terminating null byte.  If YYRESULT is null, do not
-   copy anything; just return the number of bytes that would be
-   copied.  As a special case, return 0 if an ordinary "syntax error"
-   message will do.  Return YYSIZE_MAXIMUM if overflow occurs during
-   size calculation.  */
-static YYSIZE_T
-yysyntax_error (char *yyresult, int yystate, int yychar)
+/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
+   about the unexpected token YYTOKEN for the state stack whose top is
+   YYSSP.
+
+   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
+   not large enough to hold the message.  In that case, also set
+   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
+   required number of bytes is too large to store.  */
+static int
+yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
+                yytype_int16 *yyssp, int yytoken)
 {
-  int yyn = yypact[yystate];
+  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
+  YYSIZE_T yysize = yysize0;
+  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat. */
+  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
+  /* Number of reported tokens (one for the "unexpected", one per
+     "expected"). */
+  int yycount = 0;
 
-  if (! (YYPACT_NINF < yyn && yyn <= YYLAST))
-    return 0;
-  else
+  /* There are many possibilities here to consider:
+     - If this state is a consistent state with a default action, then
+       the only way this function was invoked is if the default action
+       is an error action.  In that case, don't check for expected
+       tokens because there are none.
+     - The only way there can be no lookahead present (in yychar) is if
+       this state is a consistent state with a default action.  Thus,
+       detecting the absence of a lookahead is sufficient to determine
+       that there is no unexpected or expected token to report.  In that
+       case, just report a simple "syntax error".
+     - Don't assume there isn't a lookahead just because this state is a
+       consistent state with a default action.  There might have been a
+       previous inconsistent state, consistent state with a non-default
+       action, or user semantic action that manipulated yychar.
+     - Of course, the expected token list depends on states to have
+       correct lookahead information, and it depends on the parser not
+       to perform extra reductions after fetching a lookahead from the
+       scanner and before detecting a syntax error.  Thus, state merging
+       (from LALR or IELR) and default reductions corrupt the expected
+       token list.  However, the list is correct for canonical LR with
+       one exception: it will still contain any token that will not be
+       accepted due to an error action in a later state.
+  */
+  if (yytoken != YYEMPTY)
     {
-      int yytype = YYTRANSLATE (yychar);
-      YYSIZE_T yysize0 = yytnamerr (0, yytname[yytype]);
-      YYSIZE_T yysize = yysize0;
-      YYSIZE_T yysize1;
-      int yysize_overflow = 0;
-      enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-      char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-      int yyx;
+      int yyn = yypact[*yyssp];
+      yyarg[yycount++] = yytname[yytoken];
+      if (!yypact_value_is_default (yyn))
+        {
+          /* Start YYX at -YYN if negative to avoid negative indexes in
+             YYCHECK.  In other words, skip the first -YYN actions for
+             this state because they are default actions.  */
+          int yyxbegin = yyn < 0 ? -yyn : 0;
+          /* Stay within bounds of both yycheck and yytname.  */
+          int yychecklim = YYLAST - yyn + 1;
+          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+          int yyx;
 
-# if 0
-      /* This is so xgettext sees the translatable formats that are
-	 constructed on the fly.  */
-      YY_("syntax error, unexpected %s");
-      YY_("syntax error, unexpected %s, expecting %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s");
-# endif
-      char *yyfmt;
-      char const *yyf;
-      static char const yyunexpected[] = "syntax error, unexpected %s";
-      static char const yyexpecting[] = ", expecting %s";
-      static char const yyor[] = " or %s";
-      char yyformat[sizeof yyunexpected
-		    + sizeof yyexpecting - 1
-		    + ((YYERROR_VERBOSE_ARGS_MAXIMUM - 2)
-		       * (sizeof yyor - 1))];
-      char const *yyprefix = yyexpecting;
-
-      /* Start YYX at -YYN if negative to avoid negative indexes in
-	 YYCHECK.  */
-      int yyxbegin = yyn < 0 ? -yyn : 0;
-
-      /* Stay within bounds of both yycheck and yytname.  */
-      int yychecklim = YYLAST - yyn + 1;
-      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-      int yycount = 1;
-
-      yyarg[0] = yytname[yytype];
-      yyfmt = yystpcpy (yyformat, yyunexpected);
-
-      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-	if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR)
-	  {
-	    if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-	      {
-		yycount = 1;
-		yysize = yysize0;
-		yyformat[sizeof yyunexpected - 1] = '\0';
-		break;
-	      }
-	    yyarg[yycount++] = yytname[yyx];
-	    yysize1 = yysize + yytnamerr (0, yytname[yyx]);
-	    yysize_overflow |= (yysize1 < yysize);
-	    yysize = yysize1;
-	    yyfmt = yystpcpy (yyfmt, yyprefix);
-	    yyprefix = yyor;
-	  }
-
-      yyf = YY_(yyformat);
-      yysize1 = yysize + yystrlen (yyf);
-      yysize_overflow |= (yysize1 < yysize);
-      yysize = yysize1;
-
-      if (yysize_overflow)
-	return YYSIZE_MAXIMUM;
-
-      if (yyresult)
-	{
-	  /* Avoid sprintf, as that infringes on the user's name space.
-	     Don't have undefined behavior even if the translation
-	     produced a string with the wrong number of "%s"s.  */
-	  char *yyp = yyresult;
-	  int yyi = 0;
-	  while ((*yyp = *yyf) != '\0')
-	    {
-	      if (*yyp == '%' && yyf[1] == 's' && yyi < yycount)
-		{
-		  yyp += yytnamerr (yyp, yyarg[yyi++]);
-		  yyf += 2;
-		}
-	      else
-		{
-		  yyp++;
-		  yyf++;
-		}
-	    }
-	}
-      return yysize;
+          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
+                && !yytable_value_is_error (yytable[yyx + yyn]))
+              {
+                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
+                  {
+                    yycount = 1;
+                    yysize = yysize0;
+                    break;
+                  }
+                yyarg[yycount++] = yytname[yyx];
+                {
+                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
+                  if (! (yysize <= yysize1
+                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+                    return 2;
+                  yysize = yysize1;
+                }
+              }
+        }
     }
+
+  switch (yycount)
+    {
+# define YYCASE_(N, S)                      \
+      case N:                               \
+        yyformat = S;                       \
+      break
+      YYCASE_(0, YY_("syntax error"));
+      YYCASE_(1, YY_("syntax error, unexpected %s"));
+      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
+      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
+      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
+      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
+# undef YYCASE_
+    }
+
+  {
+    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
+    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+      return 2;
+    yysize = yysize1;
+  }
+
+  if (*yymsg_alloc < yysize)
+    {
+      *yymsg_alloc = 2 * yysize;
+      if (! (yysize <= *yymsg_alloc
+             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
+        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
+      return 1;
+    }
+
+  /* Avoid sprintf, as that infringes on the user's name space.
+     Don't have undefined behavior even if the translation
+     produced a string with the wrong number of "%s"s.  */
+  {
+    char *yyp = *yymsg;
+    int yyi = 0;
+    while ((*yyp = *yyformat) != '\0')
+      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
+        {
+          yyp += yytnamerr (yyp, yyarg[yyi++]);
+          yyformat += 2;
+        }
+      else
+        {
+          yyp++;
+          yyformat++;
+        }
+  }
+  return 0;
 }
 #endif /* YYERROR_VERBOSE */
-
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep)
-#else
-static void
-yydestruct (yymsg, yytype, yyvaluep)
-    const char *yymsg;
-    int yytype;
-    YYSTYPE *yyvaluep;
-#endif
 {
   YYUSE (yyvaluep);
-
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
-  switch (yytype)
-    {
-
-      default:
-	break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
-/* Prevent warnings from -Wmissing-prototypes.  */
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void *YYPARSE_PARAM);
-#else
-int yyparse ();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void);
-#else
-int yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
+
 
 
 /* The lookahead symbol.  */
@@ -1545,49 +1381,26 @@ int yychar;
 
 /* The semantic value of the lookahead symbol.  */
 YYSTYPE yylval;
-
 /* Number of syntax errors so far.  */
 int yynerrs;
 
 
+/*----------.
+| yyparse.  |
+`----------*/
 
-/*-------------------------.
-| yyparse or yypush_parse.  |
-`-------------------------*/
-
-#ifdef YYPARSE_PARAM
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-int
-yyparse (void *YYPARSE_PARAM)
-#else
-int
-yyparse (YYPARSE_PARAM)
-    void *YYPARSE_PARAM;
-#endif
-#else /* ! YYPARSE_PARAM */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 int
 yyparse (void)
-#else
-int
-yyparse ()
-
-#endif
-#endif
 {
-
-
     int yystate;
     /* Number of tokens to shift before error messages enabled.  */
     int yyerrstatus;
 
     /* The stacks and their tools:
-       `yyss': related to states.
-       `yyvs': related to semantic values.
+       'yyss': related to states.
+       'yyvs': related to semantic values.
 
-       Refer to the stacks thru separate pointers, to allow yyoverflow
+       Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
     /* The state stack.  */
@@ -1605,7 +1418,7 @@ yyparse ()
   int yyn;
   int yyresult;
   /* Lookahead token as an internal (translated) token number.  */
-  int yytoken;
+  int yytoken = 0;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
@@ -1623,9 +1436,8 @@ yyparse ()
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yytoken = 0;
-  yyss = yyssa;
-  yyvs = yyvsa;
+  yyssp = yyss = yyssa;
+  yyvsp = yyvs = yyvsa;
   yystacksize = YYINITDEPTH;
 
   YYDPRINTF ((stderr, "Starting parse\n"));
@@ -1634,14 +1446,6 @@ yyparse ()
   yyerrstatus = 0;
   yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
-
-  /* Initialize stack pointers.
-     Waste one element of value and location stack
-     so that they stay on the same level as the state stack.
-     The wasted elements are never initialized.  */
-  yyssp = yyss;
-  yyvsp = yyvs;
-
   goto yysetstate;
 
 /*------------------------------------------------------------.
@@ -1662,23 +1466,23 @@ yyparse ()
 
 #ifdef yyoverflow
       {
-	/* Give user a chance to reallocate the stack.  Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	yytype_int16 *yyss1 = yyss;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        YYSTYPE *yyvs1 = yyvs;
+        yytype_int16 *yyss1 = yyss;
 
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow (YY_("memory exhausted"),
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-		    &yystacksize);
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * sizeof (*yyssp),
+                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yystacksize);
 
-	yyss = yyss1;
-	yyvs = yyvs1;
+        yyss = yyss1;
+        yyvs = yyvs1;
       }
 #else /* no yyoverflow */
 # ifndef YYSTACK_RELOCATE
@@ -1686,22 +1490,22 @@ yyparse ()
 # else
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyexhaustedlab;
+        goto yyexhaustedlab;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	yytype_int16 *yyss1 = yyss;
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss_alloc, yyss);
-	YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+        yytype_int16 *yyss1 = yyss;
+        union yyalloc *yyptr =
+          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+        if (! yyptr)
+          goto yyexhaustedlab;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
 #endif /* no yyoverflow */
@@ -1710,10 +1514,10 @@ yyparse ()
       yyvsp = yyvs + yysize - 1;
 
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
+                  (unsigned long int) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
+        YYABORT;
     }
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
@@ -1733,7 +1537,7 @@ yybackup:
 
   /* First try to decide what to do without reference to lookahead token.  */
   yyn = yypact[yystate];
-  if (yyn == YYPACT_NINF)
+  if (yypact_value_is_default (yyn))
     goto yydefault;
 
   /* Not known => get a lookahead token if don't already have one.  */
@@ -1742,7 +1546,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = YYLEX;
+      yychar = yylex ();
     }
 
   if (yychar <= YYEOF)
@@ -1764,8 +1568,8 @@ yybackup:
   yyn = yytable[yyn];
   if (yyn <= 0)
     {
-      if (yyn == 0 || yyn == YYTABLE_NINF)
-	goto yyerrlab;
+      if (yytable_value_is_error (yyn))
+        goto yyerrlab;
       yyn = -yyn;
       goto yyreduce;
     }
@@ -1782,7 +1586,9 @@ yybackup:
   yychar = YYEMPTY;
 
   yystate = yyn;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
   goto yynewstate;
 
@@ -1805,7 +1611,7 @@ yyreduce:
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -1819,112 +1625,100 @@ yyreduce:
   switch (yyn)
     {
         case 4:
-
-/* Line 1464 of yacc.c  */
-#line 171 "dcParser.yxx"
+#line 177 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  parameter_description = (yyvsp[(2) - (2)].u.field);
+  parameter_description = (yyvsp[0].u.field);
 }
+#line 1633 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 7:
-
-/* Line 1464 of yacc.c  */
-#line 180 "dcParser.yxx"
+#line 186 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (!dc_file->add_class((yyvsp[(2) - (2)].u.dclass))) {
-    DCClass *old_class = dc_file->get_class_by_name((yyvsp[(2) - (2)].u.dclass)->get_name());
-    if (old_class != (DCClass *)NULL && old_class->is_bogus_class()) {
-      yyerror("Base class defined after its first reference: " + (yyvsp[(2) - (2)].u.dclass)->get_name());
+  if (!dc_file->add_class((yyvsp[0].u.dclass))) {
+    DCClass *old_class = dc_file->get_class_by_name((yyvsp[0].u.dclass)->get_name());
+    if (old_class != nullptr && old_class->is_bogus_class()) {
+      yyerror("Base class defined after its first reference: " + (yyvsp[0].u.dclass)->get_name());
     } else {
-      yyerror("Duplicate class name: " + (yyvsp[(2) - (2)].u.dclass)->get_name());
+      yyerror("Duplicate class name: " + (yyvsp[0].u.dclass)->get_name());
     }
   }
 }
+#line 1648 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 8:
-
-/* Line 1464 of yacc.c  */
-#line 191 "dcParser.yxx"
+#line 197 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (!dc_file->add_switch((yyvsp[(2) - (2)].u.dswitch))) {
-    yyerror("Duplicate class name: " + (yyvsp[(2) - (2)].u.dswitch)->get_name());
+  if (!dc_file->add_switch((yyvsp[0].u.dswitch))) {
+    yyerror("Duplicate class name: " + (yyvsp[0].u.dswitch)->get_name());
   }
 }
+#line 1658 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 13:
-
-/* Line 1464 of yacc.c  */
-#line 204 "dcParser.yxx"
+#line 210 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.str) = (yyvsp[(1) - (3)].str) + string("/") + (yyvsp[(3) - (3)].str);
+  (yyval.str) = (yyvsp[-2].str) + string("/") + (yyvsp[0].str);
 }
+#line 1666 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 15:
-
-/* Line 1464 of yacc.c  */
-#line 212 "dcParser.yxx"
+#line 218 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.str) = (yyvsp[(1) - (3)].str) + string(".") + (yyvsp[(3) - (3)].str);
+  (yyval.str) = (yyvsp[-2].str) + string(".") + (yyvsp[0].str);
 }
+#line 1674 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 16:
-
-/* Line 1464 of yacc.c  */
-#line 219 "dcParser.yxx"
+#line 225 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  dc_file->add_import_module((yyvsp[(2) - (2)].str));
+  dc_file->add_import_module((yyvsp[0].str));
 }
+#line 1682 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 17:
-
-/* Line 1464 of yacc.c  */
-#line 223 "dcParser.yxx"
+#line 229 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  dc_file->add_import_module((yyvsp[(2) - (3)].str));
+  dc_file->add_import_module((yyvsp[-1].str));
 }
+#line 1690 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 20:
-
-/* Line 1464 of yacc.c  */
-#line 232 "dcParser.yxx"
+#line 238 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   dc_file->add_import_symbol("*");
 }
+#line 1698 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 21:
-
-/* Line 1464 of yacc.c  */
-#line 239 "dcParser.yxx"
+#line 245 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  dc_file->add_import_symbol((yyvsp[(1) - (1)].str));
+  dc_file->add_import_symbol((yyvsp[0].str));
 }
+#line 1706 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 22:
-
-/* Line 1464 of yacc.c  */
-#line 243 "dcParser.yxx"
+#line 249 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  dc_file->add_import_symbol((yyvsp[(3) - (3)].str));
+  dc_file->add_import_symbol((yyvsp[0].str));
 }
+#line 1714 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 23:
-
-/* Line 1464 of yacc.c  */
-#line 250 "dcParser.yxx"
+#line 256 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(2) - (2)].u.parameter) != (DCParameter *)NULL) {
-    DCTypedef *dtypedef = new DCTypedef((yyvsp[(2) - (2)].u.parameter));
-    
+  if ((yyvsp[0].u.parameter) != nullptr) {
+    DCTypedef *dtypedef = new DCTypedef((yyvsp[0].u.parameter));
+
     if (!dc_file->add_typedef(dtypedef)) {
       DCTypedef *old_typedef = dc_file->get_typedef_by_name(dtypedef->get_name());
       if (old_typedef->is_bogus_typedef()) {
@@ -1935,343 +1729,316 @@ yyreduce:
     }
   }
 }
+#line 1733 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 26:
-
-/* Line 1464 of yacc.c  */
-#line 273 "dcParser.yxx"
+#line 279 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  dc_file->add_keyword((yyvsp[(2) - (2)].str));
+  dc_file->add_keyword((yyvsp[0].str));
 }
+#line 1741 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 27:
-
-/* Line 1464 of yacc.c  */
-#line 277 "dcParser.yxx"
+#line 283 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   // This keyword has already been defined.  But since we are now
   // explicitly defining it, clear its bitmask, so that we will have a
   // new hash code--doing this will allow us to phase out the
   // historical hash code support later.
-  ((DCKeyword *)(yyvsp[(2) - (2)].u.keyword))->clear_historical_flag();
+  ((DCKeyword *)(yyvsp[0].u.keyword))->clear_historical_flag();
 }
+#line 1753 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 30:
-
-/* Line 1464 of yacc.c  */
-#line 293 "dcParser.yxx"
+#line 299 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_class = new DCClass(dc_file, (yyvsp[(2) - (2)].str), false, false);
+  current_class = new DCClass(dc_file, (yyvsp[0].str), false, false);
 }
+#line 1761 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 31:
-
-/* Line 1464 of yacc.c  */
-#line 297 "dcParser.yxx"
+#line 303 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.dclass) = current_class;
-  current_class = (yyvsp[(3) - (7)].u.dclass);
+  current_class = (yyvsp[-4].u.dclass);
 }
+#line 1770 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 32:
-
-/* Line 1464 of yacc.c  */
-#line 305 "dcParser.yxx"
+#line 311 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (dc_file == (DCFile *)NULL) {
+  if (dc_file == nullptr) {
     yyerror("No DCFile available, so no class names are predefined.");
-    (yyval.u.dclass) = NULL;
+    (yyval.u.dclass) = nullptr;
 
   } else {
-    DCClass *dclass = dc_file->get_class_by_name((yyvsp[(1) - (1)].str));
-    if (dclass == (DCClass *)NULL) {
+    DCClass *dclass = dc_file->get_class_by_name((yyvsp[0].str));
+    if (dclass == nullptr) {
       // Create a bogus class as a forward reference.
-      dclass = new DCClass(dc_file, (yyvsp[(1) - (1)].str), false, true);
+      dclass = new DCClass(dc_file, (yyvsp[0].str), false, true);
       dc_file->add_class(dclass);
     }
     if (dclass->is_struct()) {
       yyerror("struct name not allowed");
     }
-  
+
     (yyval.u.dclass) = dclass;
   }
 }
+#line 1794 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 35:
-
-/* Line 1464 of yacc.c  */
-#line 333 "dcParser.yxx"
+#line 339 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (1)].u.dclass) != (DCClass *)NULL) {
-    current_class->add_parent((yyvsp[(1) - (1)].u.dclass));
+  if ((yyvsp[0].u.dclass) != nullptr) {
+    current_class->add_parent((yyvsp[0].u.dclass));
   }
 }
+#line 1804 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 36:
-
-/* Line 1464 of yacc.c  */
-#line 339 "dcParser.yxx"
+#line 345 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   if (!dc_multiple_inheritance) {
     yyerror("Multiple inheritance is not supported without \"dc-multiple-inheritance 1\" in your Config.prc file.");
 
   } else {
-    if ((yyvsp[(3) - (3)].u.dclass) != (DCClass *)NULL) {
-      current_class->add_parent((yyvsp[(3) - (3)].u.dclass));
+    if ((yyvsp[0].u.dclass) != nullptr) {
+      current_class->add_parent((yyvsp[0].u.dclass));
     }
   }
 }
+#line 1819 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 39:
-
-/* Line 1464 of yacc.c  */
-#line 355 "dcParser.yxx"
+#line 361 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(2) - (3)].u.field) == (DCField *)NULL) {
+  if ((yyvsp[-1].u.field) == nullptr) {
     // Pass this error up.
-  } else if (!current_class->add_field((yyvsp[(2) - (3)].u.field))) {
-    yyerror("Duplicate field name: " + (yyvsp[(2) - (3)].u.field)->get_name());
-  } else if ((yyvsp[(2) - (3)].u.field)->get_number() < 0) {
+  } else if (!current_class->add_field((yyvsp[-1].u.field))) {
+    yyerror("Duplicate field name: " + (yyvsp[-1].u.field)->get_name());
+  } else if ((yyvsp[-1].u.field)->get_number() < 0) {
     yyerror("A non-network field cannot be stored on a dclass");
   }
 }
+#line 1833 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 40:
-
-/* Line 1464 of yacc.c  */
-#line 368 "dcParser.yxx"
+#line 374 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (2)].u.field) != (DCField *)NULL) {
-    if ((yyvsp[(1) - (2)].u.field)->get_name().empty()) {
+  if ((yyvsp[-1].u.field) != nullptr) {
+    if ((yyvsp[-1].u.field)->get_name().empty()) {
       yyerror("Field name required.");
     }
-    (yyvsp[(1) - (2)].u.field)->copy_keywords(current_keyword_list);
+    (yyvsp[-1].u.field)->copy_keywords(current_keyword_list);
   }
-  (yyval.u.field) = (yyvsp[(1) - (2)].u.field);
+  (yyval.u.field) = (yyvsp[-1].u.field);
 }
+#line 1847 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 42:
-
-/* Line 1464 of yacc.c  */
-#line 379 "dcParser.yxx"
+#line 385 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   yyerror("Unnamed parameters are not allowed on a dclass");
-  if ((yyvsp[(1) - (2)].u.parameter) != (DCField *)NULL) {
-    (yyvsp[(1) - (2)].u.parameter)->copy_keywords(current_keyword_list);
+  if ((yyvsp[-1].u.parameter) != nullptr) {
+    (yyvsp[-1].u.parameter)->copy_keywords(current_keyword_list);
   }
-  (yyval.u.field) = (yyvsp[(1) - (2)].u.parameter);
+  (yyval.u.field) = (yyvsp[-1].u.parameter);
 }
+#line 1859 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 43:
-
-/* Line 1464 of yacc.c  */
-#line 387 "dcParser.yxx"
+#line 393 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (2)].u.parameter) != (DCField *)NULL) {
-    (yyvsp[(1) - (2)].u.parameter)->copy_keywords(current_keyword_list);
+  if ((yyvsp[-1].u.parameter) != nullptr) {
+    (yyvsp[-1].u.parameter)->copy_keywords(current_keyword_list);
   }
-  (yyval.u.field) = (yyvsp[(1) - (2)].u.parameter);
+  (yyval.u.field) = (yyvsp[-1].u.parameter);
 }
+#line 1870 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 44:
-
-/* Line 1464 of yacc.c  */
-#line 397 "dcParser.yxx"
+#line 403 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_class = new DCClass(dc_file, (yyvsp[(2) - (2)].str), true, false);
+  current_class = new DCClass(dc_file, (yyvsp[0].str), true, false);
 }
+#line 1878 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 45:
-
-/* Line 1464 of yacc.c  */
-#line 401 "dcParser.yxx"
+#line 407 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.dclass) = current_class;
-  current_class = (yyvsp[(3) - (7)].u.dclass);
+  current_class = (yyvsp[-4].u.dclass);
 }
+#line 1887 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 46:
-
-/* Line 1464 of yacc.c  */
-#line 409 "dcParser.yxx"
+#line 415 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (dc_file == (DCFile *)NULL) {
+  if (dc_file == nullptr) {
     yyerror("No DCFile available, so no struct names are predefined.");
-    (yyval.u.dclass) = NULL;
+    (yyval.u.dclass) = nullptr;
 
   } else {
-    DCClass *dstruct = dc_file->get_class_by_name((yyvsp[(1) - (1)].str));
-    if (dstruct == (DCClass *)NULL) {
+    DCClass *dstruct = dc_file->get_class_by_name((yyvsp[0].str));
+    if (dstruct == nullptr) {
       // Create a bogus class as a forward reference.
-      dstruct = new DCClass(dc_file, (yyvsp[(1) - (1)].str), false, true);
+      dstruct = new DCClass(dc_file, (yyvsp[0].str), false, true);
       dc_file->add_class(dstruct);
     }
     if (!dstruct->is_struct()) {
       yyerror("struct name required");
     }
-  
+
     (yyval.u.dclass) = dstruct;
   }
 }
+#line 1911 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 49:
-
-/* Line 1464 of yacc.c  */
-#line 437 "dcParser.yxx"
+#line 443 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (1)].u.dclass) != (DCClass *)NULL) {
-    current_class->add_parent((yyvsp[(1) - (1)].u.dclass));
+  if ((yyvsp[0].u.dclass) != nullptr) {
+    current_class->add_parent((yyvsp[0].u.dclass));
   }
 }
+#line 1921 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 50:
-
-/* Line 1464 of yacc.c  */
-#line 443 "dcParser.yxx"
+#line 449 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(3) - (3)].u.dclass) != (DCClass *)NULL) {
-    current_class->add_parent((yyvsp[(3) - (3)].u.dclass));
+  if ((yyvsp[0].u.dclass) != nullptr) {
+    current_class->add_parent((yyvsp[0].u.dclass));
   }
 }
+#line 1931 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 53:
-
-/* Line 1464 of yacc.c  */
-#line 454 "dcParser.yxx"
+#line 460 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(2) - (3)].u.field) == (DCField *)NULL) {
+  if ((yyvsp[-1].u.field) == nullptr) {
     // Pass this error up.
-  } else if (!current_class->add_field((yyvsp[(2) - (3)].u.field))) {
-    yyerror("Duplicate field name: " + (yyvsp[(2) - (3)].u.field)->get_name());
+  } else if (!current_class->add_field((yyvsp[-1].u.field))) {
+    yyerror("Duplicate field name: " + (yyvsp[-1].u.field)->get_name());
   }
 }
+#line 1943 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 54:
-
-/* Line 1464 of yacc.c  */
-#line 465 "dcParser.yxx"
+#line 471 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (2)].u.field)->get_name().empty()) {
+  if ((yyvsp[-1].u.field)->get_name().empty()) {
     yyerror("Field name required.");
   }
-  (yyval.u.field) = (yyvsp[(1) - (2)].u.field);
+  (yyval.u.field) = (yyvsp[-1].u.field);
 }
+#line 1954 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 56:
-
-/* Line 1464 of yacc.c  */
-#line 473 "dcParser.yxx"
+#line 479 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.field) = (yyvsp[(1) - (2)].u.parameter);
+  (yyval.u.field) = (yyvsp[-1].u.parameter);
 }
+#line 1962 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 57:
-
-/* Line 1464 of yacc.c  */
-#line 477 "dcParser.yxx"
+#line 483 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.field) = (yyvsp[(1) - (2)].u.parameter);
+  (yyval.u.field) = (yyvsp[-1].u.parameter);
 }
+#line 1970 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 58:
-
-/* Line 1464 of yacc.c  */
-#line 484 "dcParser.yxx"
+#line 490 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (current_class == (DCClass *)NULL) {
+  if (current_class == nullptr) {
     yyerror("Cannot define a method outside of a struct or class.");
     DCClass *temp_class = new DCClass(dc_file, "temp", false, false);  // memory leak.
-    current_atomic = new DCAtomicField((yyvsp[(1) - (2)].str), temp_class, false);
+    current_atomic = new DCAtomicField((yyvsp[-1].str), temp_class, false);
   } else {
-    current_atomic = new DCAtomicField((yyvsp[(1) - (2)].str), current_class, false);
+    current_atomic = new DCAtomicField((yyvsp[-1].str), current_class, false);
   }
 }
+#line 1984 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 59:
-
-/* Line 1464 of yacc.c  */
-#line 494 "dcParser.yxx"
+#line 500 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.field) = current_atomic;
-  current_atomic = (yyvsp[(3) - (5)].u.atomic);
+  current_atomic = (yyvsp[-2].u.atomic);
 }
+#line 1993 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 64:
-
-/* Line 1464 of yacc.c  */
-#line 512 "dcParser.yxx"
+#line 518 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (1)].u.parameter) != (DCParameter *)NULL) {
-    current_atomic->add_element((yyvsp[(1) - (1)].u.parameter));
+  if ((yyvsp[0].u.parameter) != nullptr) {
+    current_atomic->add_element((yyvsp[0].u.parameter));
   }
 }
+#line 2003 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 65:
-
-/* Line 1464 of yacc.c  */
-#line 521 "dcParser.yxx"
+#line 527 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_parameter = (yyvsp[(1) - (1)].u.parameter);
+  current_parameter = (yyvsp[0].u.parameter);
 }
+#line 2011 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 66:
-
-/* Line 1464 of yacc.c  */
-#line 525 "dcParser.yxx"
+#line 531 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.parameter) = (yyvsp[(3) - (3)].u.parameter);
+  (yyval.u.parameter) = (yyvsp[0].u.parameter);
 }
+#line 2019 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 69:
-
-/* Line 1464 of yacc.c  */
-#line 537 "dcParser.yxx"
+#line 543 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_packer = &default_packer;
   current_packer->clear_data();
-  if ((yyvsp[(1) - (2)].u.parameter) != (DCField *)NULL) {
-    current_packer->begin_pack((yyvsp[(1) - (2)].u.parameter));
+  if ((yyvsp[-1].u.parameter) != nullptr) {
+    current_packer->begin_pack((yyvsp[-1].u.parameter));
   }
 }
+#line 2031 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 70:
-
-/* Line 1464 of yacc.c  */
-#line 545 "dcParser.yxx"
+#line 551 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   bool is_valid = false;
-  if ((yyvsp[(1) - (4)].u.parameter) != (DCField *)NULL) {
-    is_valid = (yyvsp[(1) - (4)].u.parameter)->is_valid();
+  if ((yyvsp[-3].u.parameter) != nullptr) {
+    is_valid = (yyvsp[-3].u.parameter)->is_valid();
   }
   if (current_packer->end_pack()) {
-    (yyvsp[(1) - (4)].u.parameter)->set_default_value(current_packer->get_string());
+    (yyvsp[-3].u.parameter)->set_default_value(current_packer->get_bytes());
 
   } else {
     if (is_valid) {
@@ -2282,32 +2049,30 @@ yyreduce:
     // just ignore the default value in this case.
   }
 }
+#line 2053 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 72:
-
-/* Line 1464 of yacc.c  */
-#line 567 "dcParser.yxx"
+#line 573 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_packer = &default_packer;
   current_packer->clear_data();
-  if ((yyvsp[(1) - (2)].u.parameter) != (DCField *)NULL) {
-    current_packer->begin_pack((yyvsp[(1) - (2)].u.parameter));
+  if ((yyvsp[-1].u.parameter) != nullptr) {
+    current_packer->begin_pack((yyvsp[-1].u.parameter));
   }
 }
+#line 2065 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 73:
-
-/* Line 1464 of yacc.c  */
-#line 575 "dcParser.yxx"
+#line 581 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   bool is_valid = false;
-  if ((yyvsp[(1) - (4)].u.parameter) != (DCField *)NULL) {
-    is_valid = (yyvsp[(1) - (4)].u.parameter)->is_valid();
+  if ((yyvsp[-3].u.parameter) != nullptr) {
+    is_valid = (yyvsp[-3].u.parameter)->is_valid();
   }
   if (current_packer->end_pack()) {
-    (yyvsp[(1) - (4)].u.parameter)->set_default_value(current_packer->get_string());
+    (yyvsp[-3].u.parameter)->set_default_value(current_packer->get_bytes());
 
   } else {
     if (is_valid) {
@@ -2318,87 +2083,79 @@ yyreduce:
     // just ignore the default value in this case.
   }
 }
+#line 2087 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 78:
-
-/* Line 1464 of yacc.c  */
-#line 606 "dcParser.yxx"
+#line 612 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.field) = (yyvsp[(1) - (1)].u.parameter);
+  (yyval.u.field) = (yyvsp[0].u.parameter);
 }
+#line 2095 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 79:
-
-/* Line 1464 of yacc.c  */
-#line 610 "dcParser.yxx"
+#line 616 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.field) = (yyvsp[(1) - (1)].u.field);
+  (yyval.u.field) = (yyvsp[0].u.field);
 }
+#line 2103 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 80:
-
-/* Line 1464 of yacc.c  */
-#line 617 "dcParser.yxx"
+#line 623 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.field) = (yyvsp[(1) - (2)].u.field);
+  (yyval.u.field) = (yyvsp[-1].u.field);
 }
+#line 2111 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 81:
-
-/* Line 1464 of yacc.c  */
-#line 621 "dcParser.yxx"
+#line 627 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.field) = (yyvsp[(1) - (2)].u.parameter);
+  (yyval.u.field) = (yyvsp[-1].u.parameter);
 }
+#line 2119 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 82:
-
-/* Line 1464 of yacc.c  */
-#line 625 "dcParser.yxx"
+#line 631 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.field) = (yyvsp[(1) - (2)].u.parameter);
+  (yyval.u.field) = (yyvsp[-1].u.parameter);
 }
+#line 2127 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 83:
-
-/* Line 1464 of yacc.c  */
-#line 632 "dcParser.yxx"
+#line 638 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.parameter) = new DCSimpleParameter((yyvsp[(1) - (1)].u.subatomic));
+  (yyval.u.parameter) = new DCSimpleParameter((yyvsp[0].u.subatomic));
 }
+#line 2135 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 84:
-
-/* Line 1464 of yacc.c  */
-#line 636 "dcParser.yxx"
+#line 642 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  DCSimpleParameter *simple_param = (yyvsp[(1) - (4)].u.parameter)->as_simple_parameter();
-  nassertr(simple_param != (DCSimpleParameter *)NULL, 0);
+  DCSimpleParameter *simple_param = (yyvsp[-3].u.parameter)->as_simple_parameter();
+  nassertr(simple_param != nullptr, 0);
   if (!simple_param->set_range(double_range)) {
     yyerror("Inappropriate range for type");
   }
   (yyval.u.parameter) = simple_param;
 }
+#line 2148 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 85:
-
-/* Line 1464 of yacc.c  */
-#line 645 "dcParser.yxx"
+#line 651 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  DCSimpleParameter *simple_param = (yyvsp[(1) - (3)].u.parameter)->as_simple_parameter();
-  nassertr(simple_param != (DCSimpleParameter *)NULL, 0);
+  DCSimpleParameter *simple_param = (yyvsp[-2].u.parameter)->as_simple_parameter();
+  nassertr(simple_param != nullptr, 0);
   if (!simple_param->is_numeric_type()) {
     yyerror("A divisor is only valid on a numeric type.");
 
-  } else if (!simple_param->set_divisor((yyvsp[(3) - (3)].u.s_uint))) {
+  } else if (!simple_param->set_divisor((yyvsp[0].u.s_uint))) {
     yyerror("Invalid divisor.");
 
   } else if (simple_param->has_modulus() && !simple_param->set_modulus(simple_param->get_modulus())) {
@@ -2407,982 +2164,907 @@ yyreduce:
   }
   (yyval.u.parameter) = simple_param;
 }
+#line 2168 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 86:
-
-/* Line 1464 of yacc.c  */
-#line 661 "dcParser.yxx"
-    { 
-  DCSimpleParameter *simple_param = (yyvsp[(1) - (3)].u.parameter)->as_simple_parameter();
-  nassertr(simple_param != (DCSimpleParameter *)NULL, 0);
+#line 667 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
+    {
+  DCSimpleParameter *simple_param = (yyvsp[-2].u.parameter)->as_simple_parameter();
+  nassertr(simple_param != nullptr, 0);
   if (!simple_param->is_numeric_type()) {
     yyerror("A divisor is only valid on a numeric type.");
 
-  } else if (!simple_param->set_modulus((yyvsp[(3) - (3)].u.real))) {
+  } else if (!simple_param->set_modulus((yyvsp[0].u.real))) {
     yyerror("Invalid modulus.");
   }
   (yyval.u.parameter) = simple_param;
 }
+#line 2184 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 88:
-
-/* Line 1464 of yacc.c  */
-#line 677 "dcParser.yxx"
+#line 683 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (dc_file == (DCFile *)NULL) {
+  if (dc_file == nullptr) {
     yyerror("Invalid type.");
-    (yyval.u.parameter) = NULL;
+    (yyval.u.parameter) = nullptr;
 
   } else {
-    DCTypedef *dtypedef = dc_file->get_typedef_by_name((yyvsp[(1) - (1)].str));
-    if (dtypedef == (DCTypedef *)NULL) {
+    DCTypedef *dtypedef = dc_file->get_typedef_by_name((yyvsp[0].str));
+    if (dtypedef == nullptr) {
       // Maybe it's a class name.
-      DCClass *dclass = dc_file->get_class_by_name((yyvsp[(1) - (1)].str));
-      if (dclass != (DCClass *)NULL) {
+      DCClass *dclass = dc_file->get_class_by_name((yyvsp[0].str));
+      if (dclass != nullptr) {
         // Create an implicit typedef for this.
         dtypedef = new DCTypedef(new DCClassParameter(dclass), true);
       } else {
         // Maybe it's a switch name.
-        DCSwitch *dswitch = dc_file->get_switch_by_name((yyvsp[(1) - (1)].str));
-        if (dswitch != (DCSwitch *)NULL) {
+        DCSwitch *dswitch = dc_file->get_switch_by_name((yyvsp[0].str));
+        if (dswitch != nullptr) {
           // This also gets an implicit typedef.
           dtypedef = new DCTypedef(new DCSwitchParameter(dswitch), true);
         } else {
           // It's an undefined typedef.  Create a bogus forward reference.
-          dtypedef = new DCTypedef((yyvsp[(1) - (1)].str));
+          dtypedef = new DCTypedef((yyvsp[0].str));
         }
       }
-      
+
       dc_file->add_typedef(dtypedef);
     }
-    
+
     (yyval.u.parameter) = dtypedef->make_new_parameter();
   }
 }
+#line 2220 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 89:
-
-/* Line 1464 of yacc.c  */
-#line 709 "dcParser.yxx"
+#line 715 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   // This is an inline struct definition.
-  if ((yyvsp[(1) - (1)].u.dclass) == (DCClass *)NULL) {
-    (yyval.u.parameter) = NULL;
+  if ((yyvsp[0].u.dclass) == nullptr) {
+    (yyval.u.parameter) = nullptr;
   } else {
-    if (dc_file != (DCFile *)NULL) {
-      dc_file->add_thing_to_delete((yyvsp[(1) - (1)].u.dclass));
+    if (dc_file != nullptr) {
+      dc_file->add_thing_to_delete((yyvsp[0].u.dclass));
     } else {
       // This is a memory leak--this happens when we put an anonymous
       // struct reference within the string passed to
       // DCPackerInterface::check_match().  Maybe it doesn't really matter.
     }
-    (yyval.u.parameter) = new DCClassParameter((yyvsp[(1) - (1)].u.dclass));
+    (yyval.u.parameter) = new DCClassParameter((yyvsp[0].u.dclass));
   }
 }
+#line 2240 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 90:
-
-/* Line 1464 of yacc.c  */
-#line 725 "dcParser.yxx"
+#line 731 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   // This is an inline switch definition.
-  if ((yyvsp[(1) - (1)].u.dswitch) == (DCSwitch *)NULL) {
-    (yyval.u.parameter) = NULL;
+  if ((yyvsp[0].u.dswitch) == nullptr) {
+    (yyval.u.parameter) = nullptr;
   } else {
-    if (dc_file != (DCFile *)NULL) {
-      dc_file->add_thing_to_delete((yyvsp[(1) - (1)].u.dswitch));
+    if (dc_file != nullptr) {
+      dc_file->add_thing_to_delete((yyvsp[0].u.dswitch));
     } else {
       // This is a memory leak--this happens when we put an anonymous
       // switch reference within the string passed to
       // DCPackerInterface::check_match().  Maybe it doesn't really matter.
     }
-    (yyval.u.parameter) = new DCSwitchParameter((yyvsp[(1) - (1)].u.dswitch));
+    (yyval.u.parameter) = new DCSwitchParameter((yyvsp[0].u.dswitch));
   }
 }
+#line 2260 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 91:
-
-/* Line 1464 of yacc.c  */
-#line 744 "dcParser.yxx"
+#line 750 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   double_range.clear();
 }
+#line 2268 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 92:
-
-/* Line 1464 of yacc.c  */
-#line 748 "dcParser.yxx"
+#line 754 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   double_range.clear();
-  if (!double_range.add_range((yyvsp[(1) - (1)].u.real), (yyvsp[(1) - (1)].u.real))) {
+  if (!double_range.add_range((yyvsp[0].u.real), (yyvsp[0].u.real))) {
     yyerror("Overlapping range");
   }
 }
+#line 2279 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 93:
-
-/* Line 1464 of yacc.c  */
-#line 755 "dcParser.yxx"
+#line 761 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   double_range.clear();
-  if (!double_range.add_range((yyvsp[(1) - (3)].u.real), (yyvsp[(3) - (3)].u.real))) {
+  if (!double_range.add_range((yyvsp[-2].u.real), (yyvsp[0].u.real))) {
     yyerror("Overlapping range");
   }
 }
+#line 2290 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 94:
-
-/* Line 1464 of yacc.c  */
-#line 762 "dcParser.yxx"
+#line 768 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   double_range.clear();
-  if ((yyvsp[(2) - (2)].u.real) >= 0) {
+  if ((yyvsp[0].u.real) >= 0) {
     yyerror("Syntax error");
-  } else if (!double_range.add_range((yyvsp[(1) - (2)].u.real), -(yyvsp[(2) - (2)].u.real))) {
+  } else if (!double_range.add_range((yyvsp[-1].u.real), -(yyvsp[0].u.real))) {
     yyerror("Overlapping range");
   }
 }
+#line 2303 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 95:
-
-/* Line 1464 of yacc.c  */
-#line 771 "dcParser.yxx"
+#line 777 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (!double_range.add_range((yyvsp[(3) - (3)].u.real), (yyvsp[(3) - (3)].u.real))) {
+  if (!double_range.add_range((yyvsp[0].u.real), (yyvsp[0].u.real))) {
     yyerror("Overlapping range");
   }
 }
+#line 2313 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 96:
-
-/* Line 1464 of yacc.c  */
-#line 777 "dcParser.yxx"
+#line 783 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (!double_range.add_range((yyvsp[(3) - (5)].u.real), (yyvsp[(5) - (5)].u.real))) {
+  if (!double_range.add_range((yyvsp[-2].u.real), (yyvsp[0].u.real))) {
     yyerror("Overlapping range");
   }
 }
+#line 2323 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 97:
-
-/* Line 1464 of yacc.c  */
-#line 783 "dcParser.yxx"
+#line 789 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(4) - (4)].u.real) >= 0) {
+  if ((yyvsp[0].u.real) >= 0) {
     yyerror("Syntax error");
-  } else if (!double_range.add_range((yyvsp[(3) - (4)].u.real), -(yyvsp[(4) - (4)].u.real))) {
+  } else if (!double_range.add_range((yyvsp[-1].u.real), -(yyvsp[0].u.real))) {
     yyerror("Overlapping range");
   }
 }
+#line 2335 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 98:
-
-/* Line 1464 of yacc.c  */
-#line 794 "dcParser.yxx"
+#line 800 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   uint_range.clear();
 }
+#line 2343 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 99:
-
-/* Line 1464 of yacc.c  */
-#line 798 "dcParser.yxx"
+#line 804 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   uint_range.clear();
-  if (!uint_range.add_range((yyvsp[(1) - (1)].u.s_uint), (yyvsp[(1) - (1)].u.s_uint))) {
+  if (!uint_range.add_range((yyvsp[0].u.s_uint), (yyvsp[0].u.s_uint))) {
     yyerror("Overlapping range");
   }
 }
+#line 2354 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 100:
-
-/* Line 1464 of yacc.c  */
-#line 805 "dcParser.yxx"
+#line 811 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   uint_range.clear();
-  if (!uint_range.add_range((yyvsp[(1) - (3)].u.s_uint), (yyvsp[(3) - (3)].u.s_uint))) {
+  if (!uint_range.add_range((yyvsp[-2].u.s_uint), (yyvsp[0].u.s_uint))) {
     yyerror("Overlapping range");
   }
 }
+#line 2365 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 101:
-
-/* Line 1464 of yacc.c  */
-#line 812 "dcParser.yxx"
+#line 818 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   uint_range.clear();
-  if (!uint_range.add_range((yyvsp[(1) - (2)].u.s_uint), (yyvsp[(2) - (2)].u.s_uint))) {
+  if (!uint_range.add_range((yyvsp[-1].u.s_uint), (yyvsp[0].u.s_uint))) {
     yyerror("Overlapping range");
   }
 }
+#line 2376 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 102:
-
-/* Line 1464 of yacc.c  */
-#line 819 "dcParser.yxx"
+#line 825 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (!uint_range.add_range((yyvsp[(3) - (3)].u.s_uint), (yyvsp[(3) - (3)].u.s_uint))) {
+  if (!uint_range.add_range((yyvsp[0].u.s_uint), (yyvsp[0].u.s_uint))) {
     yyerror("Overlapping range");
   }
 }
+#line 2386 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 103:
-
-/* Line 1464 of yacc.c  */
-#line 825 "dcParser.yxx"
+#line 831 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (!uint_range.add_range((yyvsp[(3) - (5)].u.s_uint), (yyvsp[(5) - (5)].u.s_uint))) {
+  if (!uint_range.add_range((yyvsp[-2].u.s_uint), (yyvsp[0].u.s_uint))) {
     yyerror("Overlapping range");
   }
 }
+#line 2396 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 104:
-
-/* Line 1464 of yacc.c  */
-#line 831 "dcParser.yxx"
+#line 837 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if (!uint_range.add_range((yyvsp[(3) - (4)].u.s_uint), (yyvsp[(4) - (4)].u.s_uint))) {
+  if (!uint_range.add_range((yyvsp[-1].u.s_uint), (yyvsp[0].u.s_uint))) {
     yyerror("Overlapping range");
   }
 }
+#line 2406 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 106:
-
-/* Line 1464 of yacc.c  */
-#line 841 "dcParser.yxx"
+#line 847 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (4)].u.parameter) == (DCParameter *)NULL) {
-    (yyval.u.parameter) = NULL;
+  if ((yyvsp[-3].u.parameter) == nullptr) {
+    (yyval.u.parameter) = nullptr;
   } else {
-    (yyval.u.parameter) = (yyvsp[(1) - (4)].u.parameter)->append_array_specification(uint_range);
+    (yyval.u.parameter) = (yyvsp[-3].u.parameter)->append_array_specification(uint_range);
   }
 }
+#line 2418 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 107:
-
-/* Line 1464 of yacc.c  */
-#line 852 "dcParser.yxx"
+#line 858 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_parameter->set_name((yyvsp[(1) - (1)].str));
+  current_parameter->set_name((yyvsp[0].str));
   (yyval.u.parameter) = current_parameter;
 }
+#line 2427 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 108:
-
-/* Line 1464 of yacc.c  */
-#line 857 "dcParser.yxx"
+#line 863 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  DCSimpleParameter *simple_param = (yyvsp[(1) - (3)].u.parameter)->as_simple_parameter();
-  if (simple_param == NULL || simple_param->get_typedef() != (DCTypedef *)NULL) {
+  DCSimpleParameter *simple_param = (yyvsp[-2].u.parameter)->as_simple_parameter();
+  if (simple_param == nullptr || simple_param->get_typedef() != nullptr) {
     yyerror("A divisor is only allowed on a primitive type.");
 
   } else if (!simple_param->is_numeric_type()) {
       yyerror("A divisor is only valid on a numeric type.");
 
   } else {
-    if (!simple_param->set_divisor((yyvsp[(3) - (3)].u.s_uint))) {
+    if (!simple_param->set_divisor((yyvsp[0].u.s_uint))) {
       yyerror("Invalid divisor.");
     }
   }
 }
+#line 2446 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 109:
-
-/* Line 1464 of yacc.c  */
-#line 872 "dcParser.yxx"
+#line 878 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  DCSimpleParameter *simple_param = (yyvsp[(1) - (3)].u.parameter)->as_simple_parameter();
-  if (simple_param == NULL || simple_param->get_typedef() != (DCTypedef *)NULL) {
+  DCSimpleParameter *simple_param = (yyvsp[-2].u.parameter)->as_simple_parameter();
+  if (simple_param == nullptr || simple_param->get_typedef() != nullptr) {
     yyerror("A modulus is only allowed on a primitive type.");
 
   } else if (!simple_param->is_numeric_type()) {
       yyerror("A modulus is only valid on a numeric type.");
 
   } else {
-    if (!simple_param->set_modulus((yyvsp[(3) - (3)].u.real))) {
+    if (!simple_param->set_modulus((yyvsp[0].u.real))) {
       yyerror("Invalid modulus.");
     }
   }
 }
+#line 2465 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 110:
-
-/* Line 1464 of yacc.c  */
-#line 887 "dcParser.yxx"
+#line 893 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.parameter) = (yyvsp[(1) - (4)].u.parameter)->append_array_specification(uint_range);
+  (yyval.u.parameter) = (yyvsp[-3].u.parameter)->append_array_specification(uint_range);
 }
+#line 2473 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 111:
-
-/* Line 1464 of yacc.c  */
-#line 894 "dcParser.yxx"
+#line 900 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (1)].str).length() != 1) {
+  if ((yyvsp[0].str).length() != 1) {
     yyerror("Single character required.");
     (yyval.u.s_uint) = 0;
   } else {
-    (yyval.u.s_uint) = (unsigned char)(yyvsp[(1) - (1)].str)[0];
+    (yyval.u.s_uint) = (unsigned char)(yyvsp[0].str)[0];
   }
 }
+#line 2486 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 113:
-
-/* Line 1464 of yacc.c  */
-#line 907 "dcParser.yxx"
+#line 913 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.s_uint) = (unsigned int)(yyvsp[(1) - (1)].u.uint64);
-  if ((yyval.u.s_uint) != (yyvsp[(1) - (1)].u.uint64)) {
+  (yyval.u.s_uint) = (unsigned int)(yyvsp[0].u.uint64);
+  if ((yyval.u.s_uint) != (yyvsp[0].u.uint64)) {
     yyerror("Number out of range.");
     (yyval.u.s_uint) = 1;
   }
 }
+#line 2498 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 114:
-
-/* Line 1464 of yacc.c  */
-#line 918 "dcParser.yxx"
+#line 924 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.s_uint) = (unsigned int)-(yyvsp[(1) - (1)].u.int64);
-  if ((yyvsp[(1) - (1)].u.int64) >= 0) {
+  (yyval.u.s_uint) = (unsigned int)-(yyvsp[0].u.int64);
+  if ((yyvsp[0].u.int64) >= 0) {
     yyerror("Syntax error.");
 
-  } else if ((yyval.u.s_uint) != -(yyvsp[(1) - (1)].u.int64)) {
+  } else if ((yyval.u.s_uint) != -(yyvsp[0].u.int64)) {
     yyerror("Number out of range.");
     (yyval.u.s_uint) = 1;
   }
 }
+#line 2513 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 117:
-
-/* Line 1464 of yacc.c  */
-#line 940 "dcParser.yxx"
+#line 946 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.real) = (double)(yyvsp[(1) - (1)].u.uint64);
+  (yyval.u.real) = (double)(yyvsp[0].u.uint64);
 }
+#line 2521 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 118:
-
-/* Line 1464 of yacc.c  */
-#line 944 "dcParser.yxx"
+#line 950 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.real) = (double)(yyvsp[(1) - (1)].u.int64);
+  (yyval.u.real) = (double)(yyvsp[0].u.int64);
 }
+#line 2529 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 120:
-
-/* Line 1464 of yacc.c  */
-#line 952 "dcParser.yxx"
+#line 958 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (1)].str).length() != 1) {
+  if ((yyvsp[0].str).length() != 1) {
     yyerror("Single character required.");
     (yyval.u.real) = 0;
   } else {
-    (yyval.u.real) = (double)(unsigned char)(yyvsp[(1) - (1)].str)[0];
+    (yyval.u.real) = (double)(unsigned char)(yyvsp[0].str)[0];
   }
 }
+#line 2542 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 122:
-
-/* Line 1464 of yacc.c  */
-#line 966 "dcParser.yxx"
+#line 972 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
 }
+#line 2549 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 123:
-
-/* Line 1464 of yacc.c  */
-#line 969 "dcParser.yxx"
+#line 975 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (2)].str) != current_packer->get_current_field_name()) {
+  if ((yyvsp[-1].str) != current_packer->get_current_field_name()) {
     ostringstream strm;
-    strm << "Got '" << (yyvsp[(1) - (2)].str) << "', expected '" 
+    strm << "Got '" << (yyvsp[-1].str) << "', expected '"
          << current_packer->get_current_field_name() << "'";
     yyerror(strm.str());
   }
 }
+#line 2562 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 124:
-
-/* Line 1464 of yacc.c  */
-#line 978 "dcParser.yxx"
+#line 984 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
 }
+#line 2569 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 125:
-
-/* Line 1464 of yacc.c  */
-#line 984 "dcParser.yxx"
+#line 990 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_packer->pack_int64((yyvsp[(1) - (1)].u.int64));
+  current_packer->pack_int64((yyvsp[0].u.int64));
 }
+#line 2577 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 126:
-
-/* Line 1464 of yacc.c  */
-#line 988 "dcParser.yxx"
+#line 994 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_packer->pack_uint64((yyvsp[(1) - (1)].u.uint64));
+  current_packer->pack_uint64((yyvsp[0].u.uint64));
 }
+#line 2585 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 127:
-
-/* Line 1464 of yacc.c  */
-#line 992 "dcParser.yxx"
+#line 998 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_packer->pack_double((yyvsp[(1) - (1)].u.real));
+  current_packer->pack_double((yyvsp[0].u.real));
 }
+#line 2593 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 128:
-
-/* Line 1464 of yacc.c  */
-#line 996 "dcParser.yxx"
+#line 1002 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_packer->pack_string((yyvsp[(1) - (1)].str));
+  current_packer->pack_string((yyvsp[0].str));
 }
+#line 2601 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 129:
-
-/* Line 1464 of yacc.c  */
-#line 1000 "dcParser.yxx"
+#line 1006 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_packer->pack_literal_value((yyvsp[(1) - (1)].str));
+  current_packer->pack_literal_value((yyvsp[0].bytes));
 }
+#line 2609 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 130:
-
-/* Line 1464 of yacc.c  */
-#line 1004 "dcParser.yxx"
+#line 1010 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_packer->push();
 }
+#line 2617 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 131:
-
-/* Line 1464 of yacc.c  */
-#line 1008 "dcParser.yxx"
+#line 1014 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_packer->pop();
 }
+#line 2625 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 132:
-
-/* Line 1464 of yacc.c  */
-#line 1012 "dcParser.yxx"
+#line 1018 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_packer->push();
 }
+#line 2633 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 133:
-
-/* Line 1464 of yacc.c  */
-#line 1016 "dcParser.yxx"
+#line 1022 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_packer->pop();
 }
+#line 2641 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 134:
-
-/* Line 1464 of yacc.c  */
-#line 1020 "dcParser.yxx"
+#line 1026 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_packer->push();
 }
+#line 2649 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 135:
-
-/* Line 1464 of yacc.c  */
-#line 1024 "dcParser.yxx"
+#line 1030 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_packer->pop();
 }
+#line 2657 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 136:
-
-/* Line 1464 of yacc.c  */
-#line 1028 "dcParser.yxx"
+#line 1034 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  for (unsigned int i = 0; i < (yyvsp[(3) - (3)].u.s_uint); i++) {
-    current_packer->pack_int64((yyvsp[(1) - (3)].u.int64));
+  for (unsigned int i = 0; i < (yyvsp[0].u.s_uint); i++) {
+    current_packer->pack_int64((yyvsp[-2].u.int64));
   }
 }
+#line 2667 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 137:
-
-/* Line 1464 of yacc.c  */
-#line 1034 "dcParser.yxx"
+#line 1040 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  for (unsigned int i = 0; i < (yyvsp[(3) - (3)].u.s_uint); i++) {
-    current_packer->pack_uint64((yyvsp[(1) - (3)].u.uint64));
+  for (unsigned int i = 0; i < (yyvsp[0].u.s_uint); i++) {
+    current_packer->pack_uint64((yyvsp[-2].u.uint64));
   }
 }
+#line 2677 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 138:
-
-/* Line 1464 of yacc.c  */
-#line 1040 "dcParser.yxx"
+#line 1046 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  for (unsigned int i = 0; i < (yyvsp[(3) - (3)].u.s_uint); i++) {
-    current_packer->pack_double((yyvsp[(1) - (3)].u.real));
+  for (unsigned int i = 0; i < (yyvsp[0].u.s_uint); i++) {
+    current_packer->pack_double((yyvsp[-2].u.real));
   }
 }
+#line 2687 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 139:
-
-/* Line 1464 of yacc.c  */
-#line 1046 "dcParser.yxx"
+#line 1052 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  for (unsigned int i = 0; i < (yyvsp[(3) - (3)].u.s_uint); i++) {
-    current_packer->pack_literal_value((yyvsp[(1) - (3)].str));
+  for (unsigned int i = 0; i < (yyvsp[0].u.s_uint); i++) {
+    current_packer->pack_literal_value((yyvsp[-2].bytes));
   }
 }
+#line 2697 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 146:
-
-/* Line 1464 of yacc.c  */
-#line 1070 "dcParser.yxx"
+#line 1076 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_int8;
 }
+#line 2705 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 147:
-
-/* Line 1464 of yacc.c  */
-#line 1074 "dcParser.yxx"
+#line 1080 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_int16;
 }
+#line 2713 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 148:
-
-/* Line 1464 of yacc.c  */
-#line 1078 "dcParser.yxx"
+#line 1084 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_int32;
 }
+#line 2721 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 149:
-
-/* Line 1464 of yacc.c  */
-#line 1082 "dcParser.yxx"
+#line 1088 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_int64;
 }
+#line 2729 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 150:
-
-/* Line 1464 of yacc.c  */
-#line 1086 "dcParser.yxx"
+#line 1092 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_uint8;
 }
+#line 2737 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 151:
-
-/* Line 1464 of yacc.c  */
-#line 1090 "dcParser.yxx"
+#line 1096 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_uint16;
 }
+#line 2745 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 152:
-
-/* Line 1464 of yacc.c  */
-#line 1094 "dcParser.yxx"
+#line 1100 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_uint32;
 }
+#line 2753 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 153:
-
-/* Line 1464 of yacc.c  */
-#line 1098 "dcParser.yxx"
+#line 1104 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_uint64;
 }
+#line 2761 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 154:
-
-/* Line 1464 of yacc.c  */
-#line 1102 "dcParser.yxx"
+#line 1108 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_float64;
 }
+#line 2769 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 155:
-
-/* Line 1464 of yacc.c  */
-#line 1106 "dcParser.yxx"
+#line 1112 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_string;
 }
+#line 2777 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 156:
-
-/* Line 1464 of yacc.c  */
-#line 1110 "dcParser.yxx"
+#line 1116 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_blob;
 }
+#line 2785 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 157:
-
-/* Line 1464 of yacc.c  */
-#line 1114 "dcParser.yxx"
+#line 1120 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_blob32;
 }
+#line 2793 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 158:
-
-/* Line 1464 of yacc.c  */
-#line 1118 "dcParser.yxx"
+#line 1124 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_int8array;
 }
+#line 2801 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 159:
-
-/* Line 1464 of yacc.c  */
-#line 1122 "dcParser.yxx"
+#line 1128 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_int16array;
 }
+#line 2809 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 160:
-
-/* Line 1464 of yacc.c  */
-#line 1126 "dcParser.yxx"
+#line 1132 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_int32array;
 }
+#line 2817 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 161:
-
-/* Line 1464 of yacc.c  */
-#line 1130 "dcParser.yxx"
+#line 1136 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_uint8array;
 }
+#line 2825 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 162:
-
-/* Line 1464 of yacc.c  */
-#line 1134 "dcParser.yxx"
+#line 1140 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_uint16array;
 }
+#line 2833 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 163:
-
-/* Line 1464 of yacc.c  */
-#line 1138 "dcParser.yxx"
+#line 1144 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_uint32array;
 }
+#line 2841 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 164:
-
-/* Line 1464 of yacc.c  */
-#line 1142 "dcParser.yxx"
+#line 1148 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_uint32uint8array;
 }
+#line 2849 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 165:
-
-/* Line 1464 of yacc.c  */
-#line 1146 "dcParser.yxx"
+#line 1152 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.subatomic) = ST_char;
 }
+#line 2857 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 166:
-
-/* Line 1464 of yacc.c  */
-#line 1153 "dcParser.yxx"
+#line 1159 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_keyword_list.clear_keywords();
 }
+#line 2865 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 167:
-
-/* Line 1464 of yacc.c  */
-#line 1157 "dcParser.yxx"
+#line 1163 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_keyword_list.add_keyword((yyvsp[(2) - (2)].u.keyword));
+  current_keyword_list.add_keyword((yyvsp[0].u.keyword));
 }
+#line 2873 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 168:
-
-/* Line 1464 of yacc.c  */
-#line 1164 "dcParser.yxx"
+#line 1170 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   if (current_keyword_list.get_num_keywords() != 0) {
     yyerror("Communication keywords are not allowed here.");
   }
 }
+#line 2883 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 169:
-
-/* Line 1464 of yacc.c  */
-#line 1173 "dcParser.yxx"
+#line 1179 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_molecular = new DCMolecularField((yyvsp[(1) - (2)].str), current_class);
+  current_molecular = new DCMolecularField((yyvsp[-1].str), current_class);
 }
+#line 2891 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 170:
-
-/* Line 1464 of yacc.c  */
-#line 1177 "dcParser.yxx"
+#line 1183 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.field) = current_molecular;
 }
+#line 2899 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 171:
-
-/* Line 1464 of yacc.c  */
-#line 1184 "dcParser.yxx"
+#line 1190 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  DCField *field = current_class->get_field_by_name((yyvsp[(1) - (1)].str));
-  (yyval.u.atomic) = (DCAtomicField *)NULL;
-  if (field == (DCField *)NULL) {
+  DCField *field = current_class->get_field_by_name((yyvsp[0].str));
+  (yyval.u.atomic) = nullptr;
+  if (field == nullptr) {
     // Maybe the field is unknown because the class is partially
     // bogus.  In that case, allow it for now; create a bogus field as
     // a placeholder.
     if (current_class->inherits_from_bogus_class()) {
-      (yyval.u.atomic) = new DCAtomicField((yyvsp[(1) - (1)].str), current_class, true);
+      (yyval.u.atomic) = new DCAtomicField((yyvsp[0].str), current_class, true);
       current_class->add_field((yyval.u.atomic));
 
     } else {
       // Nope, it's a fully-defined class, so this is a real error.
-      yyerror("Unknown field: " + (yyvsp[(1) - (1)].str));
+      yyerror("Unknown field: " + (yyvsp[0].str));
     }
 
   } else {
     (yyval.u.atomic) = field->as_atomic_field();
-    if ((yyval.u.atomic) == (DCAtomicField *)NULL) {
-      yyerror("Not an atomic field: " + (yyvsp[(1) - (1)].str));
+    if ((yyval.u.atomic) == nullptr) {
+      yyerror("Not an atomic field: " + (yyvsp[0].str));
     }
   }
 }
+#line 2927 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 172:
-
-/* Line 1464 of yacc.c  */
-#line 1211 "dcParser.yxx"
+#line 1217 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(1) - (1)].u.atomic) != (DCAtomicField *)NULL) {
-    current_molecular->add_atomic((yyvsp[(1) - (1)].u.atomic));
+  if ((yyvsp[0].u.atomic) != nullptr) {
+    current_molecular->add_atomic((yyvsp[0].u.atomic));
   }
 }
+#line 2937 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 173:
-
-/* Line 1464 of yacc.c  */
-#line 1217 "dcParser.yxx"
+#line 1223 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  if ((yyvsp[(3) - (3)].u.atomic) != (DCAtomicField *)NULL) {
-    current_molecular->add_atomic((yyvsp[(3) - (3)].u.atomic));
-    if (!(yyvsp[(3) - (3)].u.atomic)->is_bogus_field() && !current_molecular->compare_keywords(*(yyvsp[(3) - (3)].u.atomic))) {
-      yyerror("Mismatched keywords in molecule between " + 
+  if ((yyvsp[0].u.atomic) != nullptr) {
+    current_molecular->add_atomic((yyvsp[0].u.atomic));
+    if (!(yyvsp[0].u.atomic)->is_bogus_field() && !current_molecular->compare_keywords(*(yyvsp[0].u.atomic))) {
+      yyerror("Mismatched keywords in molecule between " +
               current_molecular->get_atomic(0)->get_name() + " and " +
-              (yyvsp[(3) - (3)].u.atomic)->get_name());
+              (yyvsp[0].u.atomic)->get_name());
     }
   }
 }
+#line 2952 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 174:
-
-/* Line 1464 of yacc.c  */
-#line 1231 "dcParser.yxx"
+#line 1237 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.str) = "";
 }
+#line 2960 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 176:
-
-/* Line 1464 of yacc.c  */
-#line 1239 "dcParser.yxx"
+#line 1245 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  current_switch = new DCSwitch((yyvsp[(2) - (6)].str), (yyvsp[(4) - (6)].u.field));
+  current_switch = new DCSwitch((yyvsp[-4].str), (yyvsp[-2].u.field));
 }
+#line 2968 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 177:
-
-/* Line 1464 of yacc.c  */
-#line 1243 "dcParser.yxx"
+#line 1249 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   (yyval.u.dswitch) = current_switch;
-  current_switch = (DCSwitch *)(yyvsp[(7) - (9)].u.parameter);
+  current_switch = (DCSwitch *)(yyvsp[-2].u.parameter);
 }
+#line 2977 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 183:
-
-/* Line 1464 of yacc.c  */
-#line 1257 "dcParser.yxx"
+#line 1263 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   if (!current_switch->is_field_valid()) {
     yyerror("case declaration required before first element");
-  } else if ((yyvsp[(2) - (3)].u.field) != (DCField *)NULL) {
-    if (!current_switch->add_field((yyvsp[(2) - (3)].u.field))) {
-      yyerror("Duplicate field name: " + (yyvsp[(2) - (3)].u.field)->get_name());
+  } else if ((yyvsp[-1].u.field) != nullptr) {
+    if (!current_switch->add_field((yyvsp[-1].u.field))) {
+      yyerror("Duplicate field name: " + (yyvsp[-1].u.field)->get_name());
     }
   }
 }
+#line 2991 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 184:
-
-/* Line 1464 of yacc.c  */
-#line 1270 "dcParser.yxx"
+#line 1276 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_packer = &default_packer;
   current_packer->clear_data();
   current_packer->begin_pack(current_switch->get_key_parameter());
 }
+#line 3001 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 185:
-
-/* Line 1464 of yacc.c  */
-#line 1276 "dcParser.yxx"
+#line 1282 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   if (!current_packer->end_pack()) {
     yyerror("Invalid value for switch parameter");
     current_switch->add_invalid_case();
   } else {
-    int case_index = current_switch->add_case(current_packer->get_string());
+    int case_index = current_switch->add_case(current_packer->get_bytes());
     if (case_index == -1) {
       yyerror("Duplicate case value");
     }
   }
 }
+#line 3017 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 186:
-
-/* Line 1464 of yacc.c  */
-#line 1291 "dcParser.yxx"
+#line 1297 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   if (!current_switch->add_default()) {
     yyerror("Default case already defined");
   }
 }
+#line 3027 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 187:
-
-/* Line 1464 of yacc.c  */
-#line 1300 "dcParser.yxx"
+#line 1306 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
   current_switch->add_break();
 }
+#line 3035 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 188:
-
-/* Line 1464 of yacc.c  */
-#line 1307 "dcParser.yxx"
+#line 1313 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.field) = (yyvsp[(1) - (1)].u.parameter);
+  (yyval.u.field) = (yyvsp[0].u.parameter);
 }
+#line 3043 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
   case 189:
-
-/* Line 1464 of yacc.c  */
-#line 1311 "dcParser.yxx"
+#line 1317 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1646  */
     {
-  (yyval.u.field) = (yyvsp[(1) - (1)].u.parameter);
+  (yyval.u.field) = (yyvsp[0].u.parameter);
 }
+#line 3051 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
     break;
 
 
-
-/* Line 1464 of yacc.c  */
-#line 3380 "y.tab.c"
+#line 3055 "built/tmp/dcParser.yxx.c" /* yacc.c:1646  */
       default: break;
     }
+  /* User semantic actions sometimes alter yychar, and that requires
+     that yytoken be updated with the new translation.  We take the
+     approach of translating immediately before every use of yytoken.
+     One alternative is translating here after every semantic action,
+     but that translation would be missed if the semantic action invokes
+     YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
+     if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
+     incorrect destructor might then be invoked immediately.  In the
+     case of YYERROR or YYBACKUP, subsequent parser actions might lead
+     to an incorrect destructor call or verbose syntax error message
+     before the lookahead is translated.  */
   YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
@@ -3391,7 +3073,7 @@ yyreduce:
 
   *++yyvsp = yyval;
 
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
 
@@ -3406,10 +3088,14 @@ yyreduce:
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
+  /* Make sure we have latest lookahead translation.  See comments at
+     user semantic actions for why this is necessary.  */
+  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
+
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
@@ -3417,37 +3103,36 @@ yyerrlab:
 #if ! YYERROR_VERBOSE
       yyerror (YY_("syntax error"));
 #else
+# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
+                                        yyssp, yytoken)
       {
-	YYSIZE_T yysize = yysyntax_error (0, yystate, yychar);
-	if (yymsg_alloc < yysize && yymsg_alloc < YYSTACK_ALLOC_MAXIMUM)
-	  {
-	    YYSIZE_T yyalloc = 2 * yysize;
-	    if (! (yysize <= yyalloc && yyalloc <= YYSTACK_ALLOC_MAXIMUM))
-	      yyalloc = YYSTACK_ALLOC_MAXIMUM;
-	    if (yymsg != yymsgbuf)
-	      YYSTACK_FREE (yymsg);
-	    yymsg = (char *) YYSTACK_ALLOC (yyalloc);
-	    if (yymsg)
-	      yymsg_alloc = yyalloc;
-	    else
-	      {
-		yymsg = yymsgbuf;
-		yymsg_alloc = sizeof yymsgbuf;
-	      }
-	  }
-
-	if (0 < yysize && yysize <= yymsg_alloc)
-	  {
-	    (void) yysyntax_error (yymsg, yystate, yychar);
-	    yyerror (yymsg);
-	  }
-	else
-	  {
-	    yyerror (YY_("syntax error"));
-	    if (yysize != 0)
-	      goto yyexhaustedlab;
-	  }
+        char const *yymsgp = YY_("syntax error");
+        int yysyntax_error_status;
+        yysyntax_error_status = YYSYNTAX_ERROR;
+        if (yysyntax_error_status == 0)
+          yymsgp = yymsg;
+        else if (yysyntax_error_status == 1)
+          {
+            if (yymsg != yymsgbuf)
+              YYSTACK_FREE (yymsg);
+            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
+            if (!yymsg)
+              {
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = 2;
+              }
+            else
+              {
+                yysyntax_error_status = YYSYNTAX_ERROR;
+                yymsgp = yymsg;
+              }
+          }
+        yyerror (yymsgp);
+        if (yysyntax_error_status == 2)
+          goto yyexhaustedlab;
       }
+# undef YYSYNTAX_ERROR
 #endif
     }
 
@@ -3456,20 +3141,20 @@ yyerrlab:
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
-	 error, discard it.  */
+         error, discard it.  */
 
       if (yychar <= YYEOF)
-	{
-	  /* Return failure if at end of input.  */
-	  if (yychar == YYEOF)
-	    YYABORT;
-	}
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
+        }
       else
-	{
-	  yydestruct ("Error: discarding",
-		      yytoken, &yylval);
-	  yychar = YYEMPTY;
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval);
+          yychar = YYEMPTY;
+        }
     }
 
   /* Else will try to reuse lookahead token after shifting the error
@@ -3488,7 +3173,7 @@ yyerrorlab:
   if (/*CONSTCOND*/ 0)
      goto yyerrorlab;
 
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -3501,35 +3186,37 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
   for (;;)
     {
       yyn = yypact[yystate];
-      if (yyn != YYPACT_NINF)
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+      if (!yypact_value_is_default (yyn))
+        {
+          yyn += YYTERROR;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
 
       yydestruct ("Error: popping",
-		  yystos[yystate], yyvsp);
+                  yystos[yystate], yyvsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
     }
 
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
 
   /* Shift the error token.  */
@@ -3553,7 +3240,7 @@ yyabortlab:
   yyresult = 1;
   goto yyreturn;
 
-#if !defined(yyoverflow) || YYERROR_VERBOSE
+#if !defined yyoverflow || YYERROR_VERBOSE
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
@@ -3565,16 +3252,21 @@ yyexhaustedlab:
 
 yyreturn:
   if (yychar != YYEMPTY)
-     yydestruct ("Cleanup: discarding lookahead",
-		 yytoken, &yylval);
-  /* Do not reclaim the symbols of the rule which action triggered
+    {
+      /* Make sure we have latest lookahead translation.  See comments at
+         user semantic actions for why this is necessary.  */
+      yytoken = YYTRANSLATE (yychar);
+      yydestruct ("Cleanup: discarding lookahead",
+                  yytoken, &yylval);
+    }
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-		  yystos[*yyssp], yyvsp);
+                  yystos[*yyssp], yyvsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -3585,9 +3277,5 @@ yyreturn:
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
 #endif
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
+  return yyresult;
 }
-
-
-

--- a/direct/src/dcparser/dcParser.h.prebuilt
+++ b/direct/src/dcparser/dcParser.h.prebuilt
@@ -1,20 +1,19 @@
-/* A Bison parser, made by GNU Bison 2.4.2.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
-/* Skeleton interface for Bison's Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2006, 2009-2010 Free Software
-   Foundation, Inc.
-   
+/* Bison interface for Yacc-like parsers in C
+
+   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -27,66 +26,74 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
+#ifndef YY_DCYY_BUILT_TMP_DCPARSER_YXX_H_INCLUDED
+# define YY_DCYY_BUILT_TMP_DCPARSER_YXX_H_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 0
+#endif
+#if YYDEBUG
+extern int dcyydebug;
+#endif
 
-/* Tokens.  */
+/* Token type.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     UNSIGNED_INTEGER = 258,
-     SIGNED_INTEGER = 259,
-     REAL = 260,
-     STRING = 261,
-     HEX_STRING = 262,
-     IDENTIFIER = 263,
-     KEYWORD = 264,
-     KW_DCLASS = 265,
-     KW_STRUCT = 266,
-     KW_FROM = 267,
-     KW_IMPORT = 268,
-     KW_TYPEDEF = 269,
-     KW_KEYWORD = 270,
-     KW_SWITCH = 271,
-     KW_CASE = 272,
-     KW_DEFAULT = 273,
-     KW_BREAK = 274,
-     KW_INT8 = 275,
-     KW_INT16 = 276,
-     KW_INT32 = 277,
-     KW_INT64 = 278,
-     KW_UINT8 = 279,
-     KW_UINT16 = 280,
-     KW_UINT32 = 281,
-     KW_UINT64 = 282,
-     KW_FLOAT64 = 283,
-     KW_STRING = 284,
-     KW_BLOB = 285,
-     KW_BLOB32 = 286,
-     KW_INT8ARRAY = 287,
-     KW_INT16ARRAY = 288,
-     KW_INT32ARRAY = 289,
-     KW_UINT8ARRAY = 290,
-     KW_UINT16ARRAY = 291,
-     KW_UINT32ARRAY = 292,
-     KW_UINT32UINT8ARRAY = 293,
-     KW_CHAR = 294,
-     START_DC = 295,
-     START_PARAMETER_VALUE = 296,
-     START_PARAMETER_DESCRIPTION = 297
-   };
+  enum yytokentype
+  {
+    UNSIGNED_INTEGER = 258,
+    SIGNED_INTEGER = 259,
+    REAL = 260,
+    STRING = 261,
+    IDENTIFIER = 262,
+    HEX_STRING = 263,
+    KEYWORD = 264,
+    KW_DCLASS = 265,
+    KW_STRUCT = 266,
+    KW_FROM = 267,
+    KW_IMPORT = 268,
+    KW_TYPEDEF = 269,
+    KW_KEYWORD = 270,
+    KW_SWITCH = 271,
+    KW_CASE = 272,
+    KW_DEFAULT = 273,
+    KW_BREAK = 274,
+    KW_INT8 = 275,
+    KW_INT16 = 276,
+    KW_INT32 = 277,
+    KW_INT64 = 278,
+    KW_UINT8 = 279,
+    KW_UINT16 = 280,
+    KW_UINT32 = 281,
+    KW_UINT64 = 282,
+    KW_FLOAT64 = 283,
+    KW_STRING = 284,
+    KW_BLOB = 285,
+    KW_BLOB32 = 286,
+    KW_INT8ARRAY = 287,
+    KW_INT16ARRAY = 288,
+    KW_INT32ARRAY = 289,
+    KW_UINT8ARRAY = 290,
+    KW_UINT16ARRAY = 291,
+    KW_UINT32ARRAY = 292,
+    KW_UINT32UINT8ARRAY = 293,
+    KW_CHAR = 294,
+    START_DC = 295,
+    START_PARAMETER_VALUE = 296,
+    START_PARAMETER_DESCRIPTION = 297
+  };
 #endif
 /* Tokens.  */
 #define UNSIGNED_INTEGER 258
 #define SIGNED_INTEGER 259
 #define REAL 260
 #define STRING 261
-#define HEX_STRING 262
-#define IDENTIFIER 263
+#define IDENTIFIER 262
+#define HEX_STRING 263
 #define KEYWORD 264
 #define KW_DCLASS 265
 #define KW_STRUCT 266
@@ -122,15 +129,11 @@
 #define START_PARAMETER_VALUE 296
 #define START_PARAMETER_DESCRIPTION 297
 
+/* Value type.  */
 
-
-
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-#endif
 
 extern YYSTYPE dcyylval;
 
+int dcyyparse (void);
 
+#endif /* !YY_DCYY_BUILT_TMP_DCPARSER_YXX_H_INCLUDED  */

--- a/direct/src/dcparser/dcParser.yxx
+++ b/direct/src/dcparser/dcParser.yxx
@@ -57,7 +57,7 @@ dc_init_parser(istream &in, const string &filename, DCFile &file) {
 }
 
 void
-dc_init_parser_parameter_value(istream &in, const string &filename, 
+dc_init_parser_parameter_value(istream &in, const string &filename,
                                DCPacker &packer) {
   dc_file = nullptr;
   current_packer = &packer;
@@ -89,15 +89,16 @@ dc_cleanup_parser() {
 %token <u.uint64> UNSIGNED_INTEGER
 %token <u.int64> SIGNED_INTEGER
 %token <u.real> REAL
-%token <str> STRING HEX_STRING IDENTIFIER
+%token <str> STRING IDENTIFIER
+%token <bytes> HEX_STRING
 %token <u.keyword> KEYWORD
 
-%token KW_DCLASS 
-%token KW_STRUCT 
-%token KW_FROM 
-%token KW_IMPORT 
-%token KW_TYPEDEF 
-%token KW_KEYWORD 
+%token KW_DCLASS
+%token KW_STRUCT
+%token KW_FROM
+%token KW_IMPORT
+%token KW_TYPEDEF
+%token KW_KEYWORD
 %token KW_SWITCH
 %token KW_CASE
 %token KW_DEFAULT
@@ -224,7 +225,7 @@ import:
 {
   dc_file->add_import_module($2);
 }
-        | KW_FROM import_identifier KW_IMPORT 
+        | KW_FROM import_identifier KW_IMPORT
 {
   dc_file->add_import_module($2);
 }
@@ -255,7 +256,7 @@ typedef_decl:
 {
   if ($2 != nullptr) {
     DCTypedef *dtypedef = new DCTypedef($2);
-    
+
     if (!dc_file->add_typedef(dtypedef)) {
       DCTypedef *old_typedef = dc_file->get_typedef_by_name(dtypedef->get_name());
       if (old_typedef->is_bogus_typedef()) {
@@ -294,7 +295,7 @@ dclass_or_struct:
         ;
 
 dclass:
-        KW_DCLASS optional_name 
+        KW_DCLASS optional_name
 {
   current_class = new DCClass(dc_file, $2, false, false);
 }
@@ -322,7 +323,7 @@ dclass_name:
     if (dclass->is_struct()) {
       yyerror("struct name not allowed");
     }
-  
+
     $$ = dclass;
   }
 }
@@ -398,7 +399,7 @@ dclass_field:
         ;
 
 struct:
-        KW_STRUCT optional_name 
+        KW_STRUCT optional_name
 {
   current_class = new DCClass(dc_file, $2, true, false);
 }
@@ -426,7 +427,7 @@ struct_name:
     if (!dstruct->is_struct()) {
       yyerror("struct name required");
     }
-  
+
     $$ = dstruct;
   }
 }
@@ -538,7 +539,7 @@ unnamed_parameter:
 
 named_parameter_with_default:
         named_parameter
-        | named_parameter '=' 
+        | named_parameter '='
 {
   current_packer = &default_packer;
   current_packer->clear_data();
@@ -553,7 +554,7 @@ named_parameter_with_default:
     is_valid = $1->is_valid();
   }
   if (current_packer->end_pack()) {
-    $1->set_default_value(current_packer->get_string());
+    $1->set_default_value(current_packer->get_bytes());
 
   } else {
     if (is_valid) {
@@ -568,7 +569,7 @@ named_parameter_with_default:
 
 unnamed_parameter_with_default:
         unnamed_parameter
-        | unnamed_parameter '=' 
+        | unnamed_parameter '='
 {
   current_packer = &default_packer;
   current_packer->clear_data();
@@ -583,7 +584,7 @@ unnamed_parameter_with_default:
     is_valid = $1->is_valid();
   }
   if (current_packer->end_pack()) {
-    $1->set_default_value(current_packer->get_string());
+    $1->set_default_value(current_packer->get_bytes());
 
   } else {
     if (is_valid) {
@@ -663,7 +664,7 @@ simple_type_name:
   $$ = simple_param;
 }
         | simple_type_name '%' number
-{ 
+{
   DCSimpleParameter *simple_param = $1->as_simple_parameter();
   nassertr(simple_param != nullptr, 0);
   if (!simple_param->is_numeric_type()) {
@@ -703,10 +704,10 @@ type_name:
           dtypedef = new DCTypedef($1);
         }
       }
-      
+
       dc_file->add_typedef(dtypedef);
     }
-    
+
     $$ = dtypedef->make_new_parameter();
   }
 }
@@ -974,7 +975,7 @@ parameter_value:
 {
   if ($1 != current_packer->get_current_field_name()) {
     ostringstream strm;
-    strm << "Got '" << $1 << "', expected '" 
+    strm << "Got '" << $1 << "', expected '"
          << current_packer->get_current_field_name() << "'";
     yyerror(strm.str());
   }
@@ -1005,7 +1006,7 @@ parameter_actual_value:
 {
   current_packer->pack_literal_value($1);
 }
-        | '{' 
+        | '{'
 {
   current_packer->push();
 }
@@ -1013,7 +1014,7 @@ parameter_actual_value:
 {
   current_packer->pop();
 }
-        | '[' 
+        | '['
 {
   current_packer->push();
 }
@@ -1021,7 +1022,7 @@ parameter_actual_value:
 {
   current_packer->pop();
 }
-        | '(' 
+        | '('
 {
   current_packer->push();
 }
@@ -1223,7 +1224,7 @@ molecular_atom_list:
   if ($3 != nullptr) {
     current_molecular->add_atomic($3);
     if (!$3->is_bogus_field() && !current_molecular->compare_keywords(*$3)) {
-      yyerror("Mismatched keywords in molecule between " + 
+      yyerror("Mismatched keywords in molecule between " +
               current_molecular->get_atomic(0)->get_name() + " and " +
               $3->get_name());
     }
@@ -1283,7 +1284,7 @@ switch_case:
     yyerror("Invalid value for switch parameter");
     current_switch->add_invalid_case();
   } else {
-    int case_index = current_switch->add_case(current_packer->get_string());
+    int case_index = current_switch->add_case(current_packer->get_bytes());
     if (case_index == -1) {
       yyerror("Duplicate case value");
     }

--- a/direct/src/dcparser/dcParserDefs.h
+++ b/direct/src/dcparser/dcParserDefs.h
@@ -16,6 +16,7 @@
 
 #include "dcbase.h"
 #include "dcSubatomicType.h"
+#include "vector_uchar.h"
 
 class DCFile;
 class DCClass;
@@ -61,6 +62,7 @@ public:
     const DCKeyword *keyword;
   } u;
   std::string str;
+  vector_uchar bytes;
 };
 
 // The yacc-generated code expects to use the symbol 'YYSTYPE' to refer to the

--- a/direct/src/dcparser/dcSimpleParameter.h
+++ b/direct/src/dcparser/dcSimpleParameter.h
@@ -62,6 +62,8 @@ public:
                            bool &pack_error, bool &range_error) const;
   virtual void pack_string(DCPackData &pack_data, const std::string &value,
                            bool &pack_error, bool &range_error) const;
+  virtual void pack_blob(DCPackData &pack_data, const vector_uchar &value,
+                         bool &pack_error, bool &range_error) const;
   virtual bool pack_default_value(DCPackData &pack_data, bool &pack_error) const;
 
   virtual void unpack_double(const char *data, size_t length, size_t &p,
@@ -76,6 +78,8 @@ public:
                              uint64_t &value, bool &pack_error, bool &range_error) const;
   virtual void unpack_string(const char *data, size_t length, size_t &p,
                              std::string &value, bool &pack_error, bool &range_error) const;
+  virtual void unpack_blob(const char *data, size_t length, size_t &p,
+                           vector_uchar &value, bool &pack_error, bool &range_error) const;
   virtual bool unpack_validate(const char *data, size_t length, size_t &p,
                                bool &pack_error, bool &range_error) const;
   virtual bool unpack_skip(const char *data, size_t length, size_t &p,

--- a/direct/src/dcparser/dcSwitch.cxx
+++ b/direct/src/dcparser/dcSwitch.cxx
@@ -109,7 +109,7 @@ get_num_cases() const {
  * if no case has this value.
  */
 int DCSwitch::
-get_case_by_value(const string &case_value) const {
+get_case_by_value(const vector_uchar &case_value) const {
   CasesByValue::const_iterator vi;
   vi = _cases_by_value.find(case_value);
   if (vi != _cases_by_value.end()) {
@@ -140,9 +140,9 @@ get_default_case() const {
 /**
  * Returns the packed value associated with the indicated case.
  */
-string DCSwitch::
+vector_uchar DCSwitch::
 get_value(int case_index) const {
-  nassertr(case_index >= 0 && case_index < (int)_cases.size(), string());
+  nassertr(case_index >= 0 && case_index < (int)_cases.size(), vector_uchar());
   return _cases[case_index]->_value;
 }
 
@@ -198,7 +198,7 @@ is_field_valid() const {
  * -1. This is normally called only by the parser.
  */
 int DCSwitch::
-add_case(const string &value) {
+add_case(const vector_uchar &value) {
   int case_index = (int)_cases.size();
   if (!_cases_by_value.insert(CasesByValue::value_type(value, case_index)).second) {
     add_invalid_case();
@@ -283,7 +283,8 @@ add_break() {
 const DCPackerInterface *DCSwitch::
 apply_switch(const char *value_data, size_t length) const {
   CasesByValue::const_iterator vi;
-  vi = _cases_by_value.find(string(value_data, length));
+  vi = _cases_by_value.find(vector_uchar((const unsigned char *)value_data,
+                                         (const unsigned char *)value_data + length));
   if (vi != _cases_by_value.end()) {
     return _cases[(*vi).second]->_fields;
   }
@@ -421,7 +422,7 @@ generate_hash(HashGenerator &hashgen) const {
   Cases::const_iterator ci;
   for (ci = _cases.begin(); ci != _cases.end(); ++ci) {
     const SwitchCase *dcase = (*ci);
-    hashgen.add_string(dcase->_value);
+    hashgen.add_blob(dcase->_value);
 
     const SwitchFields *fields = dcase->_fields;
     hashgen.add_int(fields->_fields.size());
@@ -702,7 +703,7 @@ do_check_match(const DCPackerInterface *) const {
  *
  */
 DCSwitch::SwitchCase::
-SwitchCase(const string &value, DCSwitch::SwitchFields *fields) :
+SwitchCase(const vector_uchar &value, DCSwitch::SwitchFields *fields) :
   _value(value),
   _fields(fields)
 {

--- a/direct/src/dcparser/dcSwitch.h
+++ b/direct/src/dcparser/dcSwitch.h
@@ -40,18 +40,18 @@ PUBLISHED:
   DCField *get_key_parameter() const;
 
   int get_num_cases() const;
-  int get_case_by_value(const std::string &case_value) const;
+  int get_case_by_value(const vector_uchar &case_value) const;
   DCPackerInterface *get_case(int n) const;
   DCPackerInterface *get_default_case() const;
 
-  std::string get_value(int case_index) const;
+  vector_uchar get_value(int case_index) const;
   int get_num_fields(int case_index) const;
   DCField *get_field(int case_index, int n) const;
   DCField *get_field_by_name(int case_index, const std::string &name) const;
 
 public:
   bool is_field_valid() const;
-  int add_case(const std::string &value);
+  int add_case(const vector_uchar &value);
   void add_invalid_case();
   bool add_default();
   bool add_field(DCField *field);
@@ -98,13 +98,13 @@ public:
 
   class SwitchCase {
   public:
-    SwitchCase(const std::string &value, SwitchFields *fields);
+    SwitchCase(const vector_uchar &value, SwitchFields *fields);
     ~SwitchCase();
 
     bool do_check_match_switch_case(const SwitchCase *other) const;
 
   public:
-    std::string _value;
+    vector_uchar _value;
     SwitchFields *_fields;
   };
 
@@ -137,7 +137,7 @@ private:
   bool _fields_added;
 
   // This map indexes into the _cases vector, above.
-  typedef pmap<std::string, int> CasesByValue;
+  typedef pmap<vector_uchar, int> CasesByValue;
   CasesByValue _cases_by_value;
 };
 

--- a/direct/src/dcparser/hashGenerator.cxx
+++ b/direct/src/dcparser/hashGenerator.cxx
@@ -57,6 +57,18 @@ add_string(const std::string &str) {
 }
 
 /**
+ * Adds a blob to the hash, by breaking it down into a sequence of integers.
+ */
+void HashGenerator::
+add_blob(const vector_uchar &bytes) {
+  add_int(bytes.size());
+  vector_uchar::const_iterator bi;
+  for (bi = bytes.begin(); bi != bytes.end(); ++bi) {
+    add_int(*bi);
+  }
+}
+
+/**
  * Returns the hash number generated.
  */
 unsigned long HashGenerator::

--- a/direct/src/dcparser/hashGenerator.h
+++ b/direct/src/dcparser/hashGenerator.h
@@ -16,6 +16,7 @@
 
 #include "dcbase.h"
 #include "primeNumberGenerator.h"
+#include "vector_uchar.h"
 
 /**
  * This class generates an arbitrary hash number from a sequence of ints.
@@ -26,6 +27,7 @@ public:
 
   void add_int(int num);
   void add_string(const std::string &str);
+  void add_blob(const vector_uchar &bytes);
 
   unsigned long get_hash() const;
 

--- a/direct/src/distributed/cConnectionRepository.cxx
+++ b/direct/src/distributed/cConnectionRepository.cxx
@@ -891,7 +891,7 @@ describe_message(std::ostream &out, const string &prefix,
                  const Datagram &dg) const {
   DCPacker packer;
 
-  packer.set_unpack_data(dg.get_message());
+  packer.set_unpack_data((const char *)dg.get_data(), dg.get_length(), false);
   CHANNEL_TYPE do_id;
   int msg_type;
   bool is_update = false;


### PR DESCRIPTION
This is a suggestion for how to solve the Python 3 compatibility issues in dcparser.  It already makes a distinction between text strings and binary blobs, so this change changes it so that `vector_uchar` is used for decoding and encoding blob data.

It also uses `vector_uchar` for representing any packed data.  A separate `get_bytes()` is added to DCPacker since the existing `get_string()` isn't really named accurately any more.

@cfsworks I've marked you as reviewer because you're in a better position than I am at checking whether this is going to break anything, or whether this it is at all a good idea to treat strings as UTF-8 in dcparser.