### PR TITLE
dtool: Cull certain issues that arise with non-glibc builds

### DIFF
--- a/dtool/src/dtoolbase/dtoolbase.h
+++ b/dtool/src/dtoolbase/dtoolbase.h
@@ -123,7 +123,7 @@
 
 // This is a workaround for a glibc bug that is triggered by clang when
 // compiling with -ffast-math.
-#ifdef __clang__
+#if defined(__clang__) && defined(__GLIBC__)
 #include <sys/cdefs.h>
 #ifndef __extern_always_inline
 #define __extern_always_inline extern __always_inline

--- a/dtool/src/dtoolutil/executionEnvironment.cxx
+++ b/dtool/src/dtoolutil/executionEnvironment.cxx
@@ -577,8 +577,8 @@ read_args() {
   }
 #endif
 
-#if defined(IS_FREEBSD) || (defined(IS_LINUX) && !defined(__ANDROID__))
-  // FreeBSD and Linux have a function to get the origin of a loaded library.
+#if defined(RTLD_DI_ORIGIN)
+  // When building with glibc/uClibc, we typically have access to RTLD_DI_ORIGIN in Unix-like operating systems.
 
   char origin[PATH_MAX + 1];
 
@@ -598,12 +598,16 @@ read_args() {
   }
 #endif
 
-#if defined(IS_FREEBSD)
-  // On FreeBSD, we can use dlinfo to get the linked libraries.
-
+#if !defined(RTLD_DI_ORIGIN) && defined(RTLD_DI_LINKMAP)
+  // On platforms without RTLD_DI_ORIGIN, we can use dlinfo with RTLD_DI_LINKMAP to get the origin of a loaded library.
   if (_dtool_name.empty()) {
-    Link_map *map;
-    dlinfo(RTLD_SELF, RTLD_DI_LINKMAP, &map);
+    struct link_map *map;
+    #ifdef RTLD_SELF
+        void* self = RTLD_SELF;
+    #else
+        void* self = dlopen(NULL, RTLD_NOW | RTLD_NOLOAD);
+    #endif
+    dlinfo(self, RTLD_DI_LINKMAP, &map);
 
     while (map != NULL) {
       const char *tail = strrchr(map->l_name, '/');


### PR DESCRIPTION
# Summary
Currently, the dtool branch makes some assumptions as to the characteristics of the standard C library implementations it's being compiled against (mostly relating to non-GNU-compliant libdl implementations). 

This PR serves to make it deal with non-glibc stdlib implementations in a more flexible manner. Note that this was written and has been tested with musl in mind, however, it should also theoretically allow for compiling against uClibc as well.