### PR TITLE
Add support for X11 window icon

### DIFF
--- a/panda/src/x11display/x11GraphicsPipe.cxx
+++ b/panda/src/x11display/x11GraphicsPipe.cxx
@@ -308,6 +308,7 @@ x11GraphicsPipe(const std::string &display) :
   _net_wm_state_add = XInternAtom(_display, "_NET_WM_STATE_ADD", false);
   _net_wm_state_remove = XInternAtom(_display, "_NET_WM_STATE_REMOVE", false);
   _net_wm_bypass_compositor = XInternAtom(_display, "_NET_WM_BYPASS_COMPOSITOR", false);
+  _net_wm_icon = XInternAtom(_display, "_NET_WM_ICON", false);
 }
 
 /**

--- a/panda/src/x11display/x11GraphicsPipe.h
+++ b/panda/src/x11display/x11GraphicsPipe.h
@@ -136,6 +136,7 @@ public:
   Atom _net_wm_state_add;
   Atom _net_wm_state_remove;
   Atom _net_wm_bypass_compositor;
+  Atom _net_wm_icon;
 
   // Extension functions.
   typedef int (*pfn_XcursorGetDefaultSize)(X11_Display *);

--- a/panda/src/x11display/x11GraphicsWindow.h
+++ b/panda/src/x11display/x11GraphicsWindow.h
@@ -20,6 +20,32 @@
 #include "graphicsWindow.h"
 #include "buttonHandle.h"
 
+class IcoFile {
+public:
+  struct Entry {
+    unsigned int width, height;
+    unsigned int xhot, yhot;
+    uint32_t *pixels;
+  };
+
+  IcoFile(Filename filename);
+  IcoFile(std::istream &str);
+  ~IcoFile(void);
+
+  unsigned int get_nb_of_entries(void) const;
+  Entry const *get_entry(unsigned int i) const;
+  unsigned int find_largest(void) const;
+  unsigned int find_size(unsigned int size) const;
+
+protected:
+  void load_all_entries(std::istream &str);
+  void load_entry(std::istream &str, unsigned int entry_id);
+
+protected:
+  unsigned int _nb_of_entries;
+  Entry *_entries;
+};
+
 /**
  * Interfaces to the X11 window system.
  */
@@ -73,7 +99,6 @@ protected:
 
 private:
   X11_Cursor get_cursor(const Filename &filename);
-  X11_Cursor read_ico(std::istream &ico);
 
 protected:
   X11_Display *_display;
@@ -114,6 +139,12 @@ public:
 
 private:
   static TypeHandle _type_handle;
+
+  // Window icon. X11 requires that image uses long as element type.
+  Filename _icon_filename;
+  IcoFile *_icon;
+  long *_icon_image;
+  size_t _icon_image_size;
 
   // Since the Panda API requests icons and cursors by filename, we need a
   // table mapping filenames to handles, so we can avoid re-reading the file


### PR DESCRIPTION
This PR adds support of window icon for X11 application. It uses the wm hint NET_WM_ICON to transfer the icon image to the X11 server. Only one image is transferred, the largest one found in the ICO file, the WM is supposed to perform scaling if needed.

Tested OK with "icon-filename" property and using setIconFilename() method of WindowProperties.

Note that it does not work with Ubuntu Unity as it ignores NET_WM_ICON and only uses the icon in the .desktop file. It also uses its own WM Hint (NET_WM_DESKTOP_FILE) to be notified when the .desktop file has been changed.

Finally, read_cursor (formerly read_ico) and read_icon are 95% identical, but as memory allocation for the image is done differently (using XCursor lib for the cursor, vanilla new[] for the icon) and as the output image format is slightly different, I'm not sure that it is worth the effort. 
