### PR TITLE
distributed: Add missing `addTaggedInterest` method

### DIFF
--- a/direct/src/distributed/DoInterestManager.py
+++ b/direct/src/distributed/DoInterestManager.py
@@ -192,6 +192,9 @@ class DoInterestManager(DirectObject.DirectObject):
             messenger.send(self._getAddInterestEvent(), [event])
         assert self.printInterestsIfDebug()
         return InterestHandle(handle)
+    
+    def addTaggedInterest(self, parentId, zoneIdList, mainTag, description, otherTags=[], event=None):
+        return self.addInterest(parentId, zoneIdList, description, event)
 
     def addAutoInterest(self, parentId, zoneIdList, description):
         """


### PR DESCRIPTION
This missing method is called in `GridChild`, and if your ClientRepository does not have it already then you'll get an AttributeError when attempting to set grid interest.