### PR TITLE
display: fix pointer casting in get_pointer()

### DIFF
--- a/panda/src/windisplay/winGraphicsWindow.cxx
+++ b/panda/src/windisplay/winGraphicsWindow.cxx
@@ -138,7 +138,7 @@ get_pointer(int device) const {
       double time = ClockObject::get_global_clock()->get_real_time();
       result._xpos = cpos.x;
       result._ypos = cpos.y;
-      ((GraphicsWindowInputDevice &)_input_devices[0]).set_pointer_in_window(result._xpos, result._ypos, time);
+      ((GraphicsWindowInputDevice *)_input_devices[0].p())->set_pointer_in_window(result._xpos, result._ypos, time);
     }
   }
   return result;

--- a/panda/src/x11display/x11GraphicsWindow.cxx
+++ b/panda/src/x11display/x11GraphicsWindow.cxx
@@ -164,7 +164,7 @@ get_pointer(int device) const {
         double time = ClockObject::get_global_clock()->get_real_time();
         result._xpos = event.xbutton.x;
         result._ypos = event.xbutton.y;
-        ((GraphicsWindowInputDevice &)_input_devices[0]).set_pointer_in_window(result._xpos, result._ypos, time);
+        ((GraphicsWindowInputDevice *)_input_devices[0].p())->set_pointer_in_window(result._xpos, result._ypos, time);
       }
       x11GraphicsPipe::_x_mutex.release();
     }


### PR DESCRIPTION
After merging 7ed8b01a commit, a crash happens on patched line of `get_pointer()`.
I fixed it to pointer casting because `_input_devices` is vector of pointer.

ps. I don't know why there was no problem previously.