### PR TITLE
python3 prelinked modules names are wrong

### DIFF
--- a/dtool/src/interrogate/interfaceMakerPythonSimple.cxx
+++ b/dtool/src/interrogate/interfaceMakerPythonSimple.cxx
@@ -95,7 +95,7 @@ write_module(ostream &out,ostream *out_h, InterrogateModuleDef *def) {
       << "#if PY_MAJOR_VERSION >= 3\n"
       << "static struct PyModuleDef python_simple_module = {\n"
       << "  PyModuleDef_HEAD_INIT,\n"
-      << "  \"" << def->library_name << "\",\n"
+      << "  \"" << def->module_name << "\",\n"
       << "  NULL,\n"
       << "  -1,\n"
       << "  python_simple_funcs,\n"

--- a/dtool/src/interrogate/interrogate_module.cxx
+++ b/dtool/src/interrogate/interrogate_module.cxx
@@ -153,7 +153,7 @@ int write_python_table_native(ostream &out) {
       << "#if PY_MAJOR_VERSION >= 3\n"
       << "static struct PyModuleDef py_" << library_name << "_module = {\n"
       << "  PyModuleDef_HEAD_INIT,\n"
-      << "  \"" << library_name << "\",\n"
+      << "  \"" << module_name << "\",\n"
       << "  NULL,\n"
       << "  -1,\n"
       << "  NULL,\n"


### PR DESCRIPTION
importlib is not there to correct ```__name__``` when doing package import