### PR TITLE
express: Readd missing Datagram constructors

### DIFF
--- a/panda/src/express/datagram.I
+++ b/panda/src/express/datagram.I
@@ -53,6 +53,25 @@ Datagram(vector_uchar data) :
 }
 
 /**
+ * Constructs a datagram from an existing datagram.
+ */
+INLINE Datagram::
+Datagram(const Datagram &copy) :
+  _data(copy._data),
+  _stdfloat_double(copy._stdfloat_double)
+{
+}
+
+/**
+ * Assigns another datagram's data to the datagram.
+ */
+INLINE void Datagram::
+operator = (const Datagram &copy) {
+  _data = copy._data;
+  _stdfloat_double = copy._stdfloat_double;
+}
+
+/**
  * Adds a boolean value to the datagram.
  */
 INLINE void Datagram::

--- a/panda/src/express/datagram.I
+++ b/panda/src/express/datagram.I
@@ -53,16 +53,6 @@ Datagram(vector_uchar data) :
 }
 
 /**
- * Constructs a datagram from an existing datagram.
- */
-INLINE Datagram::
-Datagram(const Datagram &copy) :
-  _data(copy._data),
-  _stdfloat_double(copy._stdfloat_double)
-{
-}
-
-/**
  * Assigns another datagram's data to the datagram.
  */
 INLINE void Datagram::

--- a/panda/src/express/datagram.h
+++ b/panda/src/express/datagram.h
@@ -40,7 +40,7 @@ PUBLISHED:
   INLINE Datagram();
   INLINE Datagram(const void *data, size_t size);
   INLINE explicit Datagram(vector_uchar data);
-  INLINE Datagram(const Datagram &copy);
+  INLINE Datagram(const Datagram &copy) = default;
   INLINE void operator = (const Datagram &copy);
 
   virtual ~Datagram();

--- a/panda/src/express/datagram.h
+++ b/panda/src/express/datagram.h
@@ -40,6 +40,8 @@ PUBLISHED:
   INLINE Datagram();
   INLINE Datagram(const void *data, size_t size);
   INLINE explicit Datagram(vector_uchar data);
+  INLINE Datagram(const Datagram &copy);
+  INLINE void operator = (const Datagram &copy);
 
   virtual ~Datagram();
 

--- a/tests/putil/test_datagram.py
+++ b/tests/putil/test_datagram.py
@@ -97,7 +97,7 @@ def test_iterator(datagram_small):
     verify(dgi)
 
 # This tests the copy constructor:
-@pytest.mark.xfail
+
 def test_copy(datagram_small):
     dg, verify = datagram_small
 
@@ -105,7 +105,6 @@ def test_copy(datagram_small):
     dgi = core.DatagramIterator(dg2)
     verify(dgi)
 
-@pytest.mark.xfail
 def test_assign(datagram_small):
     dg, verify = datagram_small
 


### PR DESCRIPTION
Some game code relies on this functionality. Even though it's possible to rewrite the logic by constructing an empty Datagram and assigning the data to it manually, it's more convenient to have a constructor for it.

This code was removed in e9ae7dcc407d8198a701b761d0431f456c8ad925, but I feel like it should be added back.