### PR TITLE
Fix up the Scene Editor

### DIFF
--- a/contrib/src/sceneeditor/collisionWindow.py
+++ b/contrib/src/sceneeditor/collisionWindow.py
@@ -11,7 +11,7 @@ from direct.tkwidgets import Floater
 from direct.tkwidgets import Slider
 from Tkinter import *
 import string, math, types
-from pandac.PandaModules import *
+from panda3d.core import *
 
 
 class collisionWindow(AppShell):

--- a/contrib/src/sceneeditor/lightingPanel.py
+++ b/contrib/src/sceneeditor/lightingPanel.py
@@ -9,7 +9,7 @@ from direct.tkwidgets.VectorWidgets import Vector3Entry
 from direct.tkwidgets.Slider import Slider
 from Tkinter import Frame, Button, Menubutton, Menu
 import string, math, types, Pmw, Tkinter
-from pandac.PandaModules import *
+from panda3d.core import *
 
 class lightingPanel(AppShell):
     #################################################################

--- a/contrib/src/sceneeditor/propertyWindow.py
+++ b/contrib/src/sceneeditor/propertyWindow.py
@@ -11,7 +11,7 @@ from direct.tkwidgets import Floater
 from direct.tkwidgets import Dial
 from direct.tkwidgets import Slider
 from direct.tkwidgets import VectorWidgets
-from pandac.PandaModules import *
+from panda3d.core import *
 from Tkinter import *
 import Pmw
 

--- a/contrib/src/sceneeditor/quad.py
+++ b/contrib/src/sceneeditor/quad.py
@@ -9,10 +9,8 @@
 from direct.showbase.ShowBaseGlobal import *
 from direct.interval.IntervalGlobal import *
 from direct.showbase.DirectObject import DirectObject
-from pandac.PandaModules import *
+from panda3d.core import *
 import math
-#Manakel 2/12/2005: replace from pandac import by from pandac.PandaModules import
-from pandac.PandaModules import MouseWatcher
 
 
 class ViewPort:

--- a/contrib/src/sceneeditor/sceneEditor.py
+++ b/contrib/src/sceneeditor/sceneEditor.py
@@ -251,7 +251,10 @@ class myLevelEditor(AppShell):
         for event in self.actionEvents:
             self.accept(event[0], event[1], extraArgs = event[2:])
 
-        camera.toggleVis()
+        if camera.is_hidden():
+            camera.show()
+        else:
+            camera.hide()
         self.selectNode(base.camera) ## Initially, we select camera as the first node...
 
     def appInit(self):

--- a/contrib/src/sceneeditor/sceneEditor.py
+++ b/contrib/src/sceneeditor/sceneEditor.py
@@ -3,8 +3,10 @@ import sys
 try: import _tkinter
 except: sys.exit("Please install python module 'Tkinter'")
 
-import direct
-from direct.directbase.DirectStart import*
+from direct.showbase.ShowBase import ShowBase
+
+ShowBase()
+
 from direct.showbase.TkGlobal import spawnTkLoop
 from Tkinter import *
 from tkFileDialog import *
@@ -1708,4 +1710,4 @@ class myLevelEditor(AppShell):
 
 editor = myLevelEditor(parent = base.tkRoot)
 
-run()
+base.run()

--- a/contrib/src/sceneeditor/seCameraControl.py
+++ b/contrib/src/sceneeditor/seCameraControl.py
@@ -392,8 +392,7 @@ class DirectCameraControl(DirectObject):
             sf = 0.1
         self.coaMarker.setScale(sf)
         # Lerp color to fade out
-        self.coaMarker.lerpColor(VBase4(1,0,0,1), VBase4(1,0,0,0), 3.0,
-                                 task = 'fadeAway')
+        self.coaMarker.colorInterval(3.0, VBase4(1, 0, 0, 0), name='fadeAway').start()
 
     def homeCam(self):
         # Record undo point

--- a/contrib/src/sceneeditor/seFileSaver.py
+++ b/contrib/src/sceneeditor/seFileSaver.py
@@ -3,7 +3,7 @@
 # This code saves the scene out as python code... the scene is stored in the various dictionaries in "dataHolder.py" ...the class "AllScene"
 #
 ####################################################################################################################################################
