### PR TITLE
Supporting "any" state transitions in FSM

### DIFF
--- a/direct/src/fsm/FSM.py
+++ b/direct/src/fsm/FSM.py
@@ -376,6 +376,22 @@ class FSM(DirectObject):
                 # accept it.
                 return (request,) + args
 
+            elif '*' in self.defaultTransitions.get(self.state, []):
+                # Whenever we have a '*' as our to transition, we allow
+                # to transit to any other state
+                return (request,) + args
+
+            elif request in self.defaultTransitions.get('*', []):
+                # If the requested state is in the default transitions
+                # from any state list, we also alow to transit to the
+                # new state
+                return (request,) + args
+
+            elif '*' in self.defaultTransitions.get('*', []):
+                # This is like we had set the defaultTransitions to None.
+                # Any state can transit to any other state
+                return (request,) + args
+
             # If self.defaultTransitions is not None, it is an error
             # to request a direct state transition (capital letter
             # request) not listed in defaultTransitions and not


### PR DESCRIPTION
Compared to other FSM implementations in other engines, Panda3D still missed an implementation to be able to transition to and from any given state when using the defaultTransitions dictionary.
Every user had to extend the filters by themselves to allow such transitions or add any possible state to the dictionary. This implementation will simplify the cases where a transition would need to be able to transit to or from any other state by simply adding an asterisk '\*' to the value part of the defaultTransitions dict or add the state to the '\*' key.

e.g.
`self.defaultTransitions = {
            "A": ["*"],
            "B": ["C"],
            "D": ["A"],
            "*": ["B", "D"]
        }`

In this example one can transit:
**From** -> **To**
A -> _Any State_
B -> C
B -> B
B -> D
C -> B
C -> D
D -> A
D -> B
D -> D

Without the any state implementation it would need to be written as:

`self.defaultTransitions = {
            "A": ["A", "B", "C", "D"],
            "B": ["B", "C", "D"],
            "C": ["B", "D"],
            "D": ["A", "B", "D"]
        }`

And if any other state had been added with an ability to transit to or from any state, it would be necessary to keep track of all states that are available to that FSM.