### PR TITLE
bullet: Allow intractions with bullet world during tick callbacks

### DIFF
--- a/panda/src/bullet/bulletWorld.cxx
+++ b/panda/src/bullet/bulletWorld.cxx
@@ -1186,7 +1186,12 @@ tick_callback(btDynamicsWorld *world, btScalar timestep) {
   CallbackObject *obj = w->_tick_callback_obj;
   if (obj) {
     BulletTickCallbackData cbdata(timestep);
+    // Release the global lock that we are holding during the tick callback
+    // and allow interactions with bullet world in the user callback
+    get_global_lock().release();
     obj->do_callback(&cbdata);
+    // Acquire the global lock again and protect the execution
+    get_global_lock().acquire();
   }
 }
 


### PR DESCRIPTION
        - Release the global lock during the user tick callback
        and allow interactions with bullet world
        - Acquire the lock again after the callback

Signed-off-by: deflected <deflected@users.noreply.github.com>