### PR TITLE
putil: add is_allocated convenience method to UniqueIdAllocator

### DIFF
--- a/panda/src/putil/uniqueIdAllocator.cxx
+++ b/panda/src/putil/uniqueIdAllocator.cxx
@@ -173,6 +173,20 @@ initial_reserve_id(uint32_t id) {
   --_free;
 }
 
+/**
+ * Checks the allocated state of an index. Returns true for
+ * indices that are currently allocated and in use.
+ */
+bool UniqueIdAllocator::
+is_allocated(uint32_t id) {
+  if (id < _min || id > _max) {
+    // This id is out of range, not allocated.
+    return false;
+  }
+
+  uint32_t index = id - _min; // Convert to _table index.
+  return _table[index] == IndexAllocated;
+}
 
 /**
  * Free an allocated index (index must be between _min and _max that were

--- a/panda/src/putil/uniqueIdAllocator.h
+++ b/panda/src/putil/uniqueIdAllocator.h
@@ -43,6 +43,8 @@ PUBLISHED:
   uint32_t allocate();
   void initial_reserve_id(uint32_t id);
 
+  bool is_allocated(uint32_t index);
+
   void free(uint32_t index);
   PN_stdfloat fraction_used() const;
 


### PR DESCRIPTION
This commit adds a new convenience method to UniqueIdAllocator: is_allocated(uint32_t index), which returns true for indices that are currently in use by the UniqueIdAllocator.

This is especially useful when you're not sure if you can free an index or not, as trying to free an index that is not allocated results in an assertion error.