### PR TITLE
char: fix CharacterJointEffect dereferencing deleted Character pointer

### DIFF
--- a/panda/src/char/characterJointEffect.I
+++ b/panda/src/char/characterJointEffect.I
@@ -35,5 +35,9 @@ get_character() const {
  */
 INLINE bool CharacterJointEffect::
 matches_character(Character *character) const {
+  if (_character.was_deleted()) {
+    return false;
+  }
+
   return _character == character;
 }


### PR DESCRIPTION
This fixes a crash that would intermittently occur when deleting an Actor that had CJEs in the hierarchy.