### PR TITLE
x11display: Do not grab the mouse in confined mode when the window does not have focus

### DIFF
--- a/panda/src/x11display/x11GraphicsWindow.cxx
+++ b/panda/src/x11display/x11GraphicsWindow.cxx
@@ -508,6 +508,26 @@ process_events() {
     changed_properties = true;
   }
 
+  if (properties.has_foreground() && _properties.get_mouse_mode() == WindowProperties::M_confined) {
+      // Focus has changed, let's let go of the pointer if we've grabbed or re-grab it if needed
+      if (properties.get_foreground()) {
+        // Window is going to the foreground, re-grab the pointer
+        X11_Cursor cursor = None;
+        if (_properties.get_cursor_hidden()) {
+            x11GraphicsPipe *x11_pipe;
+            DCAST_INTO_V(x11_pipe, _pipe);
+            cursor = x11_pipe->get_hidden_cursor();
+        }
+
+        XGrabPointer(_display, _xwindow, True, 0, GrabModeAsync, GrabModeAsync,
+                    _xwindow, cursor, CurrentTime);
+      }
+      else {
+        // window is leaving the foreground, ungrab the pointer
+        XUngrabPointer(_display, CurrentTime);
+      }
+  }
+
   if (changed_properties) {
     system_changed_properties(properties);
   }


### PR DESCRIPTION
This fixes #393 and seems to work fine with the mouse_mode sample app.