### PR TITLE
cmake: Fix install procedure for direct

### DIFF
--- a/direct/CMakeLists.txt
+++ b/direct/CMakeLists.txt
@@ -29,6 +29,7 @@ if(HAVE_PYTHON)
 endif()
 
 # Installation:
+install(TARGETS p3direct DESTINATION lib)
 if(HAVE_PYTHON)
   set(DIRECT_INSTALL_DIRECTORIES
       actor cluster controls directbase directdevices directnotify directscripts


### PR DESCRIPTION
# Summary
Currently, the libp3direct shared object and any symlinks associated with it are not included in the install process for the direct library. This MR adds the necessary install directive to direct's CMakeLists in order to rectify this behaviour.