### PR TITLE
Fix Shader::_error_flag not being set for GLSL shader compile errors

### DIFF
--- a/panda/src/glstuff/glShaderContext_src.cxx
+++ b/panda/src/glstuff/glShaderContext_src.cxx
@@ -3301,7 +3301,7 @@ glsl_compile_and_link() {
   }
 
   _glgsg->report_my_gl_errors();
-  return true;
+  return valid;
 }
 
 #endif  // OPENGLES_1

--- a/tests/display/cg_bad.sha
+++ b/tests/display/cg_bad.sha
@@ -1,0 +1,21 @@
+//Cg
+//
+
+void vshader(float4 vtx_position : POSITION, 
+             float2 vtx_texcoord0 : TEXCOORD0,
+             uniform float4x4 mat_modelproj,
+	     out float4 l_position : POSITION,
+	     out float2 l_texcoord0 : TEXCOORD0)
+{
+	l_position=mul(mat_modelproj, vtx_position);
+	l_texcoord0=vtx_texcoord0;
+}
+
+void fshader(float2 l_texcoord0 : TEXCOORD0,
+       	     uniform sampler2D tex_0 : TEXUNIT0,
+	     out float4 o_color : COLOR)
+{
+	float4 texColor=tex2D(tex_0, l_texcoord0);
+	does_not_exist=texColor*2*(texColor.w - 0.5);
+}
+

--- a/tests/display/cg_simple.sha
+++ b/tests/display/cg_simple.sha
@@ -1,0 +1,21 @@
+//Cg
+//
+
+void vshader(float4 vtx_position : POSITION, 
+             float2 vtx_texcoord0 : TEXCOORD0,
+             uniform float4x4 mat_modelproj,
+	     out float4 l_position : POSITION,
+	     out float2 l_texcoord0 : TEXCOORD0)
+{
+	l_position=mul(mat_modelproj, vtx_position);
+	l_texcoord0=vtx_texcoord0;
+}
+
+void fshader(float2 l_texcoord0 : TEXCOORD0,
+       	     uniform sampler2D tex_0 : TEXUNIT0,
+	     out float4 o_color : COLOR)
+{
+	float4 texColor=tex2D(tex_0, l_texcoord0);
+	o_color=texColor*2*(texColor.w - 0.5);
+}
+

--- a/tests/display/glsl_bad.vert
+++ b/tests/display/glsl_bad.vert
@@ -1,0 +1,12 @@
+#version 130
+
+// Uniform inputs
+uniform mat4 p3d_ModelViewProjectionMatrix;
+
+// Vertex inputs
+in vec4 p3d_Vertex;
+
+void main() {
+  gl_Position = p3d_ModelViewProjectionMatrix * p3d_Vertex;
+  does_not_exist = p3d_Vertex;
+}

--- a/tests/display/glsl_include.vert
+++ b/tests/display/glsl_include.vert
@@ -1,0 +1,7 @@
+#version 130
+
+#pragma include "glsl_include_inputs.vert"
+
+void main() {
+  gl_Position = p3d_ModelViewProjectionMatrix * p3d_Vertex;
+}

--- a/tests/display/glsl_include_inputs.vert
+++ b/tests/display/glsl_include_inputs.vert
@@ -1,0 +1,5 @@
+// Uniform inputs
+uniform mat4 p3d_ModelViewProjectionMatrix;
+
+// Vertex inputs
+in vec4 p3d_Vertex;

--- a/tests/display/glsl_simple.frag
+++ b/tests/display/glsl_simple.frag
@@ -1,0 +1,5 @@
+#version 130
+
+void main() {
+  gl_FragColor = vec4(0, 0, 0, 1);
+}

--- a/tests/display/glsl_simple.vert
+++ b/tests/display/glsl_simple.vert
@@ -1,0 +1,11 @@
+#version 130
+
+// Uniform inputs
+uniform mat4 p3d_ModelViewProjectionMatrix;
+
+// Vertex inputs
+in vec4 p3d_Vertex;
+
+void main() {
+  gl_Position = p3d_ModelViewProjectionMatrix * p3d_Vertex;
+}

