### PR TITLE
Open AL works on macOS(updated makepanda.py)

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -3003,9 +3003,6 @@ else:
 if (GetTarget() == 'darwin'):
     configprc = configprc.replace("$XDG_CACHE_HOME/panda3d", "$HOME/Library/Caches/Panda3D-%s" % MAJOR_VERSION)
 
-    # OpenAL is not yet working well on OSX for us, so let's do this for now.
-    configprc = configprc.replace("p3openal_audio", "p3fmod_audio")
-
 if GetTarget() == 'windows':
     # Convert to Windows newlines.
     ConditionalWriteFile(GetOutputDir()+"/etc/Config.prc", configprc, newline='\r\n')


### PR DESCRIPTION
Tested out if OpenAL works on Mac OS and if it actually needs FMOD  by testing audio using the Media Sampler Program(https://github.com/panda3d/panda3d/tree/master/samples/media-player).

This was tested on macOS Mojave 10.14.4