### PR TITLE
nsis: Correct building on NSIS 3.0

### DIFF
--- a/makepanda/installer.nsi
+++ b/makepanda/installer.nsi
@@ -1239,8 +1239,13 @@ done:
 
 FunctionEnd
 
+!ifndef LVM_GETITEMCOUNT
 !define LVM_GETITEMCOUNT 0x1004
+!endif
+
+!ifndef LVM_GETITEMTEXT
 !define LVM_GETITEMTEXT 0x102D
+!endif
 
 Function DumpLog
   Exch $5


### PR DESCRIPTION
LVM_GETITEMCOUNT and LVM_GETITEMTEXT are already defined post NSIS 3.0.

Trying to build the installer using an NSIS version post 3.0 will result in this error being thrown:

```
!define: "LVM_GETITEMCOUNT" already defined!
Error in script "makepanda\installer.nsi" on line 1242 -- aborting creation process
```

This pull request resolves this issue.