### PR TITLE
setuptools build_apps: Add p3assimp to the check_plugins list

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -540,6 +540,7 @@ class build_apps(setuptools.Command):
             'pandaegg',
             'p3ffmpeg',
             'p3ptloader',
+            'p3assimp',
         ]
         def parse_prc(prcstr, warn_on_missing_plugin):
             out = []


### PR DESCRIPTION
This gets rid of the runtime error message about missing Assimp.