-from pandac.PandaModules import *
+from panda3d.core import *
 
 from direct.showbase.ShowBaseGlobal import *
 import os

--- a/contrib/src/sceneeditor/seForceGroup.py
+++ b/contrib/src/sceneeditor/seForceGroup.py
@@ -1,8 +1,6 @@
-from pandac.PandaModules import *
+from panda3d.core import *
 from direct.showbase.DirectObject import DirectObject
 from direct.showbase.PhysicsManagerGlobal import *
-#Manakel 2/12/2005: replace from pandac import by from pandac.PandaModules import
-from pandac.PandaModules import ForceNode
 from direct.directnotify import DirectNotifyGlobal
 import sys
 

--- a/contrib/src/sceneeditor/seGeometry.py
+++ b/contrib/src/sceneeditor/seGeometry.py
@@ -12,7 +12,7 @@
 #
 #################################################################
 
-from pandac.PandaModules import *
+from panda3d.core import *
 from direct.directtools.DirectGlobals import *
 from direct.directtools.DirectUtil import *
 import math

--- a/contrib/src/sceneeditor/seLights.py
+++ b/contrib/src/sceneeditor/seLights.py
@@ -5,7 +5,7 @@
 from direct.showbase.DirectObject import *
 from string import lower
 from direct.directtools import DirectUtil
-from pandac.PandaModules import *
+from panda3d.core import *
 import string
 
 

--- a/contrib/src/sceneeditor/seManipulation.py
+++ b/contrib/src/sceneeditor/seManipulation.py
@@ -520,7 +520,7 @@ class ObjectHandles(NodePath,DirectObject):
         # To avoid recreating a vec every frame
         self.hitPt = Vec3(0)
         # Get a handle on the components
-        self.xHandles = self.find('**/X')
+        self.xHandles = self.find('**/ohScalingNode')
         self.xPostGroup = self.xHandles.find('**/x-post-group')
         self.xPostCollision = self.xHandles.find('**/x-post')
         self.xRingGroup = self.xHandles.find('**/x-ring-group')

--- a/contrib/src/sceneeditor/seMopathRecorder.py
+++ b/contrib/src/sceneeditor/seMopathRecorder.py
@@ -682,16 +682,16 @@ class MopathRecorder(AppShell, DirectObject):
         marker if subnode selected
         """
         taskMgr.remove(self.name + '-curveEditTask')
-        print nodePath.id()
-        if nodePath.id() in self.playbackMarkerIds:
+        print nodePath.get_key()
+        if nodePath.get_key() in self.playbackMarkerIds:
             SEditor.select(self.playbackMarker)
-        elif nodePath.id() in self.tangentMarkerIds:
+        elif nodePath.get_key() in self.tangentMarkerIds:
             SEditor.select(self.tangentMarker)
-        elif nodePath.id() == self.playbackMarker.id():
+        elif nodePath.get_key() == self.playbackMarker.get_key():
             self.tangentGroup.show()
             taskMgr.add(self.curveEditTask,
                                      self.name + '-curveEditTask')
-        elif nodePath.id() == self.tangentMarker.id():
+        elif nodePath.get_key() == self.tangentMarker.get_key():
             self.tangentGroup.show()
             taskMgr.add(self.curveEditTask,
                                      self.name + '-curveEditTask')
@@ -699,7 +699,7 @@ class MopathRecorder(AppShell, DirectObject):
             self.tangentGroup.hide()
 
     def getChildIds(self, nodePath):
-        ids = [nodePath.id()]
+        ids = [nodePath.get_key()]
         kids = nodePath.getChildren()
         for kid in kids:
             ids += self.getChildIds(kid)
@@ -710,14 +710,14 @@ class MopathRecorder(AppShell, DirectObject):
         Hook called upon deselection of a node path used to select playback
         marker if subnode selected
         """
