### PR TITLE
pandatool/maya: Fix compilation error by missing std namespace

### DIFF
--- a/pandatool/src/maya/maya_funcs.T
+++ b/pandatool/src/maya/maya_funcs.T
@@ -17,7 +17,7 @@
  */
 template<class ValueType>
 bool
-get_maya_attribute(MObject &node, const string &attribute_name,
+get_maya_attribute(MObject &node, const std::string &attribute_name,
                    ValueType &value) {
   bool status = false;
 
@@ -35,7 +35,7 @@ get_maya_attribute(MObject &node, const string &attribute_name,
  */
 template<class ValueType>
 bool
-set_maya_attribute(MObject &node, const string &attribute_name,
+set_maya_attribute(MObject &node, const std::string &attribute_name,
                    ValueType &value) {
   bool status = false;
 


### PR DESCRIPTION
Hello. I fixed compilation error in Maya tool caused by missing std namespace.