### PR TITLE
discussion: Are we abusing NULL?

### DIFF
--- a/dtool/src/interrogate/interfaceMaker.cxx
+++ b/dtool/src/interrogate/interfaceMaker.cxx
@@ -665,7 +665,6 @@ record_object(TypeIndex type_index) {
 
   InterrogateDatabase *idb = InterrogateDatabase::get_ptr();
   const InterrogateType &itype = idb->get_type(type_index);
-  assert(&itype != NULL);
 
   Object *object = new Object(itype);
   bool inserted = _objects.insert(Objects::value_type(type_index, object)).second;

--- a/dtool/src/interrogate/interrogateBuilder.cxx
+++ b/dtool/src/interrogate/interrogateBuilder.cxx
@@ -1696,8 +1696,6 @@ get_function(CPPInstance *function, string description,
     InterrogateFunction &ifunction =
       InterrogateDatabase::get_ptr()->update_function(index);
 
-    nassertr(&ifunction != NULL, 0);
-
     ifunction._flags |= flags;
 
     // Also, make sure this particular signature is defined.

--- a/panda/src/express/nodeReferenceCount.I
+++ b/panda/src/express/nodeReferenceCount.I
@@ -52,8 +52,6 @@ NodeReferenceCount(const NodeReferenceCount &copy) : ReferenceCount(copy) {
  */
 INLINE void NodeReferenceCount::
 operator = (const NodeReferenceCount &copy) {
-  nassertv(this != NULL);
-
   // If this assertion fails, our own pointer was recently deleted.  Possibly
   // you used a real pointer instead of a PointerTo at some point, and the
   // object was deleted when the PointerTo went out of scope.  Maybe you tried
@@ -74,8 +72,6 @@ operator = (const NodeReferenceCount &copy) {
  */
 INLINE NodeReferenceCount::
 ~NodeReferenceCount() {
-  nassertv(this != NULL);
-
   // If this assertion fails, we're trying to delete an object that was just
   // deleted.  Possibly you used a real pointer instead of a PointerTo at some
   // point, and the object was deleted when the PointerTo went out of scope.

--- a/panda/src/express/nodeReferenceCount.cxx
+++ b/panda/src/express/nodeReferenceCount.cxx
@@ -21,8 +21,6 @@ TypeHandle NodeReferenceCount::_type_handle;
  */
 bool NodeReferenceCount::
 do_test_ref_count_integrity() const {
-  nassertr(this != NULL, false);
-
   // If this assertion fails, we're trying to delete an object that was just
   // deleted.  Possibly you used a real pointer instead of a PointerTo at some
   // point, and the object was deleted when the PointerTo went out of scope.

--- a/panda/src/express/referenceCount.I
+++ b/panda/src/express/referenceCount.I
@@ -63,8 +63,6 @@ ReferenceCount(const ReferenceCount &) {
  */
 INLINE void ReferenceCount::
 operator = (const ReferenceCount &) {
-  nassertv(this != NULL);
-
   // If this assertion fails, our own pointer was recently deleted.  Possibly
   // you used a real pointer instead of a PointerTo at some point, and the
   // object was deleted when the PointerTo went out of scope.  Maybe you tried
@@ -80,7 +78,6 @@ operator = (const ReferenceCount &) {
 ReferenceCount::
 ~ReferenceCount() {
   TAU_PROFILE("ReferenceCount::~ReferenceCount()", " ", TAU_USER);
-  nassertv(this != NULL);
 
   // If this assertion fails, we're trying to delete an object that was just
   // deleted.  Possibly you used a real pointer instead of a PointerTo at some

--- a/panda/src/express/referenceCount.cxx
+++ b/panda/src/express/referenceCount.cxx
@@ -23,8 +23,6 @@ TypeHandle ReferenceCount::_type_handle;
  */
 bool ReferenceCount::
 do_test_ref_count_integrity() const {
-  nassertr(this != NULL, false);
-
   // If this assertion fails, we're trying to delete an object that was just
   // deleted.  Possibly you used a real pointer instead of a PointerTo at some
   // point, and the object was deleted when the PointerTo went out of scope.

--- a/panda/src/express/weakPointerTo.I
+++ b/panda/src/express/weakPointerTo.I
@@ -45,7 +45,6 @@ WeakPointerTo(const WeakPointerTo<T> &copy) :
 template<class T>
 INLINE TYPENAME WeakPointerTo<T>::To &WeakPointerTo<T>::
 operator *() const {
-  nassertr(!this->was_deleted(), *((To *)NULL));
   return *((To *)WeakPointerToBase<T>::_void_ptr);
 }
 
@@ -208,7 +207,6 @@ WeakConstPointerTo(const WeakConstPointerTo<T> &copy) :
 template<class T>
 INLINE const TYPENAME WeakConstPointerTo<T>::To &WeakConstPointerTo<T>::
 operator *() const {
-  nassertr(!this->was_deleted(), *((To *)NULL));
   return *((To *)WeakPointerToBase<T>::_void_ptr);
 }
 

--- a/panda/src/putil/cachedTypedWritableReferenceCount.I
+++ b/panda/src/putil/cachedTypedWritableReferenceCount.I
@@ -49,8 +49,6 @@ CachedTypedWritableReferenceCount(const CachedTypedWritableReferenceCount &copy)
  */
 INLINE void CachedTypedWritableReferenceCount::
 operator = (const CachedTypedWritableReferenceCount &copy) {
-  nassertv(this != NULL);
-
   // If this assertion fails, our own pointer was recently deleted.  Possibly
   // you used a real pointer instead of a PointerTo at some point, and the
   // object was deleted when the PointerTo went out of scope.  Maybe you tried
@@ -71,8 +69,6 @@ operator = (const CachedTypedWritableReferenceCount &copy) {
  */
 INLINE CachedTypedWritableReferenceCount::
 ~CachedTypedWritableReferenceCount() {
-  nassertv(this != NULL);
-
   // If this assertion fails, we're trying to delete an object that was just
   // deleted.  Possibly you used a real pointer instead of a PointerTo at some
   // point, and the object was deleted when the PointerTo went out of scope.

--- a/panda/src/putil/cachedTypedWritableReferenceCount.cxx
+++ b/panda/src/putil/cachedTypedWritableReferenceCount.cxx
@@ -21,8 +21,6 @@ TypeHandle CachedTypedWritableReferenceCount::_type_handle;
  */
 bool CachedTypedWritableReferenceCount::
 do_test_ref_count_integrity() const {
-  nassertr(this != NULL, false);
-
   // If this assertion fails, we're trying to delete an object that was just
   // deleted.  Possibly you used a real pointer instead of a PointerTo at some
   // point, and the object was deleted when the PointerTo went out of scope.

--- a/panda/src/putil/nodeCachedReferenceCount.I
+++ b/panda/src/putil/nodeCachedReferenceCount.I
@@ -49,8 +49,6 @@ NodeCachedReferenceCount(const NodeCachedReferenceCount &copy) : CachedTypedWrit
  */
 INLINE void NodeCachedReferenceCount::
 operator = (const NodeCachedReferenceCount &copy) {
-  nassertv(this != NULL);
-
   // If this assertion fails, our own pointer was recently deleted.  Possibly
   // you used a real pointer instead of a PointerTo at some point, and the
   // object was deleted when the PointerTo went out of scope.  Maybe you tried
@@ -71,8 +69,6 @@ operator = (const NodeCachedReferenceCount &copy) {
  */
 INLINE NodeCachedReferenceCount::
 ~NodeCachedReferenceCount() {
-  nassertv(this != NULL);
-
   // If this assertion fails, we're trying to delete an object that was just
   // deleted.  Possibly you used a real pointer instead of a PointerTo at some
   // point, and the object was deleted when the PointerTo went out of scope.

--- a/panda/src/putil/nodeCachedReferenceCount.cxx
+++ b/panda/src/putil/nodeCachedReferenceCount.cxx
@@ -21,8 +21,6 @@ TypeHandle NodeCachedReferenceCount::_type_handle;
  */
 bool NodeCachedReferenceCount::
 do_test_ref_count_integrity() const {
-  nassertr(this != NULL, false);
-
   // If this assertion fails, we're trying to delete an object that was just
   // deleted.  Possibly you used a real pointer instead of a PointerTo at some
   // point, and the object was deleted when the PointerTo went out of scope.

--- a/panda/src/speedtree/speedTreeNode.I
+++ b/panda/src/speedtree/speedTreeNode.I
@@ -47,7 +47,6 @@ get_tree(int n) const {
  */
 INLINE const SpeedTreeNode::InstanceList &SpeedTreeNode::
 get_instance_list(int n) const {
-  nassertr(n >= 0 && n < (int)_trees.size(), *(InstanceList *)NULL);
   InstanceList *instance_list = _trees[n];
   return *instance_list;
 }

--- a/panda/src/speedtree/speedTreeNode.cxx
+++ b/panda/src/speedtree/speedTreeNode.cxx
@@ -145,9 +145,6 @@ count_total_instances() const {
  */
 SpeedTreeNode::InstanceList &SpeedTreeNode::
 add_tree(const STTree *tree) {
-  nassertr(is_valid(), *(InstanceList *)NULL);
-  nassertr(tree->is_valid(), *(InstanceList *)NULL);
-
   InstanceList ilist(tree);
   Trees::iterator ti = _trees.find(&ilist);
   if (ti == _trees.end()) {


### PR DESCRIPTION
This PR isn't so much a PR intended for inclusion as it is for indicating several bizarre asserts I'd like to discuss.

In particular, the asserts identified are:
1. Comparing `this` to `NULL`
2. Taking the address of a variable and comparing to `NULL`
3. Dereferencing `NULL` because of a failed assert

In many cases I understand what the asserts are trying to do; but these are still bad code smells.

For example, the asserts testing `this != NULL` are probably trying to verify that the destructor doesn't run twice. However, in those circumstances, `this` wouldn't be `NULL`: it would be a dangling pointer. The only thing this would catch is somebody casting NULL to a class pointer and then deleting it - and even then I think C++11's delete operator checks this for you (it ignores deletion of null).