-        if ((nodePath.id() == self.playbackMarker.id()) or
-            (nodePath.id() == self.tangentMarker.id())):
+        if ((nodePath.get_key() == self.playbackMarker.get_key()) or
+            (nodePath.get_key() == self.tangentMarker.get_key())):
             self.tangentGroup.hide()
 
     def curveEditTask(self,state):
         if self.curveCollection != None:
             # Update curve position
-            if self.manipulandumId == self.playbackMarker.id():
+            if self.manipulandumId == self.playbackMarker.get_key():
                 # Show playback marker
                 self.playbackMarker.getChild(0).show()
                 pos = Point3(0)
@@ -731,7 +731,7 @@ class MopathRecorder(AppShell, DirectObject):
                 # Note: this calls recompute on the curves
                 self.nurbsCurveDrawer.draw()
             # Update tangent
-            if self.manipulandumId == self.tangentMarker.id():
+            if self.manipulandumId == self.tangentMarker.get_key():
                 # If manipulating marker, update tangent
                 # Hide playback marker
                 self.playbackMarker.getChild(0).hide()
@@ -766,10 +766,10 @@ class MopathRecorder(AppShell, DirectObject):
     def manipulateObjectStartHook(self):
         self.manipulandumId = None
         if SEditor.selected.last:
-            if SEditor.selected.last.id() == self.playbackMarker.id():
-                self.manipulandumId = self.playbackMarker.id()
-            elif SEditor.selected.last.id() == self.tangentMarker.id():
-                self.manipulandumId = self.tangentMarker.id()
+            if SEditor.selected.last.get_key() == self.playbackMarker.get_key():
+                self.manipulandumId = self.playbackMarker.get_key()
+            elif SEditor.selected.last.get_key() == self.tangentMarker.get_key():
+                self.manipulandumId = self.tangentMarker.get_key()
 
     def manipulateObjectCleanupHook(self):
         # Clear flag
@@ -1282,7 +1282,7 @@ class MopathRecorder(AppShell, DirectObject):
             dictName = name
         else:
             # Generate a unique name for the dict
-            dictName = name # + '-' + `nodePath.id()`
+            dictName = name # + '-' + `nodePath.get_key()`
         if not dict.has_key(dictName):
             # Update combo box to include new item
             names.append(dictName)

--- a/contrib/src/sceneeditor/seParticleEffect.py
+++ b/contrib/src/sceneeditor/seParticleEffect.py
@@ -1,4 +1,4 @@
-from pandac.PandaModules import *
+from panda3d.core import *
 import seParticles
 import seForceGroup
 from direct.directnotify import DirectNotifyGlobal

--- a/contrib/src/sceneeditor/seParticles.py
+++ b/contrib/src/sceneeditor/seParticles.py
@@ -1,28 +1,8 @@
-from pandac.PandaModules import *
+from panda3d.core import *
+from panda3d.physics import *
 from direct.particles.ParticleManagerGlobal import *
 from direct.showbase.PhysicsManagerGlobal import *
-#Manakel 2/12/2005: replace from pandac import by from pandac.PandaModules import
-from pandac.PandaModules import ParticleSystem
-from pandac.PandaModules import BaseParticleFactory
-from pandac.PandaModules import PointParticleFactory
-from pandac.PandaModules import ZSpinParticleFactory
 #import OrientedParticleFactory
-from pandac.PandaModules import BaseParticleRenderer
-from pandac.PandaModules import PointParticleRenderer
-from pandac.PandaModules import LineParticleRenderer
-from pandac.PandaModules import GeomParticleRenderer
-from pandac.PandaModules import SparkleParticleRenderer
-from pandac.PandaModules import SpriteParticleRenderer
-from pandac.PandaModules import BaseParticleEmitter
-from pandac.PandaModules import BoxEmitter
-from pandac.PandaModules import DiscEmitter
-from pandac.PandaModules import LineEmitter
-from pandac.PandaModules import PointEmitter
-from pandac.PandaModules import RectangleEmitter
-from pandac.PandaModules import RingEmitter
-from pandac.PandaModules import SphereSurfaceEmitter
-from pandac.PandaModules import SphereVolumeEmitter
-from pandac.PandaModules import TangentRingEmitter
 import string
 import os
 from direct.directnotify import DirectNotifyGlobal

