### PR TITLE
Increased resolution of Panda3D's README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/panda3d/panda3d.svg?branch=master)](https://travis-ci.org/panda3d/panda3d)
 
-<img src="https://avatars2.githubusercontent.com/u/590956?v=3&s=200" align="right" />
+<img src="https://avatars2.githubusercontent.com/u/590956?v=3&s=500" align="right" width="200"/>
 
 Panda3D
 =======


### PR DESCRIPTION
Shortly after the logo change happened the logo started having pixelation problems around its edges as shown here. 

![image](https://user-images.githubusercontent.com/2001527/50740862-1deae280-11bb-11e9-9f24-80478163462c.png)

This change simply bumps up the size its been read from Github at and adjusting the img tag size to keep the same look. Resulting in this
![image](https://user-images.githubusercontent.com/2001527/50740868-31964900-11bb-11e9-9d96-dc683ba6a90e.png)
