### PR TITLE
Make Loader.loadSound() accept a MovieAudio instance as soundPath

### DIFF
--- a/direct/src/showbase/Loader.py
+++ b/direct/src/showbase/Loader.py
@@ -934,8 +934,8 @@ class Loader(DirectObject):
         just as in loadModel(); otherwise, the loading happens before
         loadSound() returns."""
 
-        if not isinstance(soundPath, (MovieAudio, tuple, list, set)):
-            # We were given a single sound pathname.
+        if not isinstance(soundPath, (tuple, list, set)):
+            # We were given a single sound pathname or a MovieAudio instance.
             soundList = [soundPath]
             gotList = False
         else:


### PR DESCRIPTION
This functionality seems to have inadvertently been removed by
refactoring commit 23bf9ea5.