### PR TITLE
CollisionBox into CollisionCapsule

### DIFF
--- a/panda/src/collide/collisionCapsule.cxx
+++ b/panda/src/collide/collisionCapsule.cxx
@@ -190,11 +190,9 @@ test_intersection_from_box(const CollisionEntry &entry) const {
   point_on_segment[2] = a[2];
   if (closest_point[1] < std::min(a[1], b[1])) {
     point_on_segment[1] = std::min(a[1], b[1]);
-  }
-  else if (closest_point[1] > std::max(a[1], b[1])) {
+  } else if (closest_point[1] > std::max(a[1], b[1])) {
     point_on_segment[1] = std::max(a[1], b[1]);
-  }
-  else {
+  } else {
     point_on_segment[1] = closest_point[1];
   }
 
@@ -204,7 +202,15 @@ test_intersection_from_box(const CollisionEntry &entry) const {
   }
 
   PT(CollisionEntry) new_entry = new CollisionEntry(entry);
-  LVector3 normal = (closest_point - point_on_segment);
+  LVector3 normal;
+  if (point_on_segment == closest_point) {
+    // If the box directly intersects the line segment, use
+    // the box's center to determine the surface normal.
+    normal = (box->get_center() * wrt_mat * _inv_mat) - point_on_segment;
+    if (closest_point != a && closest_point != b) normal[1] = 0;
+  } else {
+    normal = (closest_point - point_on_segment);
+  }
   normal.normalize();
   LPoint3 surface_point = point_on_segment + normal * _radius;
   new_entry->set_interior_point(_mat.xform_point(closest_point));

--- a/panda/src/collide/collisionCapsule.cxx
+++ b/panda/src/collide/collisionCapsule.cxx
@@ -149,73 +149,68 @@ test_intersection_from_box(const CollisionEntry &entry) const {
   const LMatrix4 wrt_mat = entry.get_wrt_mat();
   const LMatrix4 inv_wrt_mat = entry.get_inv_wrt_mat();
 
-  // First, we test if the box intersects the cylinder part of the 
-  // capsule. We find the point on the box closest to the center of
-  // the capsule. To do this, convert the capsule to the box's
-  // coordinate space for simpler calculations.
+  // We find the closest point on the box to the line
+  // segment defined by the endpoints of the capsule. To do
+  // this, convert the capsule into the box's coordinate space.
   LPoint3 box_min = box->get_min();
   LPoint3 box_max = box->get_max();
-  LPoint3 center = inv_wrt_mat.xform_point((_a + _b)/2);
-  // Find the point on the box closest to the center of the capsule
-  LPoint3 p = center.fmax(box_min).fmin(box_max);
+  LPoint3 a = _a * inv_wrt_mat;
+  LPoint3 b = _b * inv_wrt_mat;
+  LVector3 delta = b - a;
 
-  // Align the capsule to the y axis
-  LPoint3 a = _a * _inv_mat;
-  LPoint3 b = _b * _inv_mat;
-  // Convert point p to the cylinder's coordinate space
-  p *= wrt_mat * _inv_mat;
-  // Start cylinder test
-  LPoint2 p_xz(p[0], p[2]);
-  LPoint2 a_xz(a[0], a[2]);
-
-  if ((p_xz - a_xz).length_squared() <= _radius * _radius) {
-    if (p[1] <= std::max(a[1], b[1]) && std::min(a[1], b[1]) <= p[1]) {
-      // The box intersects the cylinder
-      if (collide_cat.is_debug()) {
-        collide_cat.debug()
-          << "intersection detected from " << entry.get_from_node_path() << " into "
-          << entry.get_into_node_path() << "\n";
-      }
-      PT(CollisionEntry) new_entry = new CollisionEntry(entry);
-      LPoint3 d(a[0], p[1], a[2]);
-      LVector3 normal = (p - d);
-      normal.normalize();
-      LPoint3 surface_point = normal * _radius + d;
-      new_entry->set_surface_point(_mat.xform_point(surface_point));
-      new_entry->set_interior_point(_mat.xform_point(p));
-      new_entry->set_surface_normal(_mat.xform_vec(normal));
-      return new_entry;
+  double min_dist = DBL_MAX;
+  PN_stdfloat t;
+  LPoint3 closest_point;
+  // Iterate through the 6 planes of the box
+  for (int i = 0; i < 6; i++) {
+    if (!box->get_plane(i).intersects_line(t, a, delta)) {
+      continue;
+    }
+    if (t > 1.0) t = 1.0;
+    if (t < 0.0) t = 0.0;
+    if (t == min_dist) continue;
+    LPoint3 intersection_point = a + delta * t;
+    // Find the closest point on the box to the intersection point
+    LPoint3 p = intersection_point.fmax(box_min).fmin(box_max);
+    double dist = (p - intersection_point).length_squared();
+    if (dist < min_dist) {
+      min_dist = dist;
+      closest_point = p;
     }
   }
+  // Convert the closest point to the capsule's coordinate
+  // space where the capsule is aligned with the y axis.
+  closest_point = closest_point * wrt_mat * _inv_mat;
+  a = _a * _inv_mat;
+  b = _b * _inv_mat;
 
-  // The box doesn't intersect the cylinder, now check both spherical endcaps.
-  // To do this, we convert the endpoints to the box's coordinate space
-  LPoint3 centers[2] = {_a * inv_wrt_mat, _b * inv_wrt_mat};
-  PN_stdfloat radius_sq = inv_wrt_mat.xform_vec(LVector3(0, 0, _radius)).length_squared();
-
-  for (int i = 0; i < 2; i++) {
-    LPoint3 c = centers[i];
-    p = c.fmax(box_min).fmin(box_max);
-    if ((p - c).length_squared() <= radius_sq) {
-      // Box collides with this endcap
-      if (collide_cat.is_debug()) {
-        collide_cat.debug()
-          << "intersection detected from " << entry.get_from_node_path() << " into "
-          << entry.get_into_node_path() << "\n";
-      }
-      PT(CollisionEntry) new_entry = new CollisionEntry(entry);
-      c *= wrt_mat;
-      LPoint3 interior_point = p * wrt_mat;
-      LVector3 normal = (interior_point - c);
-      normal.normalize();
-      new_entry->set_surface_point(normal * _radius + c);
-      new_entry->set_interior_point(interior_point);
-      new_entry->set_surface_normal(normal);
-      return new_entry;
-    }
+  // Find the closest point on the line segment
+  LPoint3 point_on_segment;
+  point_on_segment[0] = a[0];
+  point_on_segment[2] = a[2];
+  if (closest_point[1] < std::min(a[1], b[1])) {
+    point_on_segment[1] = std::min(a[1], b[1]);
+  }
+  else if (closest_point[1] > std::max(a[1], b[1])) {
+    point_on_segment[1] = std::max(a[1], b[1]);
+  }
+  else {
+    point_on_segment[1] = closest_point[1];
   }
 
-  return nullptr;
+  if ((closest_point - point_on_segment).length_squared() > _radius * _radius) {
+    // No intersection.
+    return nullptr;
+  }
+
+  PT(CollisionEntry) new_entry = new CollisionEntry(entry);
+  LVector3 normal = (closest_point - point_on_segment);
+  normal.normalize();
+  LPoint3 surface_point = point_on_segment + normal * _radius;
+  new_entry->set_interior_point(_mat.xform_point(closest_point));
+  new_entry->set_surface_point(_mat.xform_point(surface_point));
+  new_entry->set_surface_normal(_mat.xform_vec(normal));
+  return new_entry;
 }
 /**
  *

--- a/panda/src/collide/collisionCapsule.h
+++ b/panda/src/collide/collisionCapsule.h
@@ -75,6 +75,8 @@ protected:
 
 protected:
   virtual PT(CollisionEntry)
+  test_intersection_from_box(const CollisionEntry &entry) const;
+  virtual PT(CollisionEntry)
   test_intersection_from_sphere(const CollisionEntry &entry) const;
   virtual PT(CollisionEntry)
   test_intersection_from_line(const CollisionEntry &entry) const;

--- a/tests/collide/test_into_capsule.py
+++ b/tests/collide/test_into_capsule.py
@@ -1,0 +1,39 @@
+from collisions import *
+
+def test_box_into_capsule():
+    capsule = CollisionCapsule((1, 0, 0), (-1, 0, 0), .5)
+
+    # colliding just on the capsule's cylinder
+    box = CollisionBox((0, 1, 0), .5, .5, .5)
+    entry = make_collision(box, capsule)[0]
+    assert entry is not None
+
+    # no longer colliding
+    box = CollisionBox((0, 1.1, 0), .5, .5, .5)
+    entry = make_collision(box, capsule)[0]
+    assert entry is None
+
+    # box is inside the capsule's cylinder
+    box = CollisionBox((0, .8, 0), .5, .5, .5)
+    entry = make_collision(box, capsule)[0]
+    assert entry is not None
+
+    # colliding with the first endcap
+    box = CollisionBox((2, 0, 0), .5, .5, .5)
+    entry = make_collision(box, capsule)[0]
+    assert entry is not None
+
+    # almost colliding with first endcap
+    box = CollisionBox((2.01, 0, 0), .5, .5, .5)
+    entry = make_collision(box, capsule)[0]
+    assert entry is None
+
+    # colliding with the second endcap
+    box = CollisionBox((-2, 0, 0), .5, .5, .5)
+    entry = make_collision(box, capsule)[0]
+    assert entry is not None
+
+    # almost colliding with second endcap
+    box = CollisionBox((-2.01, 0, 0), .5, .5, .5)
+    entry = make_collision(box, capsule)[0]
+    assert entry is None


### PR DESCRIPTION
Added collision test for box into capsule: splits the capsule into a cylinder and two hemispheres and tests for intersections with the box. Suggestions are welcomed!