--- a/tests/display/test_cg_shader.py
+++ b/tests/display/test_cg_shader.py
@@ -2,6 +2,10 @@ import os
 
 from panda3d import core
 
+
+SHADERS_DIR = core.Filename.from_os_specific(os.path.dirname(__file__))
+
+
 def run_cg_compile_check(gsg, shader_path, expect_fail=False):
     """Compile supplied Cg shader path and check for errors"""
     shader = core.Shader.load(shader_path, core.Shader.SL_Cg)
@@ -14,13 +18,11 @@ def run_cg_compile_check(gsg, shader_path, expect_fail=False):
 
 def test_cg_compile_error(gsg):
     """Test getting compile errors from bad Cg shaders"""
-    shaders_dir = os.path.dirname(__file__)
-    shader_path = os.path.join(shaders_dir, 'cg_bad.sha')
+    shader_path = core.Filename(SHADERS_DIR, 'cg_bad.sha')
     run_cg_compile_check(gsg, shader_path, expect_fail=True)
 
 
 def test_cg_from_file(gsg):
     """Test compiling Cg shaders from files"""
-    shaders_dir = os.path.dirname(__file__)
-    shader_path = os.path.join(shaders_dir, 'cg_simple.sha')
+    shader_path = core.Filename(SHADERS_DIR, 'cg_simple.sha')
     run_cg_compile_check(gsg, shader_path)

--- a/tests/display/test_cg_shader.py
+++ b/tests/display/test_cg_shader.py
@@ -1,0 +1,26 @@
+import os
+
+from panda3d import core
+
+def run_cg_compile_check(gsg, shader_path, expect_fail=False):
+    """Compile supplied Cg shader path and check for errors"""
+    shader = core.Shader.load(shader_path, core.Shader.SL_Cg)
+    # assert shader.is_prepared(gsg.prepared_objects)
+    if expect_fail:
+        assert shader is None
+    else:
+        assert shader is not None
+
+
+def test_cg_compile_error(gsg):
+    """Test getting compile errors from bad Cg shaders"""
+    shaders_dir = os.path.dirname(__file__)
+    shader_path = os.path.join(shaders_dir, 'cg_bad.sha')
+    run_cg_compile_check(gsg, shader_path, expect_fail=True)
+
+
+def test_cg_from_file(gsg):
+    """Test compiling Cg shaders from files"""
+    shaders_dir = os.path.dirname(__file__)
+    shader_path = os.path.join(shaders_dir, 'cg_simple.sha')
+    run_cg_compile_check(gsg, shader_path)

--- a/tests/display/test_glsl_shader.py
+++ b/tests/display/test_glsl_shader.py
@@ -5,6 +5,9 @@ import pytest
 from _pytest.outcomes import Failed
 
 
+SHADERS_DIR = core.Filename.from_os_specific(os.path.dirname(__file__))
+
+
 # This is the template for the compute shader that is used by run_glsl_test.
 # It defines an assert() macro that writes failures to a buffer, indexed by
 # line number.
@@ -347,23 +350,20 @@ def test_glsl_write_extract_image_buffer(gsg):
 
 def test_glsl_compile_error(gsg):
     """Test getting compile errors from bad shaders"""
-    shaders_dir = os.path.dirname(__file__)
-    vert_path = os.path.join(shaders_dir, 'glsl_bad.vert')
-    frag_path = os.path.join(shaders_dir, 'glsl_simple.frag')
+    vert_path = core.Filename(SHADERS_DIR, 'glsl_bad.vert')
+    frag_path = core.Filename(SHADERS_DIR, 'glsl_simple.frag')
     run_glsl_compile_check(gsg, vert_path, frag_path, expect_fail=True)
 
 
 def test_glsl_from_file(gsg):
     """Test compiling GLSL shaders from files"""
-    shaders_dir = os.path.dirname(__file__)
-    vert_path = os.path.join(shaders_dir, 'glsl_simple.vert')
-    frag_path = os.path.join(shaders_dir, 'glsl_simple.frag')
+    vert_path = core.Filename(SHADERS_DIR, 'glsl_simple.vert')
+    frag_path = core.Filename(SHADERS_DIR, 'glsl_simple.frag')
     run_glsl_compile_check(gsg, vert_path, frag_path)
 
 
 def test_glsl_includes(gsg):
     """Test preprocessing includes in GLSL shaders"""
