### PR TITLE
Fix macro redefinition warning

### DIFF
--- a/panda/src/express/checksumHashGenerator.I
+++ b/panda/src/express/checksumHashGenerator.I
@@ -13,7 +13,9 @@
 
 #ifdef _WIN32
 // Needed for PtrToLong, below
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
+#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
`WIN32_LEAN_AND_MEAN` macro redefinition warning happens in some C++ projects although it does not happen while compiling Panda3D. This PR fixes it.