### PR TITLE
Prevent a deadlock when using SIMPLE_THREADS on macOS.

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
@@ -53,6 +53,9 @@ public:
   Mutex _swap_lock;
   ConditionVar _swap_condition;
   AtomicAdjust::Integer _last_wait_frame = 0;
+#ifdef SIMPLE_THREADS
+  std::atomic_flag _vsync_wait_flag = ATOMIC_FLAG_INIT;
+#endif
 
 protected:
   virtual void query_gl_version();

--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
@@ -50,8 +50,8 @@ public:
   FrameBufferProperties _fbprops;
 
   CVDisplayLinkRef _display_link = nullptr;
-  Mutex _swap_lock;
-  ConditionVar _swap_condition;
+  TrueMutexImpl _swap_lock;
+  TrueConditionVarImpl _swap_condition;
   AtomicAdjust::Integer _last_wait_frame = 0;
 
 protected:

--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.h
@@ -53,9 +53,6 @@ public:
   Mutex _swap_lock;
   ConditionVar _swap_condition;
   AtomicAdjust::Integer _last_wait_frame = 0;
-#ifdef SIMPLE_THREADS
-  std::atomic_flag _vsync_wait_flag = ATOMIC_FLAG_INIT;
-#endif
 
 protected:
   virtual void query_gl_version();

--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
@@ -37,8 +37,9 @@ display_link_cb(CVDisplayLinkRef link, const CVTimeStamp *now,
                 const CVTimeStamp* output_time, CVOptionFlags flags_in,
                 CVOptionFlags *flags_out, void *context) {
   CocoaGraphicsStateGuardian *gsg = (CocoaGraphicsStateGuardian *)context;
-  MutexHolder swap_holder(gsg->_swap_lock);
+  gsg->_swap_lock.lock();
   gsg->_swap_condition.notify();
+  gsg->_swap_lock.unlock();
   return kCVReturnSuccess;
 }
 
@@ -73,8 +74,9 @@ CocoaGraphicsStateGuardian::
   if (_display_link != nil) {
     CVDisplayLinkRelease(_display_link);
     _display_link = nil;
-    MutexHolder swap_holder(_swap_lock);
+    _swap_lock.lock();
     _swap_condition.notify();
+    _swap_lock.unlock();
   }
   if (_context != nil) {
     [_context clearDrawable];

--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
@@ -37,12 +37,8 @@ display_link_cb(CVDisplayLinkRef link, const CVTimeStamp *now,
                 const CVTimeStamp* output_time, CVOptionFlags flags_in,
                 CVOptionFlags *flags_out, void *context) {
   CocoaGraphicsStateGuardian *gsg = (CocoaGraphicsStateGuardian *)context;
-#ifdef SIMPLE_THREADS
-  gsg->_vsync_wait_flag.clear();
-#else
   MutexHolder swap_holder(gsg->_swap_lock);
   gsg->_swap_condition.notify();
-#endif
   return kCVReturnSuccess;
 }
 

--- a/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsStateGuardian.mm
@@ -37,8 +37,12 @@ display_link_cb(CVDisplayLinkRef link, const CVTimeStamp *now,
                 const CVTimeStamp* output_time, CVOptionFlags flags_in,
                 CVOptionFlags *flags_out, void *context) {
   CocoaGraphicsStateGuardian *gsg = (CocoaGraphicsStateGuardian *)context;
+#ifdef SIMPLE_THREADS
+  gsg->_vsync_wait_flag.clear();
+#else
   MutexHolder swap_holder(gsg->_swap_lock);
   gsg->_swap_condition.notify();
+#endif
   return kCVReturnSuccess;
 }
 

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -277,8 +277,9 @@ end_flip() {
     if (_vsync_enabled) {
       AtomicAdjust::Integer cur_frame = ClockObject::get_global_clock()->get_frame_count();
       if (AtomicAdjust::set(cocoagsg->_last_wait_frame, cur_frame) != cur_frame) {
-        MutexHolder swap_holder(cocoagsg->_swap_lock);
+        cocoagsg->_swap_lock.lock();
         cocoagsg->_swap_condition.wait();
+        cocoagsg->_swap_lock.unlock();
       }
     }
 

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -277,14 +277,8 @@ end_flip() {
     if (_vsync_enabled) {
       AtomicAdjust::Integer cur_frame = ClockObject::get_global_clock()->get_frame_count();
       if (AtomicAdjust::set(cocoagsg->_last_wait_frame, cur_frame) != cur_frame) {
-#ifdef SIMPLE_THREADS
-        while (cocoagsg->_vsync_wait_flag.test_and_set()) {
-          ThreadSimpleManager::get_global_ptr()->get_current_thread()->yield();
-        }
-#else
         MutexHolder swap_holder(cocoagsg->_swap_lock);
         cocoagsg->_swap_condition.wait();
-#endif
       }
     }
 

--- a/panda/src/pipeline/conditionVarImpl.h
+++ b/panda/src/pipeline/conditionVarImpl.h
@@ -50,4 +50,17 @@ typedef ConditionVarPosixImpl ConditionVarFullImpl;
 
 #endif
 
+#if defined(WIN32_VC)
+#include "conditionVarWin32Impl.h"
+typedef ConditionVarWin32Impl TrueConditionVarImpl;
+
+#elif defined(HAVE_POSIX_THREADS)
+#include "conditionVarPosixImpl.h"
+typedef ConditionVarPosixImpl TrueConditionVarImpl;
+
+#else
+// No true threads, sorry.  Better not try to use 'em.
+
+#endif
+
 #endif


### PR DESCRIPTION
Panda's simulated threads and real threads are incompatible, so we need to take special consideration since CVDisplayLink notifies from a separate thread. Instead of waiting on a thread that Panda doesn't know about, it will just yield in a loop until a flag is set. Should fix #490.