### PR TITLE
Fix Static Building for .pyd targets and etc.

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -2199,6 +2199,9 @@ def CompileAnything(target, inputs, opts, progress = None):
         if (origsuffix==".exe"):
             ProgressOutput(progress, "Linking executable", target)
         else:
+            if GetLinkAllStatic(): # If we're building statically, dynamic libraries are un-needed and may cause issues.
+                ProgressOutput(progress, "Linking static library", target)
+                return CompileLib(target, inputs, opts)
             ProgressOutput(progress, "Linking dynamic library", target)
 
         # Add version number to the dynamic library, on unix

--- a/makepanda/makepandacore.py
+++ b/makepanda/makepandacore.py
@@ -3265,8 +3265,12 @@ def GetExtensionSuffix():
 
     target = GetTarget()
     if target == 'windows':
+        if GetLinkAllStatic():
+            return '.lib'
         return '.pyd'
     else:
+        if GetLinkAllStatic():
+            return '.a'
         return '.so'
 
 def GetPythonABI():


### PR DESCRIPTION
Have --static build a .dll or .pyd as .lib no matter what. It's a static build not a mixed built.

I discovered this issue when trying to build statically in a certain way and saw the compiler trying to make a .pyd when those can't be used statically. This was not an issue before a revision to the way Python targets were added but became one after a check no longer passed for them.