### PR TITLE
makepanda: fix link error of assimp tool

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -680,6 +680,9 @@ if (COMPILER == "MSVC"):
         IncDirectory("FCOLLADA", GetThirdpartyDir() + "fcollada/include/FCollada")
     if (PkgSkip("ASSIMP")==0):
         LibName("ASSIMP", GetThirdpartyDir() + "assimp/lib/assimp.lib")
+        path = GetThirdpartyDir() + "assimp/lib/IrrXML.lib"
+        if os.path.isfile(path):
+            LibName("ASSIMP", GetThirdpartyDir() + "assimp/lib/IrrXML.lib")
         IncDirectory("ASSIMP", GetThirdpartyDir() + "assimp/include/assimp")
     if (PkgSkip("SQUISH")==0):
         if GetOptimize() <= 2:


### PR DESCRIPTION
Hello! This PR fixes link error of assimp tool (libp3assimp.dll) by missing `IrrXML.lib`.
IrrXML.lib file is generated by recent Assimp library (in panda3d-thirdparty repository).