### PR TITLE
Fixes bug with SoundInterval

### DIFF
--- a/direct/src/showbase/SfxPlayer.py
+++ b/direct/src/showbase/SfxPlayer.py
@@ -53,6 +53,8 @@ class SfxPlayer:
                 d = node.getDistance(listenerNode)
             else:
                 d = node.getDistance(base.cam)
+        if not cutoff:
+            cutoff = self.cutoffDistance
         if d == None or d > cutoff:
             volume = 0
         else:
@@ -70,9 +72,6 @@ class SfxPlayer:
             self, sfx, looping = 0, interrupt = 1, volume = None,
             time = 0.0, node=None, listenerNode = None, cutoff = None):
         if sfx:
-            if not cutoff:
-                cutoff = self.cutoffDistance
-
             self.setFinalVolume(sfx, node, volume, listenerNode, cutoff)
 
             # don't start over if it's already playing, unless


### PR DESCRIPTION
If you're using SoundInterval with a defined nodepath, audio will not be played correctly under certain circumstances, and on Python3 causes a TypeError exception to be thrown. A greater than statement attempts to compare a potentially Nonetype variable to a float, different types aren't allowed to be compared on Python 3.

This sample should explain the bug better:

```
from direct.showbase.ShowBase import ShowBase
from direct.interval.IntervalGlobal import *

class MyApp(ShowBase):
 
    def __init__(self):
        ShowBase.__init__(self)

        base.cam.setPos(0,0,10)

        self.examplePanda = self.loader.loadModel("panda")
        self.examplePanda.reparentTo(render)     
        self.examplePanda.setScale(0.2)

        exampleSfx = base.loader.loadSfx('/usr/share/panda3d/models/audio/sfx/GUI_click.wav')
        myInterval = SoundInterval(exampleSfx, node=self.examplePanda, listenerNode=base.cam, volume=1)
        myInterval.loop()
 
app = MyApp()
app.run()