### PR TITLE
tkwidgets: Fix missing import on rgbPanel.

### DIFF
--- a/direct/src/tkwidgets/Valuator.py
+++ b/direct/src/tkwidgets/Valuator.py
@@ -625,6 +625,7 @@ def rgbPanel(nodePath, callback = None, style = 'mini'):
     if nodePath.hasColor():
         initColor = nodePath.getColor() * 255.0
     else:
+        from panda3d.core import Vec4
         initColor = Vec4(255)
     # Create entry scale group
     vgp = ValuatorGroupPanel(title = 'RGBA Panel: ' + nodePath.getName(),


### PR DESCRIPTION
This PR fixes a crash when trying to start the RGB (color) Panel using the DIRECT tools on the specified node that doesn't have a custom color applied.