### PR TITLE
pgraph: fix BillboardEffect regression with older models

### DIFF
--- a/panda/src/pgraph/billboardEffect.cxx
+++ b/panda/src/pgraph/billboardEffect.cxx
@@ -375,5 +375,7 @@ fillin(DatagramIterator &scan, BamReader *manager) {
   if (manager->get_file_minor_ver() >= 43) {
     _look_at.fillin(scan, manager);
     _fixed_depth = scan.get_bool();
+  } else {
+    _fixed_depth = false;
   }
 }


### PR DESCRIPTION
In older BAM files (version <= 6.42), _fixed_depth will have an uncertain value after loading, leading to incorrect transform calculations, which cause rendering issues (see issue #474).

This commit sets _fixed_depth to false when loading older models, which restores the correct legacy behavior.

Fixes issue #474.