### PR TITLE
Make Socket Send methods take vector_uchar instead of string

### DIFF
--- a/panda/src/nativenet/socket_tcp.h
+++ b/panda/src/nativenet/socket_tcp.h
@@ -3,6 +3,7 @@
 
 #include "pandabase.h"
 #include "socket_ip.h"
+#include "vector_uchar.h"
 
 /**
  * Base functionality for a TCP connected socket This class is pretty useless
@@ -22,7 +23,7 @@ PUBLISHED:
   inline bool ActiveOpenNonBlocking(const Socket_Address &theaddress);
   inline bool ErrorIs_WouldBlocking(int err);
   inline bool ShutdownSend();
-  inline int SendData(const std::string &str);
+  inline int SendData(const vector_uchar &data);
 // inline int RecvData( std::string &str, int max_len);
 
   std::string RecvData(int max_len);
@@ -217,8 +218,8 @@ DoNotLinger() {
 */
 
 inline int Socket_TCP::
-SendData(const std::string &str) {
-  return SendData(str.data(), str.size());
+SendData(const vector_uchar &data) {
+  return SendData((char *)data.data(), data.size());
 }
 
 #endif //__SOCKET_TCP_H__

--- a/panda/src/nativenet/socket_udp.h
+++ b/panda/src/nativenet/socket_udp.h
@@ -15,6 +15,7 @@
 #define __SOCKET_UDP_H__
 
 #include "socket_udp_incoming.h"
+#include "vector_uchar.h"
 
 /**
  * Base functionality for a combination UDP Reader and Writer.  This
@@ -31,11 +32,11 @@ PUBLISHED:
 public:
   inline bool Send(const char *data, int len);
 PUBLISHED:
-  inline bool Send(const std::string &data);
+  inline bool Send(const vector_uchar &data);
 public:
   inline bool SendTo(const char *data, int len, const Socket_Address &address);
 PUBLISHED:
-  inline bool SendTo(const std::string &data, const Socket_Address &address);
+  inline bool SendTo(const vector_uchar &data, const Socket_Address &address);
   inline bool SetToBroadCast();
 
 public:
@@ -96,8 +97,8 @@ Send(const char *data, int len) {
  * Send data to connected address
  */
 inline bool Socket_UDP::
-Send(const std::string &data) {
-  return Send(data.data(), data.size());
+Send(const vector_uchar &data) {
+  return Send((char*) data.data(), data.size());
 }
 
 /**
@@ -112,8 +113,8 @@ SendTo(const char *data, int len, const Socket_Address &address) {
  * Send data to specified address
  */
 inline bool Socket_UDP::
-SendTo(const std::string &data, const Socket_Address &address) {
-  return SendTo(data.data(), data.size(), address);
+SendTo(const vector_uchar &data, const Socket_Address &address) {
+  return SendTo((char*) data.data(), data.size(), address);
 }
 
 #endif //__SOCKET_UDP_H__

--- a/panda/src/nativenet/socket_udp_outgoing.h
+++ b/panda/src/nativenet/socket_udp_outgoing.h
@@ -2,6 +2,7 @@
 #define __SOCKET_UDP_OUTGOING_H__
 
 #include "config_nativenet.h"
+#include "vector_uchar.h"
 #include "socket_ip.h"
 
 /**
@@ -16,13 +17,13 @@ PUBLISHED:
 public:
   inline bool Send(const char *data, int len);
 PUBLISHED:
-  inline bool Send(const std::string &data);
+  inline bool Send(const vector_uchar &data);
   // use this interface for a none tagreted UDP connection
   inline bool InitNoAddress();
 public:
   inline bool SendTo(const char *data, int len, const Socket_Address &address);
 PUBLISHED:
-  inline bool SendTo(const std::string &data, const Socket_Address &address);
+  inline bool SendTo(const vector_uchar &data, const Socket_Address &address);
   inline bool SetToBroadCast();
 
 public:
@@ -98,8 +99,8 @@ Send(const char *data, int len) {
  * Send data to connected address
  */
 inline bool Socket_UDP_Outgoing::
-Send(const std::string &data) {
-  return Send(data.data(), data.size());
+Send(const vector_uchar &data) {
+  return Send((char*) data.data(), data.size());
 }
 
 /**
@@ -114,8 +115,8 @@ SendTo(const char *data, int len, const Socket_Address &address) {
  * Send data to specified address
  */
 inline bool Socket_UDP_Outgoing::
-SendTo(const std::string &data, const Socket_Address &address) {
-  return SendTo(data.data(), data.size(), address);
+SendTo(const vector_uchar &data, const Socket_Address &address) {
+  return SendTo((char*) data.data(), data.size(), address);
 }
 
 #endif //__SOCKET_UDP_OUTGOING_H__

--- a/panda/src/net/connection.cxx
+++ b/panda/src/net/connection.cxx
@@ -303,15 +303,18 @@ send_datagram(const NetDatagram &datagram, int tcp_header_size) {
 
     LightReMutexHolder holder(_write_mutex);
     DatagramUDPHeader header(datagram);
-    std::string data;
-    data += header.get_header();
-    data += datagram.get_message();
+    
+    vector_uchar data;
+    CPTA_uchar header_data = header.get_array();
+    CPTA_uchar message = datagram.get_array();
+    data.insert(data.end(), header_data.begin(), header_data.end());
+    data.insert(data.end(), message.begin(), message.end());
 
     if (net_cat.is_debug()) {
       header.verify_datagram(datagram);
     }
 
-    int bytes_to_send = data.length();
+    int bytes_to_send = data.size();
     Socket_Address addr = datagram.get_address().get_addr();
 
     bool okflag = udp->SendTo(data, addr);
@@ -374,7 +377,9 @@ send_raw_datagram(const NetDatagram &datagram) {
     Socket_UDP *udp;
     DCAST_INTO_R(udp, _socket, false);
 
-    std::string data = datagram.get_message();
+    CPTA_uchar msg = datagram.get_array();
+    vector_uchar data;
+    data.insert(data.end(), msg.begin(), msg.end());
 
     LightReMutexHolder holder(_write_mutex);
     Socket_Address addr = datagram.get_address().get_addr();

--- a/panda/src/net/connection.cxx
+++ b/panda/src/net/connection.cxx
@@ -347,8 +347,10 @@ send_datagram(const NetDatagram &datagram, int tcp_header_size) {
   DatagramTCPHeader header(datagram, tcp_header_size);
 
   LightReMutexHolder holder(_write_mutex);
-  _queued_data += header.get_header();
-  _queued_data += datagram.get_message();
+  CPTA_uchar header_data = header.get_array();
+  CPTA_uchar message = datagram.get_array();
+  _queued_data.insert(_queued_data.end(), header_data.begin(), header_data.end());
+  _queued_data.insert(_queued_data.end(), message.begin(), message.end());
   _queued_count++;
 
   if (net_cat.is_debug()) {
@@ -403,7 +405,8 @@ send_raw_datagram(const NetDatagram &datagram) {
 
   // We might queue up TCP packets for later sending.
   LightReMutexHolder holder(_write_mutex);
-  _queued_data += datagram.get_message();
+  CPTA_uchar msg = datagram.get_array();
+  _queued_data.insert(_queued_data.end(), msg.begin(), msg.end());
   _queued_count++;
 
   if (!_collect_tcp ||
@@ -429,13 +432,13 @@ do_flush() {
   if (net_cat.is_spam()) {
     net_cat.spam()
       << "Sending " << _queued_count << " TCP datagram(s) with "
-      << _queued_data.length() << " total bytes to " << (void *)this << "\n";
+      << _queued_data.size() << " total bytes to " << (void *)this << "\n";
   }
 
   Socket_TCP *tcp;
   DCAST_INTO_R(tcp, _socket, false);
 
-  std::string sending_data;
+  vector_uchar sending_data;
   _queued_data.swap(sending_data);
 
   _queued_count = 0;
@@ -443,7 +446,7 @@ do_flush() {
 
 #if defined(HAVE_THREADS) && defined(SIMPLE_THREADS)
   int max_send = net_max_write_per_epoch;
-  int data_sent = tcp->SendData(sending_data.data(), std::min((size_t)max_send, sending_data.size()));
+  int data_sent = tcp->SendData((char *)sending_data.data(), std::min((size_t)max_send, sending_data.size()));
   bool okflag = (data_sent == (int)sending_data.size());
   if (!okflag) {
     int total_sent = 0;
@@ -458,7 +461,7 @@ do_flush() {
       } else {
         Thread::consider_yield();
       }
-      data_sent = tcp->SendData(sending_data.data() + total_sent, std::min((size_t)max_send, sending_data.size() - total_sent));
+      data_sent = tcp->SendData((char *)sending_data.data() + total_sent, std::min((size_t)max_send, sending_data.size() - total_sent));
       if (data_sent > 0) {
         total_sent += data_sent;
       }

--- a/panda/src/net/connection.h
+++ b/panda/src/net/connection.h
@@ -18,6 +18,7 @@
 #include "referenceCount.h"
 #include "netAddress.h"
 #include "lightReMutex.h"
+#include "vector_uchar.h"
 
 class Socket_IP;
 class ConnectionManager;
@@ -68,7 +69,7 @@ private:
   bool _collect_tcp;
   double _collect_tcp_interval;
   double _queued_data_start;
-  std::string _queued_data;
+  vector_uchar _queued_data;
   int _queued_count;
 
   friend class ConnectionWriter;

--- a/panda/src/net/datagramTCPHeader.I
+++ b/panda/src/net/datagramTCPHeader.I
@@ -19,3 +19,8 @@ INLINE std::string DatagramTCPHeader::
 get_header() const {
   return _header.get_message();
 }
+
+INLINE CPTA_uchar DatagramTCPHeader::
+get_array() const {
+  return _header.get_array();
+}

--- a/panda/src/net/datagramTCPHeader.h
+++ b/panda/src/net/datagramTCPHeader.h
@@ -39,6 +39,7 @@ public:
 
   int get_datagram_size(int header_size) const;
   INLINE std::string get_header() const;
+  INLINE CPTA_uchar get_array() const;
 
   bool verify_datagram(const NetDatagram &datagram, int header_size) const;
 

--- a/panda/src/net/datagramUDPHeader.I
+++ b/panda/src/net/datagramUDPHeader.I
@@ -28,3 +28,8 @@ INLINE std::string DatagramUDPHeader::
 get_header() const {
   return _header.get_message();
 }
+
+INLINE CPTA_uchar DatagramUDPHeader::
+get_array() const {
+  return _header.get_array();
+}

--- a/panda/src/net/datagramUDPHeader.h
+++ b/panda/src/net/datagramUDPHeader.h
@@ -38,6 +38,7 @@ public:
 
   INLINE int get_datagram_checksum() const;
   INLINE std::string get_header() const;
+  INLINE CPTA_uchar get_array() const;
 
   bool verify_datagram(const NetDatagram &datagram) const;
 


### PR DESCRIPTION
This changes the version of these functions as exposed to Python to take `bytes`, rather than `string`s, which was causing issues when sending raw, binary data over a SocketUDP in my application when running on Python 3.

Note that as at this time, I've removed the prior implementation of `Send` and `SendTo` that take strings, compatibility with C++ applications depending on those is broken. I can re-add the `string` versions of these functions if necessary. Additionally, I have not yet touched `SocketTCP`, which also exposes `string` based functions to Python.

(Apologies if anything isn't correct here - I haven't touched the C++ side of the Panda codebase previously.)