### PR TITLE
makepanda: fix link error of assimp tool

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -5750,7 +5750,7 @@ if not PkgSkip("PANDATOOL") and not PkgSkip("ASSIMP"):
   TargetAdd('p3assimp_composite1.obj', opts=OPTS, input='p3assimp_composite1.cxx')
   TargetAdd('libp3assimp.dll', input='p3assimp_composite1.obj')
   TargetAdd('libp3assimp.dll', input=COMMON_PANDA_LIBS)
-  TargetAdd('libp3assimp.dll', opts=OPTS+['ZLIB'])
+  TargetAdd('libp3assimp.dll', opts=OPTS+['ZLIB', 'ADVAPI'])
 
 #
 # DIRECTORY: pandatool/src/daeprogs/


### PR DESCRIPTION
In rdb/panda3d-thirdparty@d1b92a84887 update, Assimp build causes link error due to missing `Advapi32.lib`. This PR fixes it.