### PR TITLE
bullet: replace NodePath scaling in BulletBodyNode::do_add_shape()

### DIFF
--- a/panda/src/bullet/bulletBodyNode.cxx
+++ b/panda/src/bullet/bulletBodyNode.cxx
@@ -40,6 +40,9 @@ BulletBodyNode(const char *name) : PandaNode(name) {
 
   // Shape
   _shape = new btEmptyShape();
+  // Set the local scaling to default, otherwise we occasionally get
+  // uninitialized data
+  _shape->setLocalScaling(btVector3(1.0, 1.0, 1.0));
 
   // Default collide mask
   set_into_collide_mask(CollideMask::all_on());
@@ -351,11 +354,8 @@ do_add_shape(BulletShape *bullet_shape, const TransformState *ts) {
   // Transform
   btTransform trans = TransformState_to_btTrans(ts);
 
-  // Reset the shape scaling before we add a shape, and remember the current
-  // Scale so we can restore it later...
-  NodePath np = NodePath::any_path((PandaNode *)this);
-  LVector3 scale = np.get_scale();
-  np.set_scale(1.0);
+  // Reset the shape scaling before we add a shape
+  _shape->setLocalScaling(btVector3(1.0,1.0,1.0));
 
   // Root shape
   btCollisionShape *previous = get_object()->getCollisionShape();
@@ -416,8 +416,12 @@ do_add_shape(BulletShape *bullet_shape, const TransformState *ts) {
 
   _shapes.push_back(bullet_shape);
 
-  // Restore the local scaling again
-  np.set_scale(scale);
+  // Restore the node's scaling again
+  NodePath np = NodePath::any_path((PandaNode *)this);
+  LVector3 scale = np.get_scale();
+  if (!scale.almost_equal(LVecBase3(1.0f, 1.0f, 1.0f))) {
+    _shape->setLocalScaling(LVecBase3_to_btVector3(scale));
+  }
 
   do_shape_changed();
 }

--- a/tests/bullet/test_bullet_rigid_shapes_scaling.py
+++ b/tests/bullet/test_bullet_rigid_shapes_scaling.py
@@ -1,0 +1,195 @@
+import pytest
+# Skip these tests if we can't import bullet.
+bullet = pytest.importorskip("panda3d.bullet")
+
+from panda3d.bullet import BulletWorld, BulletRigidBodyNode, BulletGhostNode
+from panda3d.bullet import BulletBoxShape, BulletPlaneShape
+from panda3d.core import NodePath, Vec3, TransformState
+
+
+def test_singular_rigid_shape_bounds():
+    root = NodePath("root")
+    world = BulletWorld()
+
+    # make test node
+    box = BulletRigidBodyNode('box')
+    boxNP = root.attach_new_node(box)
+    #add shape
+    box.addShape(BulletBoxShape(Vec3(0.5,0.5,0.5)), TransformState.makePos(Vec3(0.5,0,0)))
+    world.attach(box)
+    boxNP.setPos(0, 0, 0)
+
+    #add plane to collide with
+    plane = BulletRigidBodyNode('checkplane')
+    planeNP = root.attach_new_node(plane)
+    plane.addShape(BulletPlaneShape(Vec3(-1, 0, 0), 0))
+    world.attach(plane)
+    planeNP.set_pos(0.9, 0, 0)
+
+    assert world.get_num_rigid_bodies() == 2
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() > 0
+    assert test.get_contact(0).get_node0() == box
+    assert test.get_contact(0).get_node1() == plane
+
+    #move plane X coordinate, no longer colliding
+    planeNP.set_pos(1.1, 0, 0)
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() == 0
+
+def test_singular_rigid_double_scale_post_add():
+    root = NodePath("root")
+    world = BulletWorld()
+
+    # make test node
+    box = BulletRigidBodyNode('box')
+    boxNP = root.attach_new_node(box)
+    #add shape
+    box.addShape(BulletBoxShape(Vec3(0.5,0.5,0.5)), TransformState.makePos(Vec3(0.5,0,0)))
+    world.attach(box)
+    boxNP.setPos(0, 0, 0)
+    boxNP.setScale(2)
+
+    #add plane to collide with
+    plane = BulletRigidBodyNode('checkplane')
+    planeNP = root.attach_new_node(plane)
+    plane.addShape(BulletPlaneShape(Vec3(-1, 0, 0), 0))
+    world.attach(plane)
+    planeNP.set_pos(1.9, 0, 0)
+
+    assert world.get_num_rigid_bodies() == 2
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() > 0
+    assert test.get_contact(0).get_node0() == box
+    assert test.get_contact(0).get_node1() == plane
+
+    #move plane X coordinate, no longer colliding
+    planeNP.set_pos(2.1, 0, 0)
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() == 0
+
+def test_singular_rigid_double_initial_scale():
+    root = NodePath("root")
+    world = BulletWorld()
+
+    # make test node
+    box = BulletRigidBodyNode('box')
+    boxNP = root.attach_new_node(box)
+    boxNP.setScale(2)
+    #add shape
+    box.addShape(BulletBoxShape(Vec3(0.5,0.5,0.5)), TransformState.makePos(Vec3(0.5,0,0)))
+    world.attach(box)
+    boxNP.setPos(0, 0, 0)
+
+    #add plane to collide with
+    plane = BulletRigidBodyNode('checkplane')
+    planeNP = root.attach_new_node(plane)
+    plane.addShape(BulletPlaneShape(Vec3(-1, 0, 0), 0))
+    world.attach(plane)
+    planeNP.set_pos(1.9, 0, 0)
+
+    assert world.get_num_rigid_bodies() == 2
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() > 0
+    assert test.get_contact(0).get_node0() == box
+    assert test.get_contact(0).get_node1() == plane
+
+    #move plane X coordinate, no longer colliding
+    planeNP.set_pos(2.1, 0, 0)
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() == 0
+
+def test_composite_rigid_shape_bounds():
+    root = NodePath("root")
+    world = BulletWorld()
+
+    # make test node
+    box = BulletRigidBodyNode('boxes')
+    boxNP = root.attach_new_node(box)
+    #two boxes, next to each other
+    box.addShape(BulletBoxShape(Vec3(0.5,0.5,0.5)), TransformState.makePos(Vec3(0.5,0,0)))
+    box.addShape(BulletBoxShape(Vec3(0.5,0.5,0.5)), TransformState.makePos(Vec3(1.5,0,0)))
+    world.attach(box)
+    boxNP.setPos(0, 0, 0)
+
+    #add plane to collide with
+    plane = BulletRigidBodyNode('checkplane')
+    planeNP = root.attach_new_node(plane)
+    plane.addShape(BulletPlaneShape(Vec3(-1, 0, 0), 0))
+    world.attach(plane)
+    planeNP.set_pos(1.9, 0, 0)
+
+    assert world.get_num_rigid_bodies() == 2
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() > 0
+    assert test.get_contact(0).get_node0() == box
+    assert test.get_contact(0).get_node1() == plane
+
+    #move plane X coordinate, no longer colliding
+    planeNP.set_pos(2.1, 0, 0)
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() == 0
+
+def test_composite_rigid_double_scale_post_add():
+    root = NodePath("root")
+    world = BulletWorld()
+
+    # make test node
+    box = BulletRigidBodyNode('boxes')
+    boxNP = root.attach_new_node(box)
+    #two boxes, next to each other
+    box.addShape(BulletBoxShape(Vec3(0.5,0.5,0.5)), TransformState.makePos(Vec3(0.5,0,0)))
+    box.addShape(BulletBoxShape(Vec3(0.5,0.5,0.5)), TransformState.makePos(Vec3(1.5,0,0)))
+    world.attach(box)
+    boxNP.setPos(0, 0, 0)
+    boxNP.setScale(2)
+
+    #add plane to collide with
+    plane = BulletRigidBodyNode('checkplane')
+    planeNP = root.attach_new_node(plane)
+    plane.addShape(BulletPlaneShape(Vec3(-1, 0, 0), 0))
+    world.attach(plane)
+    planeNP.set_pos(3.9, 0, 0)
+
+    assert world.get_num_rigid_bodies() == 2
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() > 0
+    assert test.get_contact(0).get_node0() == box
+    assert test.get_contact(0).get_node1() == plane
+
+    #move plane X coordinate, no longer colliding
+    planeNP.set_pos(4.1, 0, 0)
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() == 0
+
+def test_composite_rigid_double_initial_scale():
+    root = NodePath("root")
+    world = BulletWorld()
+
+    # make test node
+    box = BulletRigidBodyNode('boxes')
+    boxNP = root.attach_new_node(box)
+    boxNP.setScale(2)
+    #two boxes, next to each other
+    box.addShape(BulletBoxShape(Vec3(0.5,0.5,0.5)), TransformState.makePos(Vec3(0.5,0,0)))
+    box.addShape(BulletBoxShape(Vec3(0.5,0.5,0.5)), TransformState.makePos(Vec3(1.5,0,0)))
+    world.attach(box)
+    boxNP.setPos(0, 0, 0)
+
+    #add plane to collide with
+    plane = BulletRigidBodyNode('checkplane')
+    planeNP = root.attach_new_node(plane)
+    plane.addShape(BulletPlaneShape(Vec3(-1, 0, 0), 0))
+    world.attach(plane)
+    planeNP.set_pos(3.9, 0, 0)
+
+    assert world.get_num_rigid_bodies() == 2
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() > 0
+    assert test.get_contact(0).get_node0() == box
+    assert test.get_contact(0).get_node1() == plane
+
+    #move plane X coordinate, no longer colliding
+    planeNP.set_pos(4.1, 0, 0)
+    test = world.contact_test_pair(box, plane)
+    assert test.get_num_contacts() == 0


### PR DESCRIPTION
Use btCollisionShape::[get|set]LocalScaling() instead of scaling the NodePath when adding new shapes to avoid a circular deadlock on the BulletWorld global lock. Fixes #689.