### PR TITLE
ShaderAttrib: add set_shader_inputs() for C++ users

### DIFF
--- a/panda/src/pgraph/shaderAttrib.cxx
+++ b/panda/src/pgraph/shaderAttrib.cxx
@@ -225,6 +225,29 @@ set_shader_input(ShaderInput &&input) const {
 }
 
 /**
+ * Returns a new ShaderAttrib with the given shader inputs set.  This is a
+ * more efficient way to set multiple shader inputs than calling
+ * set_shader_input multiple times.
+ */
+CPT(RenderAttrib) ShaderAttrib::
+set_shader_inputs(const pvector<ShaderInput> &inputs) const {
+  ShaderAttrib *result = new ShaderAttrib(*this);
+  
+  size_t num_inputs = inputs.size();
+  for (size_t i = 0; i < num_inputs; i++) {
+    const ShaderInput &input = inputs[i];
+    Inputs::iterator itr = result->_inputs.find(input.get_name());
+    if (itr == result->_inputs.end()) {
+      result->_inputs.insert(Inputs::value_type(input.get_name(), input));
+    } else {
+      itr->second = input;
+    }
+  }
+  
+  return return_new(result);
+}
+
+/**
  * Sets the geometry instance count.  Do not confuse this with instanceTo,
  * which is used for animation instancing, and has nothing to do with this.  A
  * value of 0 means not to use instancing at all.

--- a/panda/src/pgraph/shaderAttrib.h
+++ b/panda/src/pgraph/shaderAttrib.h
@@ -91,6 +91,8 @@ public:
   INLINE CPT(RenderAttrib) set_shader_input(CPT_InternalName id, const LMatrix3 &v, int priority=0) const;
   INLINE CPT(RenderAttrib) set_shader_input(CPT_InternalName id, double n1=0, double n2=0, double n3=0, double n4=1,
                                             int priority=0) const;
+                                            
+  CPT(RenderAttrib) set_shader_inputs(const pvector<ShaderInput> &inputs) const;
 
 PUBLISHED:
   EXTENSION(CPT(RenderAttrib) set_shader_input(CPT_InternalName, PyObject *, int priority=0) const);


### PR DESCRIPTION
This is an alternative to the Python extension for C++ users.
Example:
`shattr = DCAST(ShaderAttrib, shattr)->set_shader_inputs({ inp1, inp2, inp3, inp4 });`