### PR TITLE
setuptools: os.makedirs does not support 'exist_ok' parameter in Python2

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -1347,7 +1347,8 @@ class bdist_apps(setuptools.Command):
 
         platforms = build_cmd.platforms
         build_base = os.path.abspath(build_cmd.build_base)
-        os.makedirs(self.dist_dir, exist_ok=True)
+        if not os.path.exists(self.dist_dir):
+            os.makedirs(self.dist_dir)
         os.chdir(self.dist_dir)
 
         for platform in platforms:


### PR DESCRIPTION
When using setuptools on mac with the default python installation, the package creation fails with the following  error.
<pre>
Writing /Users/ld/git/3D/panda3d/samples/asteroids/build/win_amd64/models/plane.egg.bam
Traceback (most recent call last):
  File "setup.py", line 19, in <module>
    'p3openal_audio',
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/Developer/Panda3D/direct/dist/commands.py", line 1350, in run
    os.makedirs(self.dist_dir, exist_ok=True)
TypeError: makedirs() got an unexpected keyword argument 'exist_ok'
</pre>

This PR fixes this by replacing the 'exist_ok' parameter with an explicit test. Package creation is then successful (and still works with Python3).