### PR TITLE
makepackage: Don't include deploy-stub when building .rpm

### DIFF
--- a/makepanda/makepackage.py
+++ b/makepanda/makepackage.py
@@ -438,7 +438,8 @@ def MakeInstallerLinux(version, debversion=None, rpmrelease=1, runtime=False,
 
             # Add the binaries in /usr/bin explicitly to the spec file
             for base in os.listdir(outputdir + "/bin"):
-                txt += "/usr/bin/%s\n" % (base)
+                if not base.startswith("deploy-stub"):
+                    txt += "/usr/bin/%s\n" % (base)
 
         # Write out the spec file.
         txt = txt.replace("VERSION", version)


### PR DESCRIPTION
Attempting to include deploy-stub in the .rpm would cause rpmbuild to fail, as deploy-stub isn't present.