### PR TITLE
Undeprecate FFT compression

### DIFF
--- a/panda/src/chan/animChannelMatrixXfmTable.cxx
+++ b/panda/src/chan/animChannelMatrixXfmTable.cxx
@@ -327,16 +327,10 @@ void AnimChannelMatrixXfmTable::
 write_datagram(BamWriter *manager, Datagram &me) {
   AnimChannelMatrix::write_datagram(manager, me);
 
-  if (compress_channels) {
-    chan_cat.warning()
-      << "FFT compression of animations is deprecated.  For compatibility "
-         "with future versions of Panda3D, set compress-channels to false.\n";
-
-    if (!FFTCompressor::is_compression_available()) {
-      chan_cat.error()
-        << "Compression is not available; writing uncompressed channels.\n";
-      compress_channels = false;
-    }
+  if (compress_channels && !FFTCompressor::is_compression_available()) {
+    chan_cat.error()
+      << "Compression is not available; writing uncompressed channels.\n";
+    compress_channels = false;
   }
 
   me.add_bool(compress_channels);

--- a/panda/src/chan/animChannelScalarTable.cxx
+++ b/panda/src/chan/animChannelScalarTable.cxx
@@ -146,16 +146,10 @@ void AnimChannelScalarTable::
 write_datagram(BamWriter *manager, Datagram &me) {
   AnimChannelScalar::write_datagram(manager, me);
 
-  if (compress_channels) {
-    chan_cat.warning()
-      << "FFT compression of animations is deprecated.  For compatibility "
-         "with future versions of Panda3D, set compress-channels to false.\n";
-
-    if (!FFTCompressor::is_compression_available()) {
-      chan_cat.error()
-        << "Compression is not available; writing uncompressed channels.\n";
-      compress_channels = false;
-    }
+  if (compress_channels && !FFTCompressor::is_compression_available()) {
+    chan_cat.error()
+      << "Compression is not available; writing uncompressed channels.\n";
+    compress_channels = false;
   }
 
   me.add_bool(compress_channels);


### PR DESCRIPTION
This reverts commit 2c6a6c9f062dbb7df340133ccdce37fef2c06f2c.

This commit constitutes a commitment to keep the FFT compression feature
around in 1.10 and beyond. The plan at this time is to replace FFTW
support with FFTS (which is comparable in speed and much more liberally
licensed) and have a builtin DFT/FFT implementation to fall back on when
FFTS is not available. In this regard, FFTS does for Fourier transforms
what Eigen does for linear transforms: it provides a more efficient
implementation for Panda to use, but isn't necessary for the functionality
to work.

I should note that I'm not interested in FFT just for the animation compression
code (honestly, I think a better way to store animations would be to make use of
parametric curves), but because having a `FastFourierTransform` class in mathutil
can come in very handy for e.g. audio effects, apps working with multimedia, etc.

I made this a pull request so that we can be sure we're in agreement with this
direction before it lands on master.