### PR TITLE
Use CVDisplayLink on macOS to sync video to display(s)

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
@@ -49,11 +49,11 @@ public:
   FrameBufferProperties _fbprops;
   
   CVDisplayLinkRef _display_link;
-  Mutex swap_lock;
-  ConditionVar swap_condition;
-  std::atomic_bool should_wait;
+  Mutex _swap_lock;
+  ConditionVar _swap_condition;
+  AtomicAdjust::Integer _last_wait_frame;
+  bool _will_vsync;
   bool setup_vsync();
-  bool will_vsync;
 
 protected:
   virtual void query_gl_version();

--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
@@ -17,9 +17,11 @@
 #include "pandabase.h"
 #include "cocoaGraphicsPipe.h"
 #include "glgsg.h"
+#include <atomic>
 
 #import <AppKit/NSOpenGL.h>
 #import <OpenGL/OpenGL.h>
+#import <CoreVideo/CoreVideo.h>
 
 /**
  * A tiny specialization on GLGraphicsStateGuardian to add some Cocoa-specific
@@ -45,6 +47,13 @@ public:
   NSOpenGLContext *_share_context;
   NSOpenGLContext *_context;
   FrameBufferProperties _fbprops;
+  
+  CVDisplayLinkRef _display_link;
+  Mutex swap_lock;
+  ConditionVar swap_condition;
+  std::atomic_bool should_wait;
+  bool setup_vsync();
+  bool will_vsync;
 
 protected:
   virtual void query_gl_version();

--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
@@ -41,6 +41,7 @@ CocoaGraphicsStateGuardian(GraphicsEngine *engine, GraphicsPipe *pipe,
 {
   _share_context = nil;
   _context = nil;
+  _will_vsync = false;
 
   if (share_with != (CocoaGraphicsStateGuardian *)NULL) {
     _prepared_objects = share_with->get_prepared_objects();

--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
@@ -269,10 +269,6 @@ choose_pixel_format(const FrameBufferProperties &properties,
     return;
   }
 
-  // Set vsync setting on the context
-  GLint swap = sync_video ? 1 : 0;
-  [_context setValues:&swap forParameter:NSOpenGLCPSwapInterval];
-
   cocoadisplay_cat.debug()
     << "Created context " << _context << ": " << _fbprops << "\n";
 }

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.h
@@ -84,8 +84,6 @@ private:
   void handle_modifier(NSUInteger modifierFlags, NSUInteger mask, ButtonHandle button);
   ButtonHandle map_key(unsigned short c) const;
   ButtonHandle map_raw_key(unsigned short keycode) const;
-  
-  bool setup_vsync();
 
 private:
   NSWindow *_window;
@@ -96,9 +94,6 @@ private:
   PT(GraphicsWindowInputDevice) _input;
   bool _mouse_hidden;
   bool _context_needs_update;
-  
-  bool _can_sync_video;
-  CVDisplayLinkRef _display_link;
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
   CGDisplayModeRef _fullscreen_mode;

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.h
@@ -109,9 +109,6 @@ private:
 public:
   // Just so CocoaPandaView can access it.
   NSCursor *_cursor;
-  
-  bool has_frame;
-  void display_ready();
 
 public:
   static TypeHandle get_class_type() {

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.h
@@ -23,6 +23,8 @@
 #import <AppKit/NSView.h>
 #import <AppKit/NSWindow.h>
 
+#import <CoreVideo/CoreVideo.h>
+
 /**
  * An interface to the Cocoa system for managing OpenGL windows under Mac OS
  * X.
@@ -82,6 +84,8 @@ private:
   void handle_modifier(NSUInteger modifierFlags, NSUInteger mask, ButtonHandle button);
   ButtonHandle map_key(unsigned short c) const;
   ButtonHandle map_raw_key(unsigned short keycode) const;
+  
+  bool setup_vsync();
 
 private:
   NSWindow *_window;
@@ -92,6 +96,9 @@ private:
   PT(GraphicsWindowInputDevice) _input;
   bool _mouse_hidden;
   bool _context_needs_update;
+  
+  bool _can_sync_video;
+  CVDisplayLinkRef _display_link;
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
   CGDisplayModeRef _fullscreen_mode;
@@ -107,6 +114,9 @@ private:
 public:
   // Just so CocoaPandaView can access it.
   NSCursor *_cursor;
+  
+  bool has_frame;
+  void display_ready();
 
 public:
   static TypeHandle get_class_type() {


### PR DESCRIPTION
This PR is intended to fix #486, however it is not ready to be merged. The initial code here is making a few assumptions, but I'm wanting to see if I'm going in the right direction here.

In macOS 10.14, among other issues, `NSOpenGLContext` no longer responds to requests to sync to the display. An alternative to this is `CVDisplayLink`, which is less "set and forget" but offers greater flexibility for applications with multiple windows that are used across monitors with different refresh rates.

I'm not overly familiar with the timing system of Panda, but it appears there's just one global clock used for measuring frametime that is ticked in `GraphicsEngine`. As a result, although the draw rate is properly regulated using this method, the frames per second measurement is inaccurate. I'm interested in hearing suggestions for possible solutions to this.