### PR TITLE
Update checkPandaVersion.h

### DIFF
--- a/dtool/src/dtoolbase/dtoolbase_cc.h
+++ b/dtool/src/dtoolbase/dtoolbase_cc.h
@@ -19,6 +19,13 @@
 
 #ifdef __cplusplus
 
+// By including checkPandaVersion.h, we guarantee that runtime attempts to
+// load any DLL will fail if they inadvertently link with the wrong version of
+// dtool, which, transitively, means all DLLs must be from the same
+// (ABI-compatible) version of Panda.
+
+#include "checkPandaVersion.h"
+
 #ifdef USE_TAU
 // Tau provides this destructive version of stdbool.h that we must mask.
 #define __PDT_STDBOOL_H_

--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -2606,18 +2606,21 @@ PANDAVERSION_H_RUNTIME="""
 
 CHECKPANDAVERSION_CXX="""
 # include "dtoolbase.h"
-EXPCL_DTOOL_DTOOLUTIL int panda_version_$VERSION1_$VERSION2 = 0;
+EXPCL_DTOOL_DTOOLBASE int panda_version_$VERSION1_$VERSION2 = 0;
 """
 
 CHECKPANDAVERSION_H="""
+# ifndef CHECKPANDAVERSION_H
+# define CHECKPANDAVERSION_H
 # include "dtoolbase.h"
