### PR TITLE
showbase: Correct functionality of `weightedChoice`

### DIFF
--- a/direct/src/showbase/PythonUtil.py
+++ b/direct/src/showbase/PythonUtil.py
@@ -1132,7 +1132,7 @@ def weightedChoice(choiceList, rng=random.random, sum=None):
     weights, pass it in 'sum'."""
     # Throw an IndexError if we got an empty list.
     if not choiceList:
-        raise IndexError('Cannot choose from an empty sequence') from None
+        raise IndexError('Cannot choose from an empty sequence')
 
     # TODO: add support for dicts
     if sum is None:

--- a/direct/src/showbase/PythonUtil.py
+++ b/direct/src/showbase/PythonUtil.py
@@ -1138,14 +1138,16 @@ def weightedChoice(choiceList, rng=random.random, sum=None):
 
     rand = rng()
     accum = rand * sum
+    lastItem = 0.
     for weight, item in choiceList:
+        lastItem = item
         accum -= weight
         if accum <= 0.:
             return item
     # rand is ~1., and floating-point error prevented accum from hitting 0.
     # Or you passed in a 'sum' that was was too large.
     # Return the last item.
-    return item
+    return lastItem
 
 def randFloat(a, b=0., rng=random.random):
     """returns a random float in [a, b]

--- a/direct/src/showbase/PythonUtil.py
+++ b/direct/src/showbase/PythonUtil.py
@@ -1138,16 +1138,15 @@ def weightedChoice(choiceList, rng=random.random, sum=None):
 
     rand = rng()
     accum = rand * sum
-    lastItem = 0.
+    item = None
     for weight, item in choiceList:
-        lastItem = item
         accum -= weight
         if accum <= 0.:
             return item
     # rand is ~1., and floating-point error prevented accum from hitting 0.
     # Or you passed in a 'sum' that was was too large.
     # Return the last item.
-    return lastItem
+    return item
 
 def randFloat(a, b=0., rng=random.random):
     """returns a random float in [a, b]

--- a/direct/src/showbase/PythonUtil.py
+++ b/direct/src/showbase/PythonUtil.py
@@ -1130,6 +1130,10 @@ def weightedChoice(choiceList, rng=random.random, sum=None):
     """given a list of (weight, item) pairs, chooses an item based on the
     weights. rng must return 0..1. if you happen to have the sum of the
     weights, pass it in 'sum'."""
+    # Throw an IndexError if we got an empty list.
+    if not choiceList:
+        raise IndexError('Cannot choose from an empty sequence') from None
+
     # TODO: add support for dicts
     if sum is None:
         sum = 0.

--- a/tests/showbase/test_PythonUtil.py
+++ b/tests/showbase/test_PythonUtil.py
@@ -105,6 +105,12 @@ def test_priority_callbacks():
     assert len(l) == 0
 
 def test_weighted_choice():
+    # Test PythonUtil.weightedChoice() with no valid list.
+    item = PythonUtil.weightedChoice([])
+    
+    # Assert that what we got was a NoneType.
+    assert item == None
+    
     # Create a sample choice list.
     # This contains a few tuples containing only a weight
     # and an arbitrary item.

--- a/tests/showbase/test_PythonUtil.py
+++ b/tests/showbase/test_PythonUtil.py
@@ -103,3 +103,60 @@ def test_priority_callbacks():
     pc.clear()
     pc()
     assert len(l) == 0
+
+def test_weighted_choice():
+    # Create a sample choice list.
+    # This contains a few tuples containing only a weight
+    # and an arbitrary item.
+    choicelist = [(3, 'item1'), (1, 'item2'), (7, 'item3')]
+
+    # These are the items that we expect.
+    items = ['item1', 'item2', 'item3']
+
+    # Test PythonUtil.weightedChoice() with our choice list.
+    item = PythonUtil.weightedChoice(choicelist)
+
+    # Assert that what we got was at least an available item.
+    assert item in items
+
+    # Create yet another sample choice list, but with a couple more items.
+    choicelist = [(2, 'item1'), (25, 'item2'), (14, 'item3'), (5, 'item4'),
+                  (7, 'item5'), (3, 'item6'), (6, 'item7'), (50, 'item8')]
+
+    # Set the items that we expect again.
+    items = ['item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7', 'item8']
+
+    # The sum of all of the weights is 112.
+    weightsum = 2 + 25 + 14 + 5 + 7 + 3 + 6 + 50
+
+    # Test PythonUtil.weightedChoice() with the sum.
+    item = PythonUtil.weightedChoice(choicelist, sum=weightsum)
+
+    # Assert that we got a valid item (most of the time this should be 'item8').
+    assert item in items
+
+    # Test PythonUtil.weightedChoice(), but with an invalid sum.
+    item = PythonUtil.weightedChoice(choicelist, sum=1)
+
+    # Assert that we got 'item1'.
+    assert item == items[0]
+
+    # Test PythonUtil.weightedChoice() with an invalid sum.
+    # This time, we're using 2000 so that regardless of the random
+    # number, we will still reach the very last item.
+    item = PythonUtil.weightedChoice(choicelist, sum=100000)
+
+    # Assert that we got 'item8', since we would get the last item.
+    assert item == items[-1]
+
+    # Create a bogus random function.
+    rnd = lambda: 0.5
+
+    # Test PythonUtil.weightedChoice() with the bogus function.
+    item = PythonUtil.weightedChoice(choicelist, rng=rnd, sum=weightsum)
+
+    # Assert that we got 'item6'.
+    # We expect 'item6' because 0.5 multiplied by 112 is 56.0.
+    # When subtracting that number by each weight, it will reach 0
+    # by the time it hits 'item6' in the iteration.
+    assert item == items[5]

--- a/tests/showbase/test_PythonUtil.py
+++ b/tests/showbase/test_PythonUtil.py
@@ -106,11 +106,15 @@ def test_priority_callbacks():
 
 def test_weighted_choice():
     # Test PythonUtil.weightedChoice() with no valid list.
-    item = PythonUtil.weightedChoice([])
-    
-    # Assert that what we got was a NoneType.
-    assert item == None
-    
+    try:
+        PythonUtil.weightedChoice([])
+
+        # Assert False if we couldn't raise the IndexError.
+        assert False
+    except IndexError:
+        # We properly got an IndexError.
+        pass
+
     # Create a sample choice list.
     # This contains a few tuples containing only a weight
     # and an arbitrary item.


### PR DESCRIPTION
I'm not exactly sure why it was left like this, but if you call it under certain arguments it will crash because it attempts to return a variable which is out of scope. This simply corrects the functionality to what was intended according to the comments to avoid such a crash.

A test has also been added for this function.