### PR TITLE
Fix BulletCapsuleShape creation from Panda CollisionTube

### DIFF
--- a/panda/src/bullet/bulletCapsuleShape.cxx
+++ b/panda/src/bullet/bulletCapsuleShape.cxx
@@ -93,8 +93,8 @@ BulletCapsuleShape *BulletCapsuleShape::
 make_from_solid(const CollisionTube *solid) {
   
   PN_stdfloat radius = solid->get_radius();
-  // CollisionTube height includes the hemispheres, Bullet only wants the cylinder height.
-  PN_stdfloat height = (solid->get_point_b() - solid->get_point_a()).length() - (radius * 2);
+  // Get tube's cylinder height: length from point A to point B
+  PN_stdfloat height = (solid->get_point_b() - solid->get_point_a()).length();
 
   // CollisionTubes are always Z-Up.
   return new BulletCapsuleShape(radius, height, Z_up);


### PR DESCRIPTION
Functions get_point_a() and get_point_b() appear to return the top of the cylinder section of the tube, not the tip of the endcap, making subtracting the radius unnecessary.