### PR TITLE
Particle offset plus "_tics_since_birth" getter

### DIFF
--- a/panda/src/particlesystem/particleSystem.I
+++ b/panda/src/particlesystem/particleSystem.I
@@ -157,6 +157,15 @@ set_floor_z(PN_stdfloat z) {
 
  */
 INLINE void ParticleSystem::
+set_inital_birth_offset(PN_stdfloat offset) {
+  _inital_birth_offset = offset;
+}
+
+
+/**
+
+ */
+INLINE void ParticleSystem::
 set_active_system_flag(bool a) {
   _active_system_flag = a;
 }
@@ -340,6 +349,14 @@ get_factory() const {
 INLINE PN_stdfloat ParticleSystem::
 get_floor_z() const {
   return _floor_z;
+}
+
+/**
+
+*/
+INLINE PN_stdfloat ParticleSystem::
+get_inital_birth_offset() const {
+  return _inital_birth_offset;
 }
 
 /**

--- a/panda/src/particlesystem/particleSystem.I
+++ b/panda/src/particlesystem/particleSystem.I
@@ -44,7 +44,7 @@ clear_to_initial() {
       kill_particle(i);
     }
   }
-  _tics_since_birth = _inital_birth_offset;
+  _tics_since_birth = _initial_birth_offset;
 }
 
 /**
@@ -55,7 +55,7 @@ soft_start(PN_stdfloat br) {
   if (br > 0.0)
     set_birth_rate(br);
   _cur_birth_rate = _birth_rate;
-  _tics_since_birth = _inital_birth_offset;
+  _tics_since_birth = _initial_birth_offset;
 }
 
 /**
@@ -66,7 +66,7 @@ soft_stop(PN_stdfloat br) {
   if (br > 0.0)
     set_soft_birth_rate(br);
   _cur_birth_rate = _soft_birth_rate;
-  _tics_since_birth = _inital_birth_offset;
+  _tics_since_birth = _initial_birth_offset;
 }
 
 /**
@@ -157,8 +157,9 @@ set_floor_z(PN_stdfloat z) {
 
  */
 INLINE void ParticleSystem::
-set_inital_birth_offset(PN_stdfloat offset) {
-  _inital_birth_offset = offset;
+set_initial_birth_offset(PN_stdfloat offset) {
+  _initial_birth_offset = offset;
+  _tics_since_birth = offset;
 }
 
 
@@ -355,8 +356,8 @@ get_floor_z() const {
 
 */
 INLINE PN_stdfloat ParticleSystem::
-get_inital_birth_offset() const {
-  return _inital_birth_offset;
+get_initial_birth_offset() const {
+  return _initial_birth_offset;
 }
 
 /**

--- a/panda/src/particlesystem/particleSystem.I
+++ b/panda/src/particlesystem/particleSystem.I
@@ -44,7 +44,7 @@ clear_to_initial() {
       kill_particle(i);
     }
   }
-  _tics_since_birth = 0.0f;
+  _tics_since_birth = _inital_birth_offset;
 }
 
 /**
@@ -55,7 +55,7 @@ soft_start(PN_stdfloat br) {
   if (br > 0.0)
     set_birth_rate(br);
   _cur_birth_rate = _birth_rate;
-  _tics_since_birth = 0.0f;
+  _tics_since_birth = _inital_birth_offset;
 }
 
 /**
@@ -66,7 +66,7 @@ soft_stop(PN_stdfloat br) {
   if (br > 0.0)
     set_soft_birth_rate(br);
   _cur_birth_rate = _soft_birth_rate;
-  _tics_since_birth = 0.0f;
+  _tics_since_birth = _inital_birth_offset;
 }
 
 /**
@@ -340,6 +340,14 @@ get_factory() const {
 INLINE PN_stdfloat ParticleSystem::
 get_floor_z() const {
   return _floor_z;
+}
+
+/**
+
+*/
+INLINE PN_stdfloat ParticleSystem::
+get_tics_since_birth() const {
+  return _tics_since_birth;
 }
 
 /**

--- a/panda/src/particlesystem/particleSystem.cxx
+++ b/panda/src/particlesystem/particleSystem.cxx
@@ -45,10 +45,11 @@ ParticleSystem::
 ParticleSystem(int pool_size) :
   Physical(pool_size, false)
 {
+  _inital_birth_offset = 0.0f;
   _birth_rate = 0.5f;
   _cur_birth_rate = _birth_rate;
   _soft_birth_rate = HUGE_VAL;
-  _tics_since_birth = 0.0;
+  _tics_since_birth = _inital_birth_offset;
   _litter_size = 1;
   _litter_spread = 0;
   _living_particles = 0;
@@ -90,6 +91,7 @@ ParticleSystem(const ParticleSystem& copy) :
   _system_age(0.0f),
   _template_system_flag(false)
 {
+  _inital_birth_offset = copy._inital_birth_offset;
   _birth_rate = copy._birth_rate;
   _cur_birth_rate = copy._cur_birth_rate;
   _litter_size = copy._litter_size;
@@ -107,7 +109,7 @@ ParticleSystem(const ParticleSystem& copy) :
   _render_node_path = _renderer->get_render_node_path();
   _render_node_path.reparent_to(_render_parent);
 
-  _tics_since_birth = 0.0;
+  _tics_since_birth = _inital_birth_offset;
   _system_lifespan = copy._system_lifespan;
   _living_particles = 0;
 
@@ -723,6 +725,7 @@ write(ostream &out, int indent) const {
   out.width(indent); out<<""; out<<"ParticleSystem:\n";
   out.width(indent+2); out<<""; out<<"_particle_pool_size "<<_particle_pool_size<<"\n";
   out.width(indent+2); out<<""; out<<"_living_particles "<<_living_particles<<"\n";
+  out.width(indent+2); out<<""; out<<"_inital_birth_offset "<<_inital_birth_offset<<"\n";
   out.width(indent+2); out<<""; out<<"_tics_since_birth "<<_tics_since_birth<<"\n";
   out.width(indent+2); out<<""; out<<"_litter_size "<<_litter_size<<"\n";
   out.width(indent+2); out<<""; out<<"_litter_spread "<<_litter_spread<<"\n";

--- a/panda/src/particlesystem/particleSystem.cxx
+++ b/panda/src/particlesystem/particleSystem.cxx
@@ -45,11 +45,11 @@ ParticleSystem::
 ParticleSystem(int pool_size) :
   Physical(pool_size, false)
 {
-  _inital_birth_offset = 0.0f;
+  _initial_birth_offset = 0.0f;
   _birth_rate = 0.5f;
   _cur_birth_rate = _birth_rate;
   _soft_birth_rate = HUGE_VAL;
-  _tics_since_birth = _inital_birth_offset;
+  _tics_since_birth = _initial_birth_offset;
   _litter_size = 1;
   _litter_spread = 0;
   _living_particles = 0;
@@ -91,7 +91,7 @@ ParticleSystem(const ParticleSystem& copy) :
   _system_age(0.0f),
   _template_system_flag(false)
 {
-  _inital_birth_offset = copy._inital_birth_offset;
+  _initial_birth_offset = copy._initial_birth_offset;
   _birth_rate = copy._birth_rate;
   _cur_birth_rate = copy._cur_birth_rate;
   _litter_size = copy._litter_size;
@@ -109,7 +109,7 @@ ParticleSystem(const ParticleSystem& copy) :
   _render_node_path = _renderer->get_render_node_path();
   _render_node_path.reparent_to(_render_parent);
 
-  _tics_since_birth = _inital_birth_offset;
+  _tics_since_birth = _initial_birth_offset;
   _system_lifespan = copy._system_lifespan;
   _living_particles = 0;
 
@@ -725,7 +725,7 @@ write(ostream &out, int indent) const {
   out.width(indent); out<<""; out<<"ParticleSystem:\n";
   out.width(indent+2); out<<""; out<<"_particle_pool_size "<<_particle_pool_size<<"\n";
   out.width(indent+2); out<<""; out<<"_living_particles "<<_living_particles<<"\n";
-  out.width(indent+2); out<<""; out<<"_inital_birth_offset "<<_inital_birth_offset<<"\n";
+  out.width(indent+2); out<<""; out<<"_initial_birth_offset "<<_initial_birth_offset<<"\n";
   out.width(indent+2); out<<""; out<<"_tics_since_birth "<<_tics_since_birth<<"\n";
   out.width(indent+2); out<<""; out<<"_litter_size "<<_litter_size<<"\n";
   out.width(indent+2); out<<""; out<<"_litter_spread "<<_litter_spread<<"\n";

--- a/panda/src/particlesystem/particleSystem.h
+++ b/panda/src/particlesystem/particleSystem.h
@@ -60,6 +60,7 @@ PUBLISHED:
   INLINE void set_emitter(BaseParticleEmitter *e);
   INLINE void set_factory(BaseParticleFactory *f);
   INLINE void set_floor_z(PN_stdfloat z);
+  INLINE void set_inital_birth_offset(PN_stdfloat offset);
 
   INLINE void clear_floor_z();
 
@@ -84,6 +85,7 @@ PUBLISHED:
   INLINE BaseParticleFactory *get_factory() const;
   INLINE PN_stdfloat get_floor_z() const;
   INLINE PN_stdfloat get_tics_since_birth() const;
+  INLINE PN_stdfloat get_inital_birth_offset() const;
 
   // particle template vector
 
@@ -118,6 +120,7 @@ private:
 
   int _particle_pool_size;
   int _living_particles;
+  PN_stdfloat _inital_birth_offset;
   PN_stdfloat _cur_birth_rate;
   PN_stdfloat _birth_rate;
   PN_stdfloat _soft_birth_rate;

--- a/panda/src/particlesystem/particleSystem.h
+++ b/panda/src/particlesystem/particleSystem.h
@@ -60,7 +60,7 @@ PUBLISHED:
   INLINE void set_emitter(BaseParticleEmitter *e);
   INLINE void set_factory(BaseParticleFactory *f);
   INLINE void set_floor_z(PN_stdfloat z);
-  INLINE void set_inital_birth_offset(PN_stdfloat offset);
+  INLINE void set_initial_birth_offset(PN_stdfloat offset);
 
   INLINE void clear_floor_z();
 
@@ -85,7 +85,7 @@ PUBLISHED:
   INLINE BaseParticleFactory *get_factory() const;
   INLINE PN_stdfloat get_floor_z() const;
   INLINE PN_stdfloat get_tics_since_birth() const;
-  INLINE PN_stdfloat get_inital_birth_offset() const;
+  INLINE PN_stdfloat get_initial_birth_offset() const;
 
   // particle template vector
 
@@ -120,7 +120,7 @@ private:
 
   int _particle_pool_size;
   int _living_particles;
-  PN_stdfloat _inital_birth_offset;
+  PN_stdfloat _initial_birth_offset;
   PN_stdfloat _cur_birth_rate;
   PN_stdfloat _birth_rate;
   PN_stdfloat _soft_birth_rate;

--- a/panda/src/particlesystem/particleSystem.h
+++ b/panda/src/particlesystem/particleSystem.h
@@ -83,6 +83,7 @@ PUBLISHED:
   INLINE BaseParticleEmitter *get_emitter() const;
   INLINE BaseParticleFactory *get_factory() const;
   INLINE PN_stdfloat get_floor_z() const;
+  INLINE PN_stdfloat get_tics_since_birth() const;
 
   // particle template vector
 


### PR DESCRIPTION
The primary purpose of this pull request is to add a means of offsetting a particle system's first birth. 

To this end, a new variable, "_initial_birth_offset", has been added, along with a getter and setter for it. Where "_tics_since_birth" was previously set to "0.0f", it's now set to the value of "_initial_birth_offset" instead, causing the first particle-birth of the system to be shifted by that amount.

There is a complication: the "start" method of "ParticleEffect" just enables the relevant particle systems; it doesn't reset "_tics_since_birth". (Although "softStart" _does_ reset "_tics_since_birth".) Furthermore, there seems to be no post-setup initialisation.

As a result, having the setter-method for "_initial_birth_offset" just setting the value of the variable's isn't quite enough: it's essentially too late, as "_tics_since_birth" has already been assigned the default value of "0.0f".

Thus, I currently have the setter for "_initial_birth_offset" also reset "_tics_since_birth"; while perhaps not ideal, it does solve the problem. I'm very open to better solutions, however!

I intend to add unit-tests to this pull-request at a later point; I want to get this much uploaded now, at least!

This pull-request also adds a method to query the value of "_tics_since_birth", which may be useful for timing other objects. (I recall that it's generally preferred to split separate changes, but this one seems so small that I'm hoping that it's okay to just include it with the main request. ^^; )

And finally, a quick program that demonstrates the new functionality (aside from getting "_tics_since_birth"):

```python
from direct.showbase.ShowBase import ShowBase
from direct.particles.ParticleEffect import ParticleEffect
from panda3d.core import Vec4

class Game(ShowBase):

    def __init__(self):
        ShowBase.__init__(self)
        self.enableParticles()
        self.win.setClearColor(Vec4(0, 0, 0, 1))

        self.accept("escape", base.userExit)

        self.basicEffect = ParticleEffect()
        self.basicEffect.loadConfig("testParticles.ptf")
        self.basicEffect.setPos(0.75, 5, -0.3)

        self.offsetEffect = ParticleEffect()
        self.offsetEffect.loadConfig("testParticles.ptf")
        self.offsetEffect.getParticlesList()[0].setInitialBirthOffset(-0.25)
        self.offsetEffect.setPos(-0.75, 5, -0.3)

        self.basicEffect.start(parent = render, renderParent = render)
        self.offsetEffect.start(parent = render, renderParent = render)

app = Game()
app.run()
```

"testParticles.ptf" is a simple point-particle effect:
```python

self.reset()
self.setPos(0.000, 0.000, 0.000)
self.setHpr(0.000, 0.000, 0.000)
self.setScale(1.000, 1.000, 1.000)
p0 = Particles.Particles('particles-1')
# Particles parameters
p0.setFactory("PointParticleFactory")
p0.setRenderer("PointParticleRenderer")
p0.setEmitter("SphereSurfaceEmitter")
p0.setPoolSize(1024)
p0.setBirthRate(2.0000)
p0.setLitterSize(100)
p0.setLitterSpread(0)
p0.setSystemLifespan(0.0000)
p0.setLocalVelocityFlag(1)
p0.setSystemGrowsOlderFlag(0)
# Factory parameters
p0.factory.setLifespanBase(0.5000)
p0.factory.setLifespanSpread(0.0000)
p0.factory.setMassBase(1.0000)
p0.factory.setMassSpread(0.0000)
p0.factory.setTerminalVelocityBase(400.0000)
p0.factory.setTerminalVelocitySpread(0.0000)
# Point factory parameters
# Renderer parameters
p0.renderer.setAlphaMode(BaseParticleRenderer.PRALPHAOUT)
p0.renderer.setUserAlpha(1.00)
# Point parameters
p0.renderer.setPointSize(1.00)
p0.renderer.setStartColor(Vec4(1.00, 1.00, 1.00, 1.00))
p0.renderer.setEndColor(Vec4(1.00, 1.00, 1.00, 1.00))
p0.renderer.setBlendType(PointParticleRenderer.PPONECOLOR)
p0.renderer.setBlendMethod(BaseParticleRenderer.PPNOBLEND)
# Emitter parameters
p0.emitter.setEmissionType(BaseParticleEmitter.ETRADIATE)
p0.emitter.setAmplitude(1.0000)
p0.emitter.setAmplitudeSpread(0.0000)
p0.emitter.setOffsetForce(Vec3(0.0000, 0.0000, 1.0000))
p0.emitter.setExplicitLaunchVector(Vec3(1.0000, 0.0000, 0.0000))
p0.emitter.setRadiateOrigin(Point3(0.0000, 0.0000, 0.0000))
# Sphere Surface parameters
p0.emitter.setRadius(0.1000)
self.addParticles(p0)
```
![Screenshot from 2019-10-31 22-42-07](https://user-images.githubusercontent.com/36933600/67984610-c927c500-fc2f-11e9-9be4-8a9e8b3e76a1.png)