-    shaders_dir = os.path.dirname(__file__)
-    vert_path = os.path.join(shaders_dir, 'glsl_include.vert')
-    frag_path = os.path.join(shaders_dir, 'glsl_simple.frag')
+    vert_path = core.Filename(SHADERS_DIR, 'glsl_include.vert')
+    frag_path = core.Filename(SHADERS_DIR, 'glsl_simple.frag')
     run_glsl_compile_check(gsg, vert_path, frag_path)

--- a/tests/display/test_glsl_shader.py
+++ b/tests/display/test_glsl_shader.py
@@ -1,4 +1,5 @@
 from panda3d import core
+import os
 import struct
 import pytest
 from _pytest.outcomes import Failed
@@ -100,6 +101,19 @@ def run_glsl_test(gsg, body, preamble="", inputs={}, version=150, exts=set()):
             else:
                 formatted += '    ' + line + '\n'
         pytest.fail("{0} GLSL assertions triggered:\n{1}".format(count, formatted))
+
+
+def run_glsl_compile_check(gsg, *shader_paths, expect_fail=False):
+    """Compile supplied GLSL shader paths and check for errors"""
+    shader = core.Shader.load(core.Shader.SL_GLSL, *shader_paths)
+    assert shader is not None
+
+    shader.prepare_now(gsg.prepared_objects, gsg)
+    assert shader.is_prepared(gsg.prepared_objects)
+    if expect_fail:
+        assert shader.get_error_flag()
+    else:
+        assert not shader.get_error_flag()
 
 
 def test_glsl_test(gsg):
@@ -329,3 +343,27 @@ def test_glsl_write_extract_image_buffer(gsg):
 
     assert struct.unpack('I', tex1.get_ram_image()) == (123,)
     assert struct.unpack('i', tex2.get_ram_image()) == (-456,)
+
+
+def test_glsl_compile_error(gsg):
+    """Test getting compile errors from bad shaders"""
+    shaders_dir = os.path.dirname(__file__)
+    vert_path = os.path.join(shaders_dir, 'glsl_bad.vert')
+    frag_path = os.path.join(shaders_dir, 'glsl_simple.frag')
+    run_glsl_compile_check(gsg, vert_path, frag_path, expect_fail=True)
+
+
+def test_glsl_from_file(gsg):
+    """Test compiling GLSL shaders from files"""
+    shaders_dir = os.path.dirname(__file__)
+    vert_path = os.path.join(shaders_dir, 'glsl_simple.vert')
+    frag_path = os.path.join(shaders_dir, 'glsl_simple.frag')
+    run_glsl_compile_check(gsg, vert_path, frag_path)
+
+
+def test_glsl_includes(gsg):
+    """Test preprocessing includes in GLSL shaders"""
+    shaders_dir = os.path.dirname(__file__)
+    vert_path = os.path.join(shaders_dir, 'glsl_include.vert')
+    frag_path = os.path.join(shaders_dir, 'glsl_simple.frag')
+    run_glsl_compile_check(gsg, vert_path, frag_path)

--- a/tests/display/test_glsl_shader.py
+++ b/tests/display/test_glsl_shader.py
@@ -103,9 +103,9 @@ def run_glsl_test(gsg, body, preamble="", inputs={}, version=150, exts=set()):
         pytest.fail("{0} GLSL assertions triggered:\n{1}".format(count, formatted))
 
 
-def run_glsl_compile_check(gsg, *shader_paths, expect_fail=False):
+def run_glsl_compile_check(gsg, vert_path, frag_path, expect_fail=False):
     """Compile supplied GLSL shader paths and check for errors"""
-    shader = core.Shader.load(core.Shader.SL_GLSL, *shader_paths)
+    shader = core.Shader.load(core.Shader.SL_GLSL, vert_path, frag_path)
     assert shader is not None
 
     shader.prepare_now(gsg.prepared_objects, gsg)


### PR DESCRIPTION
This PR also adds some unit tests around compiling GLSL shaders.