### PR TITLE
dcparser: Fix a typo where an unpacked uint64 or int64 might shave off a few bits

### DIFF
--- a/direct/src/dcparser/dcPackerInterface.I
+++ b/direct/src/dcparser/dcPackerInterface.I
@@ -253,7 +253,7 @@ do_unpack_int64(const char *buffer) {
                     ((uint64_t)(unsigned char)buffer[4] << 32) |
                     ((uint64_t)(unsigned char)buffer[5] << 40) |
                     ((uint64_t)(unsigned char)buffer[6] << 48) |
-                    ((int64_t)(signed char)buffer[7] << 54));
+                    ((int64_t)(signed char)buffer[7] << 56));
 }
 /**
  *
@@ -295,7 +295,7 @@ do_unpack_uint64(const char *buffer) {
           ((uint64_t)(unsigned char)buffer[4] << 32) |
           ((uint64_t)(unsigned char)buffer[5] << 40) |
           ((uint64_t)(unsigned char)buffer[6] << 48) |
-          ((int64_t)(signed char)buffer[7] << 54));
+          ((int64_t)(signed char)buffer[7] << 56));
 }
 
 


### PR DESCRIPTION
Just was rummaging through Panda3D source after I encountered an issue in my own project that ended up giving me different numbers after packing and unpacking a large uint64 value. I believe this is the culprit.