### PR TITLE
Fix "Toon Shader" string in firefly demo

### DIFF
--- a/samples/fireflies/main.py
+++ b/samples/fireflies/main.py
@@ -65,7 +65,7 @@ class FireflyDemo(ShowBase):
         # doesn't support the necessary OpenGL extensions.
 
         if self.modelbuffer is None or self.lightbuffer is None:
-            self.t = addTitle("Toon Shader: Video driver does not support "
+            self.t = addTitle("Firefly Demo: Video driver does not support "
                               "multiple render targets")
             return
 


### PR DESCRIPTION
One of the strings in the firefly demo was prefixed with "Toon Shader" instead of "Firefly Demo". I suspect this was a copy and paste issue.