### PR TITLE
Fix an instance where a macOS window will stick around when trying to have it destroyed.

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -711,8 +711,11 @@ close_window() {
   }
 
   if (_window != nil) {
-    [_window setReleasedWhenClosed: YES];
     [_window close];
+    
+    // Process events once more so any pending NSEvents are cleared. Not doing
+    // this causes the window to stick around after calling [_window close].
+    process_events();
     _window = nil;
   }
 

--- a/panda/src/cocoadisplay/cocoaPandaWindowDelegate.h
+++ b/panda/src/cocoadisplay/cocoaPandaWindowDelegate.h
@@ -34,7 +34,6 @@ class CocoaGraphicsWindow;
 - (void)windowDidBecomeKey:(NSNotification *)notification;
 - (void)windowDidResignKey:(NSNotification *)notification;
 - (BOOL)windowShouldClose:(id)sender;
-- (void)windowWillClose:(NSNotification *)notification;
 
 // TODO: handle fullscreen on Lion.
 

--- a/panda/src/cocoadisplay/cocoaPandaWindowDelegate.mm
+++ b/panda/src/cocoadisplay/cocoaPandaWindowDelegate.mm
@@ -50,11 +50,11 @@
 }
 
 - (BOOL) windowShouldClose:(id)sender {
-  return _graphicsWindow->handle_close_request();
-}
-
-- (void) windowWillClose:(NSNotification *)notification {
-  _graphicsWindow->handle_close_event();
+  bool should_close = _graphicsWindow->handle_close_request();
+  if (should_close) {
+    _graphicsWindow->handle_close_event();
+  }
+  return should_close;
 }
 
 @end


### PR DESCRIPTION
This commit also removes an extraneous call to [_window setReleasedWhenClosed], which is already set in cocoaPandaWindow's init method. Fixes #534.