--- a/contrib/src/sceneeditor/sePlacer.py
+++ b/contrib/src/sceneeditor/sePlacer.py
@@ -428,7 +428,7 @@ class Placer(AppShell):
                 background = self.nodePathMenuBG)
             # Check to see if node path and ref node path are the same
             if ((self.refCS != None) and
-                (self.refCS.id() == self['nodePath'].id())):
+                (self.refCS.get_key() == self['nodePath'].get_key())):
                 # Yes they are, use temp CS as ref
                 # This calls updatePlacer
                 self.setReferenceNodePath(self.tempCS)
@@ -473,7 +473,7 @@ class Placer(AppShell):
                     listbox = self.refNodePathMenu.component('scrolledlist')
                     listbox.setlist(self.refNodePathNames)
         # Check to see if node path and ref node path are the same
-        if (nodePath != None) and (nodePath.id() == self['nodePath'].id()):
+        if (nodePath != None) and (nodePath.get_key() == self['nodePath'].get_key()):
             # Yes they are, use temp CS and update listbox accordingly
             nodePath = self.tempCS
             self.refNodePathMenu.selectitem('parent')
@@ -508,7 +508,7 @@ class Placer(AppShell):
             dictName = name
         else:
             # Generate a unique name for the dict
-            dictName = name + '-' + `nodePath.id()`
+            dictName = name + '-' + `nodePath.get_key()`
         if not dict.has_key(dictName):
             # Update combo box to include new item
             names.append(dictName)

--- a/contrib/src/sceneeditor/sePlacer.py
+++ b/contrib/src/sceneeditor/sePlacer.py
@@ -6,7 +6,7 @@ from direct.tkwidgets.AppShell import AppShell
 from direct.tkwidgets.Dial import AngleDial
 from direct.tkwidgets.Floater import Floater
 from Tkinter import Button, Menubutton, Menu, StringVar