-extern EXPCL_DTOOL_DTOOLUTIL int panda_version_$VERSION1_$VERSION2;
-# ifndef WIN32
-/* For Windows, exporting the symbol from the DLL is sufficient; the
-      DLL will not load unless all expected public symbols are defined.
-      Other systems may not mind if the symbol is absent unless we
-      explictly write code that references it. */
-static int check_panda_version = panda_version_$VERSION1_$VERSION2;
+extern EXPCL_DTOOL_DTOOLBASE int panda_version_$VERSION1_$VERSION2;
+// Hack to forcibly depend on the check
+template<typename T>
+class CheckPandaVersion {
+public:
+  int check() { return panda_version_$VERSION1_$VERSION2; }
+};
+template class CheckPandaVersion<void>;
 # endif
 """
 

--- a/panda/metalibs/panda/panda.cxx
+++ b/panda/metalibs/panda/panda.cxx
@@ -14,12 +14,6 @@
 #include "config_pstatclient.h"
 #endif
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpanda.so.dll will fail if they inadvertently link with the wrong
-// version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 #if !defined(CPPPARSER) && !defined(BUILDING_LIBPANDA)
   #error Buildsystem error: BUILDING_LIBPANDA not defined
 #endif

--- a/panda/metalibs/pandabullet/pandabullet.cxx
+++ b/panda/metalibs/pandabullet/pandabullet.cxx
@@ -7,12 +7,6 @@
 #include "pandabullet.h"
 #include "config_bullet.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandabullet.so.dll will fail if they inadvertently link with the
-// wrong version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandadx9/pandadx9.cxx
+++ b/panda/metalibs/pandadx9/pandadx9.cxx
@@ -9,12 +9,6 @@
 #include "config_dxgsg9.h"
 #include "wdxGraphicsPipe9.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandadx9.dll will fail if they inadvertently link with the wrong
-// version of libdtool.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandaegg/pandaegg.cxx
+++ b/panda/metalibs/pandaegg/pandaegg.cxx
@@ -9,12 +9,6 @@
 #include "config_egg.h"
 #include "config_egg2pg.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandaegg.so.dll will fail if they inadvertently link with the wrong
-// version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandaegg/pandaeggnopg.cxx
+++ b/panda/metalibs/pandaegg/pandaeggnopg.cxx
@@ -8,12 +8,6 @@
 
 #include "config_egg.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandaegg.so.dll will fail if they inadvertently link with the wrong
-// version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandaexpress/pandaexpress.cxx
+++ b/panda/metalibs/pandaexpress/pandaexpress.cxx
@@ -3,9 +3,3 @@
  * @author drose
  * @date 2000-05-15
  */
-
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandaexpress.so.dll will fail if they inadvertently link with the
-// wrong version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"

--- a/panda/metalibs/pandafx/pandafx.cxx
+++ b/panda/metalibs/pandafx/pandafx.cxx
@@ -8,12 +8,6 @@
 
 #include "config_distort.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandafx.so.dll will fail if they inadvertently link with the wrong
-// version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandagl/pandagl.cxx
+++ b/panda/metalibs/pandagl/pandagl.cxx
@@ -30,12 +30,6 @@
 #error One of HAVE_WGL, HAVE_COCOA, HAVE_CARBON or HAVE_GLX must be defined when compiling pandagl!
 #endif
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandagl.so.dll will fail if they inadvertently link with the wrong
-// version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandagles/pandagles.cxx
+++ b/panda/metalibs/pandagles/pandagles.cxx
@@ -17,12 +17,6 @@
 #include "eglGraphicsPipe.h"
 #endif
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandagles.so.dll will fail if they inadvertently link with the
-// wrong version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandagles2/pandagles2.cxx
+++ b/panda/metalibs/pandagles2/pandagles2.cxx
@@ -12,12 +12,6 @@
 #include "config_egldisplay.h"
 #include "eglGraphicsPipe.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandagles2.so.dll will fail if they inadvertently link with the
-// wrong version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandaode/pandaode.cxx
+++ b/panda/metalibs/pandaode/pandaode.cxx
@@ -7,12 +7,6 @@
 #include "pandaode.h"
 #include "config_ode.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandaode.so.dll will fail if they inadvertently link with the wrong
-// version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandaphysics/pandaphysics.cxx
+++ b/panda/metalibs/pandaphysics/pandaphysics.cxx
@@ -8,12 +8,6 @@
 #include "config_physics.h"
 #include "config_particlesystem.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandaphysics.so.dll will fail if they inadvertently link with the
-// wrong version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/metalibs/pandaphysx/pandaphysx.cxx
+++ b/panda/metalibs/pandaphysx/pandaphysx.cxx
@@ -7,12 +7,6 @@
 #include "pandaphysx.h"
 #include "config_physx.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libpandaphysx.so.dll will fail if they inadvertently link with the
-// wrong version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/src/android/pview.cxx
+++ b/panda/src/android/pview.cxx
@@ -21,12 +21,6 @@
 #include "bamCache.h"
 #include "virtualFileSystem.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to run
-// pview will fail if it inadvertently links with the wrong version of
-// libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 int main(int argc, char **argv) {
   PandaFramework framework;
   framework.open_framework(argc, argv);

--- a/panda/src/framework/config_framework.cxx
+++ b/panda/src/framework/config_framework.cxx
@@ -16,12 +16,6 @@
 #include "dconfig.h"
 #include "windowFramework.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to
-// load libframework.so.dll will fail if they inadvertently link with the
-// wrong version of libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 #if !defined(CPPPARSER) && !defined(BUILDING_FRAMEWORK)
   #error Buildsystem error: BUILDING_FRAMEWORK not defined
 #endif

--- a/panda/src/testbed/pview.cxx
+++ b/panda/src/testbed/pview.cxx
@@ -29,12 +29,6 @@
 #include "asyncTask.h"
 #include "boundingSphere.h"
 
-// By including checkPandaVersion.h, we guarantee that runtime attempts to run
-// pview will fail if it inadvertently links with the wrong version of
-// libdtool.so.dll.
-
-#include "checkPandaVersion.h"
-
 PandaFramework framework;
 
 ConfigVariableBool pview_test_hack


### PR DESCRIPTION
See relevant discussion [here](https://github.com/panda3d/panda3d/commit/d96765b9575665b72defacb72a2ee80483f934e8).

This removes the requirement for `checkPandaVersion.h` to be included only once, and moves its inclusion to `dtoolbase_cc.h`, which ensures that every Panda binary includes the check.

This uses a workaround allowed by the C++ ODR, namely that template expansions can contain multiple definitions of the same template function as long as all definitions are the same. In C++17, we'll be replacing this with inline variables. There is a note in the CMake buildsystem to remind us (loudly) once we bump the standard version to C++17.

Comparing a build of this branch vs. master:

- On master, only the following files contained a reference to the version symbol:
```
Binary file bin/pview matches
Binary file lib/x86_64-linux-gnu/panda3d/libpandagl.so matches
Binary file lib/x86_64-linux-gnu/panda3d/libp3dtool.so.1.10 matches
Binary file lib/x86_64-linux-gnu/panda3d/libpanda.so.1.10 matches
Binary file lib/x86_64-linux-gnu/panda3d/libpandaegg.so.1.10 matches
Binary file lib/x86_64-linux-gnu/panda3d/libpandaphysics.so.1.10 matches
Binary file lib/x86_64-linux-gnu/panda3d/libp3framework.so.1.10 matches
Binary file lib/x86_64-linux-gnu/panda3d/libpandabullet.so.1.10 matches
Binary file lib/x86_64-linux-gnu/panda3d/libpandaode.so.1.10 matches
Binary file lib/x86_64-linux-gnu/panda3d/libpandafx.so.1.10 matches
Binary file lib/x86_64-linux-gnu/panda3d/libpandaexpress.so.1.10 matches
```

- On this branch, all ELF binaries now contain a reference.

- Size increase for each library is negligible (101 bytes in the worst case)