-from pandac.PandaModules import *
+from panda3d.core import *
 import Tkinter, Pmw
 """
 TODO:

--- a/contrib/src/sceneeditor/seSceneGraphExplorer.py
+++ b/contrib/src/sceneeditor/seSceneGraphExplorer.py
@@ -141,7 +141,7 @@ class seSceneGraphExplorer(Pmw.MegaWidget, DirectObject):
         self._node.deselecttree()
 
     def selectNodePath(self,nodePath, callBack=True):
-        item = self._node.find(nodePath.id())
+        item = self._node.find(nodePath.get_key())
         if item!= None:
             item.select(callBack)
         else:
@@ -164,7 +164,7 @@ class SceneGraphExplorerItem(TreeItem):
         return name
 
     def GetKey(self):
-        return self.nodePath.id()
+        return self.nodePath.get_key()
 
     def IsEditable(self):
         # All nodes' names can be edited nowadays.

--- a/contrib/src/sceneeditor/seSelection.py
+++ b/contrib/src/sceneeditor/seSelection.py
@@ -78,7 +78,7 @@ class SelectedNodePaths(DirectObject):
             self.deselectAll()
 
         # Get this pointer
-        id = nodePath.id()
+        id = nodePath.get_key()
         # First see if its already in the selected dictionary
         dnp = self.getSelectedDict(id)
         # If so, we're done
@@ -96,7 +96,7 @@ class SelectedNodePaths(DirectObject):
                 # Show its bounding box
                 dnp.highlight()
             # Add it to the selected dictionary
-            self.selectedDict[dnp.id()] = dnp
+            self.selectedDict[dnp.get_key()] = dnp
         # And update last
         __builtins__["last"] = self.last = dnp
         return dnp
@@ -104,7 +104,7 @@ class SelectedNodePaths(DirectObject):
     def deselect(self, nodePath):
         """ Deselect the specified node path """
         # Get this pointer
-        id = nodePath.id()
+        id = nodePath.get_key()
         # See if it is in the selected dictionary
         dnp = self.getSelectedDict(id)
         if dnp:
@@ -204,15 +204,24 @@ class SelectedNodePaths(DirectObject):
         # Remove all selected nodePaths from the Scene Graph
         self.forEachSelectedNodePathDo(NodePath.remove)
 
+    def toggleVis(self, nodePath):
+        if nodePath.is_hidden():
+            nodePath.show()
+        else:
+            nodePath.hide()
+
     def toggleVisSelected(self):
         selected = self.last
         # Toggle visibility of selected node paths
         if selected:
-            selected.toggleVis()
+            if selected.is_hidden():
+                selected.show()
+            else:
+                selected.hide()
 
     def toggleVisAll(self):
         # Toggle viz for all selected node paths
-        self.forEachSelectedNodePathDo(NodePath.toggleVis)
+        self.forEachSelectedNodePathDo(self.toggleVis)
 
     def isolateSelected(self):
         selected = self.last
@@ -221,7 +230,7 @@ class SelectedNodePaths(DirectObject):
 
     def getDirectNodePath(self, nodePath):
         # Get this pointer
-        id = nodePath.id()
+        id = nodePath.get_key()
         # First check selected dict
         dnp = self.getSelectedDict(id)
         if dnp:

--- a/contrib/src/sceneeditor/seSelection.py
+++ b/contrib/src/sceneeditor/seSelection.py
@@ -11,7 +11,7 @@
 # (If we do change original directools, it will force user has to install the latest version of OUR Panda)
 #
 #################################################################
-from pandac.PandaModules import GeomNode
+from panda3d.core import GeomNode
 from direct.directtools.DirectGlobals import *
 from direct.directtools.DirectUtil import *
 from seGeometry import *

--- a/contrib/src/sceneeditor/seSession.py
+++ b/contrib/src/sceneeditor/seSession.py
@@ -388,7 +388,7 @@ class SeSession(DirectObject):  ### Customized DirectSession
             messenger.send('DIRECT_preSelectNodePath', [dnp])
             if fResetAncestry:
                 # Update ancestry
-                self.ancestry = dnp.getAncestors()
+                self.ancestry = list(dnp.getAncestors())
                 self.ancestry.reverse()
                 self.ancestryIndex = 0
             # Update the selectedNPReadout

--- a/contrib/src/sceneeditor/seSession.py
+++ b/contrib/src/sceneeditor/seSession.py
@@ -479,7 +479,7 @@ class SeSession(DirectObject):  ### Customized DirectSession
 
 
     def isNotCycle(self, nodePath, parent):
-        if nodePath.id() == parent.id():
+        if nodePath.get_key() == parent.get_key():
             print 'DIRECT.reparent: Invalid parent'
             return 0
         elif parent.hasParent():
@@ -520,7 +520,10 @@ class SeSession(DirectObject):  ### Customized DirectSession
             nodePath = self.selected.last
         if nodePath:
             # Now toggle node path's visibility state
-            nodePath.toggleVis()
+            if nodePath.is_hidden():
+                nodePath.show()
+            else:
+                nodePath.hide()
 
     def removeNodePath(self, nodePath = 'None Given'):
         if nodePath == 'None Given':

--- a/contrib/src/sceneeditor/seTree.py
+++ b/contrib/src/sceneeditor/seTree.py
@@ -15,7 +15,7 @@
 import os, sys, string, Pmw, Tkinter
 from direct.showbase.DirectObject import DirectObject
 from Tkinter import IntVar, Menu, PhotoImage, Label, Frame, Entry
-from pandac.PandaModules import *
+from panda3d.core import *
 
 # Initialize icon directory
 ICONDIR = getModelPath().findFile(Filename('icons')).toOsSpecific()


### PR DESCRIPTION
This pull request fixes up the Scene Editor by:

- Replacing all pandac.PandaModules imports with panda3d.* imports (mostly panda3d.core, but also a panda3d.physics import)
- Getting the Scene Editor actually running.
- Eliminating deprecated calls such as NodePath.id() & NodePath.toggleVis()
- Swapping DirectStart w/ ShowBase & base.run()
