### PR TITLE
Simpler particle birth-offset, and again plus a "_tics_since_birth" getter

### DIFF
--- a/direct/src/particles/ParticleEffect.py
+++ b/direct/src/particles/ParticleEffect.py
@@ -220,11 +220,11 @@ class ParticleEffect(NodePath):
         for particles in self.getParticlesList():
             particles.softStop()
 
-    def softStart(self, firstBirthOffset = None):
+    def softStart(self, firstBirthOffset=None):
         if self.__isValid():
             for particles in self.getParticlesList():
                 if firstBirthOffset is not None:
-                    particles.softStartOffset(boff = firstBirthOffset)
+                    particles.softStart(br = -1, first_birth_offset_time = firstBirthOffset)
                 else:
                     particles.softStart()
         else:

--- a/direct/src/particles/ParticleEffect.py
+++ b/direct/src/particles/ParticleEffect.py
@@ -220,10 +220,13 @@ class ParticleEffect(NodePath):
         for particles in self.getParticlesList():
             particles.softStop()
 
-    def softStart(self, firstBirthOffset = 0):
+    def softStart(self, firstBirthOffset = None):
         if self.__isValid():
             for particles in self.getParticlesList():
-                particles.softStart(boff = firstBirthOffset)
+                if firstBirthOffset is not None:
+                    particles.softStartOffset(boff = firstBirthOffset)
+                else:
+                    particles.softStart()
         else:
             # Not asserting here since we want to crash live clients for more expedient bugfix
             # (Sorry, live clients)

--- a/direct/src/particles/ParticleEffect.py
+++ b/direct/src/particles/ParticleEffect.py
@@ -224,7 +224,7 @@ class ParticleEffect(NodePath):
         if self.__isValid():
             for particles in self.getParticlesList():
                 if firstBirthDelay is not None:
-                    particles.softStart(br = -1, first_birth_delay = firstBirthDelay)
+                    particles.softStart(br=-1, first_birth_delay=firstBirthDelay)
                 else:
                     particles.softStart()
         else:

--- a/direct/src/particles/ParticleEffect.py
+++ b/direct/src/particles/ParticleEffect.py
@@ -220,11 +220,11 @@ class ParticleEffect(NodePath):
         for particles in self.getParticlesList():
             particles.softStop()
 
-    def softStart(self, firstBirthOffset=None):
+    def softStart(self, firstBirthDelay=None):
         if self.__isValid():
             for particles in self.getParticlesList():
-                if firstBirthOffset is not None:
-                    particles.softStart(br = -1, first_birth_offset_time = firstBirthOffset)
+                if firstBirthDelay is not None:
+                    particles.softStart(br = -1, first_birth_delay = firstBirthDelay)
                 else:
                     particles.softStart()
         else:

--- a/direct/src/particles/ParticleEffect.py
+++ b/direct/src/particles/ParticleEffect.py
@@ -220,10 +220,10 @@ class ParticleEffect(NodePath):
         for particles in self.getParticlesList():
             particles.softStop()
 
-    def softStart(self):
+    def softStart(self, firstBirthOffset = 0):
         if self.__isValid():
             for particles in self.getParticlesList():
-                particles.softStart()
+                particles.softStart(boff = firstBirthOffset)
         else:
             # Not asserting here since we want to crash live clients for more expedient bugfix
             # (Sorry, live clients)

--- a/panda/src/particlesystem/particleSystem.I
+++ b/panda/src/particlesystem/particleSystem.I
@@ -51,11 +51,11 @@ clear_to_initial() {
  * Causes system to use birth rate set by set_birth_rate()
  */
 INLINE void ParticleSystem::
-soft_start(PN_stdfloat br) {
+soft_start(PN_stdfloat br, PN_stdfloat boff) {
   if (br > 0.0)
     set_birth_rate(br);
   _cur_birth_rate = _birth_rate;
-  _tics_since_birth = 0.0f;
+  _tics_since_birth = boff;
 }
 
 /**
@@ -340,6 +340,14 @@ get_factory() const {
 INLINE PN_stdfloat ParticleSystem::
 get_floor_z() const {
   return _floor_z;
+}
+
+/**
+
+*/
+INLINE PN_stdfloat ParticleSystem::
+get_tics_since_birth() const {
+  return _tics_since_birth;
 }
 
 /**

--- a/panda/src/particlesystem/particleSystem.I
+++ b/panda/src/particlesystem/particleSystem.I
@@ -51,10 +51,19 @@ clear_to_initial() {
  * Causes system to use birth rate set by set_birth_rate()
  */
 INLINE void ParticleSystem::
-soft_start(PN_stdfloat br, PN_stdfloat boff) {
+soft_start(PN_stdfloat br) {
   if (br > 0.0)
     set_birth_rate(br);
   _cur_birth_rate = _birth_rate;
+  _tics_since_birth = 0.0f;
+}
+
+/**
+ * Causes system to use birth rate set by set_birth_rate()
+ */
+INLINE void ParticleSystem::
+soft_start_offset(PN_stdfloat br, PN_stdfloat boff) {
+  soft_start(br);
   _tics_since_birth = boff;
 }
 

--- a/panda/src/particlesystem/particleSystem.I
+++ b/panda/src/particlesystem/particleSystem.I
@@ -59,12 +59,12 @@ soft_start(PN_stdfloat br) {
 }
 
 /**
- * Causes system to use birth rate set by set_birth_rate()
+ * Causes system to use birth rate set by set_birth_rate(), with the timer for the system's initial birth offset by the value of first_birth_offset_time
  */
 INLINE void ParticleSystem::
-soft_start_offset(PN_stdfloat br, PN_stdfloat boff) {
+soft_start(PN_stdfloat br, PN_stdfloat first_birth_offset_time) {
   soft_start(br);
-  _tics_since_birth = boff;
+  _tics_since_birth = first_birth_offset_time;
 }
 
 /**

--- a/panda/src/particlesystem/particleSystem.I
+++ b/panda/src/particlesystem/particleSystem.I
@@ -59,12 +59,15 @@ soft_start(PN_stdfloat br) {
 }
 
 /**
- * Causes system to use birth rate set by set_birth_rate(), with the timer for the system's initial birth offset by the value of first_birth_offset_time
+ * Causes system to use birth rate set by set_birth_rate(), with the system's
+ * first birth being delayed by the value of first_birth_delay. Note that a
+ * negative delay is perfectly valid, causing the first birth to happen
+ * sooner rather than later.
  */
 INLINE void ParticleSystem::
-soft_start(PN_stdfloat br, PN_stdfloat first_birth_offset_time) {
+soft_start(PN_stdfloat br, PN_stdfloat first_birth_delay) {
   soft_start(br);
-  _tics_since_birth = first_birth_offset_time;
+  _tics_since_birth = -first_birth_delay;
 }
 
 /**

--- a/panda/src/particlesystem/particleSystem.h
+++ b/panda/src/particlesystem/particleSystem.h
@@ -83,6 +83,7 @@ PUBLISHED:
   INLINE BaseParticleEmitter *get_emitter() const;
   INLINE BaseParticleFactory *get_factory() const;
   INLINE PN_stdfloat get_floor_z() const;
+  INLINE PN_stdfloat get_tics_since_birth() const;
 
   // particle template vector
 
@@ -95,7 +96,7 @@ PUBLISHED:
   INLINE void induce_labor();
   INLINE void clear_to_initial();
   INLINE void soft_stop(PN_stdfloat br = 0.0);
-  INLINE void soft_start(PN_stdfloat br = 0.0);
+  INLINE void soft_start(PN_stdfloat br = 0.0, PN_stdfloat boff = 0.0);
   void update(PN_stdfloat dt);
 
   virtual void output(std::ostream &out) const;

--- a/panda/src/particlesystem/particleSystem.h
+++ b/panda/src/particlesystem/particleSystem.h
@@ -96,7 +96,8 @@ PUBLISHED:
   INLINE void induce_labor();
   INLINE void clear_to_initial();
   INLINE void soft_stop(PN_stdfloat br = 0.0);
-  INLINE void soft_start(PN_stdfloat br = 0.0, PN_stdfloat boff = 0.0);
+  INLINE void soft_start(PN_stdfloat br = 0.0);
+  INLINE void soft_start_offset(PN_stdfloat br = 0.0, PN_stdfloat boff = 0.0);
   void update(PN_stdfloat dt);
 
   virtual void output(std::ostream &out) const;

--- a/panda/src/particlesystem/particleSystem.h
+++ b/panda/src/particlesystem/particleSystem.h
@@ -97,7 +97,7 @@ PUBLISHED:
   INLINE void clear_to_initial();
   INLINE void soft_stop(PN_stdfloat br = 0.0);
   INLINE void soft_start(PN_stdfloat br = 0.0);
-  INLINE void soft_start(PN_stdfloat br, PN_stdfloat first_birth_offset_time);
+  INLINE void soft_start(PN_stdfloat br, PN_stdfloat first_birth_delay);
   void update(PN_stdfloat dt);
 
   virtual void output(std::ostream &out) const;

--- a/panda/src/particlesystem/particleSystem.h
+++ b/panda/src/particlesystem/particleSystem.h
@@ -97,7 +97,7 @@ PUBLISHED:
   INLINE void clear_to_initial();
   INLINE void soft_stop(PN_stdfloat br = 0.0);
   INLINE void soft_start(PN_stdfloat br = 0.0);
-  INLINE void soft_start_offset(PN_stdfloat br = 0.0, PN_stdfloat boff = 0.0);
+  INLINE void soft_start(PN_stdfloat br, PN_stdfloat first_birth_offset_time);
   void update(PN_stdfloat dt);
 
   virtual void output(std::ostream &out) const;

--- a/tests/particles/test_particle_offsetting_and_birth_rate.py
+++ b/tests/particles/test_particle_offsetting_and_birth_rate.py
@@ -27,13 +27,13 @@ def test_particle_soft_start():
     # used to.
     effect.softStart()
 
-    assert (system.getBirthRate() == 0.5)
+    assert system.getBirthRate() == 0.5
 
     # Now, check that the pre-existing single-parameter soft-start,
     # which alters the birth-rate, still does so.
     system.softStart(1)
 
-    assert (system.getBirthRate() == 1)
+    assert system.getBirthRate() == 1
 
     # Next, birth-delaying.
 
@@ -41,7 +41,7 @@ def test_particle_soft_start():
     # is zero, as used to be the case on running this command.
     effect.softStart()
 
-    assert (system.getTicsSinceBirth() == 0)
+    assert system.getTicsSinceBirth() == 0
 
     # Run an delayed soft-start via the system, then check
     # that the birth-timer has the assigned value,
@@ -50,18 +50,18 @@ def test_particle_soft_start():
     # (We pass in a birth-rate ("br") of -1 because the related code
     # checks for a birth-rate greater than 0, I believe. This allows
     # us to change the delay without affecting the birth-rate.)
-    system.softStart(br = -1, first_birth_delay = -2)
+    system.softStart(br=-1, first_birth_delay=-2)
 
-    assert (system.getBirthRate() == 1)
-    assert (system.getTicsSinceBirth() == 2)
+    assert system.getBirthRate() == 1
+    assert system.getTicsSinceBirth() == 2
 
     # Now, run a delayed soft-start via the effect, and
     # again check that the birth-timer has changed as intended,
     # and the birth-rate hasn't changed at all.
-    effect.softStart(firstBirthDelay = 0.25)
+    effect.softStart(firstBirthDelay=0.25)
 
-    assert (system.getBirthRate() == 1)
-    assert (system.getTicsSinceBirth() == -0.25)
+    assert system.getBirthRate() == 1
+    assert system.getTicsSinceBirth() == -0.25
 
     # Update the system, advancing it far enough that it should
     # have birthed a particle if not for the delay, but not
@@ -69,14 +69,14 @@ def test_particle_soft_start():
     # the delay. Check thus that no particles have been birthed.
     system.update(1)
 
-    assert (system.getLivingParticles() == 0)
+    assert system.getLivingParticles() == 0
 
     # Update the system again, this time far enough that with the
     # delay it should have birthed just one particle, and
     # then check that this is the case.
     system.update(1)
 
-    assert (system.getLivingParticles() == 1)
+    assert system.getLivingParticles() == 1
 
     # And finally, check that an unaltered system births as
     # expected given a single update:
@@ -85,13 +85,13 @@ def test_particle_soft_start():
     systemControl.setRenderParent(NodePath(PandaNode("test 2")))
     systemControl.setSpawnRenderNodePath(NodePath(PandaNode("test 2")))
 
-    assert (systemControl.getBirthRate() == 0.5)
-    assert (systemControl.getTicsSinceBirth() == 0)
+    assert systemControl.getBirthRate() == 0.5
+    assert systemControl.getTicsSinceBirth() == 0
 
-    assert (systemControl.getLivingParticles() == 0)
+    assert systemControl.getLivingParticles() == 0
 
     systemControl.update(0.6)
 
-    assert (systemControl.getLivingParticles() == 1)
+    assert systemControl.getLivingParticles() == 1
 
     # Done! :D

--- a/tests/particles/test_particle_offsetting_and_birth_rate.py
+++ b/tests/particles/test_particle_offsetting_and_birth_rate.py
@@ -1,0 +1,97 @@
+from panda3d.core import NodePath, PandaNode
+from direct.particles.ParticleEffect import ParticleEffect
+from direct.particles.Particles import Particles
+
+def test_particle_soft_start():
+    # Create a particle effect and a particle system.
+    # The effect serves to test the Python-level "softStart"
+    # method, while the systme serves to test the C++-level
+    # "soft_start" method (via the associated Python "softStart"
+    # method)
+    effect = ParticleEffect()
+    system = Particles("testSystem", 10)
+
+    # Setup some dummy nodes, since it seems to want them
+    system.setRenderParent(NodePath(PandaNode("test")))
+    system.setSpawnRenderNodePath(NodePath(PandaNode("test")))
+
+    # Add the system to the effect
+    effect.addParticles(system)
+
+    # Re-assign the system, just to make sure that we have the
+    # right object.
+    system = effect.getParticlesList()[0]
+
+    # First, standard "softStart"--i.e. without changing either
+    # birth-rate or applying an offset. This should work as it
+    # used to.
+    effect.softStart()
+
+    assert (system.getBirthRate() == 0.5)
+
+    # Now, check that the pre-existing single-parameter soft-start,
+    # which alters the birth-rate, still does so.
+    system.softStart(1)
+
+    assert (system.getBirthRate() == 1)
+
+    # Next, birth-offsetting.
+
+    # Run a standard soft-start, then check that the birth-timer
+    # is zero, as used to be the case on running this command.
+    effect.softStart()
+
+    assert (system.getTicsSinceBirth() == 0)
+
+    # Run an offset soft-start via the system, then check
+    # that the birth-timer has the assigned value,
+    # and that the birth-rate is unchanged.
+
+    # (We pass in a birth-rate ("br") of -1 because the related code
+    # checks for a birth-rate greater than 0, I believe. This allows
+    # us to change the offset-time without affecting the birth-rate.)
+    system.softStart(br = -1, first_birth_offset_time = 2)
+
+    assert (system.getBirthRate() == 1)
+    assert (system.getTicsSinceBirth() == 2)
+
+    # Now, run an offset soft-start via the effect, and
+    # again check that the birth-timer has changed as intended,
+    # and the birth-rate hasn't changed at all.
+    effect.softStart(firstBirthOffset = -0.25)
+
+    assert (system.getBirthRate() == 1)
+    assert (system.getTicsSinceBirth() == -0.25)
+
+    # Update the system, advancing it far enough that it should
+    # have birthed a particle if not for the offset, but not
+    # so far that it should have birthed a particle >with<
+    # the offset. Check thus that no particles have been birthed.
+    system.update(1)
+
+    assert (system.getLivingParticles() == 0)
+
+    # Update the system again, this time far enough that with the
+    # offset it should have birthed just one particle, and
+    # then check that this is the case.
+    system.update(1)
+
+    assert (system.getLivingParticles() == 1)
+
+    # And finally, check that an unaltered system births as
+    # expected given a single update:
+    systemControl = Particles("testSystem; control", 10)
+
+    systemControl.setRenderParent(NodePath(PandaNode("test 2")))
+    systemControl.setSpawnRenderNodePath(NodePath(PandaNode("test 2")))
+
+    assert (systemControl.getBirthRate() == 0.5)
+    assert (systemControl.getTicsSinceBirth() == 0)
+
+    assert (systemControl.getLivingParticles() == 0)
+
+    systemControl.update(0.6)
+
+    assert (systemControl.getLivingParticles() == 1)
+
+    # Done! :D

--- a/tests/particles/test_particle_offsetting_and_birth_rate.py
+++ b/tests/particles/test_particle_offsetting_and_birth_rate.py
@@ -22,8 +22,8 @@ def test_particle_soft_start():
     # right object.
     system = effect.getParticlesList()[0]
 
-    # First, standard "softStart"--i.e. without changing either
-    # birth-rate or applying an offset. This should work as it
+    # First, standard "softStart"--i.e. without either changing
+    # the birth-rate or applying a delay. This should work as it
     # used to.
     effect.softStart()
 
@@ -35,7 +35,7 @@ def test_particle_soft_start():
 
     assert (system.getBirthRate() == 1)
 
-    # Next, birth-offsetting.
+    # Next, birth-delaying.
 
     # Run a standard soft-start, then check that the birth-timer
     # is zero, as used to be the case on running this command.
@@ -43,36 +43,36 @@ def test_particle_soft_start():
 
     assert (system.getTicsSinceBirth() == 0)
 
-    # Run an offset soft-start via the system, then check
+    # Run an delayed soft-start via the system, then check
     # that the birth-timer has the assigned value,
     # and that the birth-rate is unchanged.
 
     # (We pass in a birth-rate ("br") of -1 because the related code
     # checks for a birth-rate greater than 0, I believe. This allows
-    # us to change the offset-time without affecting the birth-rate.)
-    system.softStart(br = -1, first_birth_offset_time = 2)
+    # us to change the delay without affecting the birth-rate.)
+    system.softStart(br = -1, first_birth_delay = -2)
 
     assert (system.getBirthRate() == 1)
     assert (system.getTicsSinceBirth() == 2)
 
-    # Now, run an offset soft-start via the effect, and
+    # Now, run a delayed soft-start via the effect, and
     # again check that the birth-timer has changed as intended,
     # and the birth-rate hasn't changed at all.
-    effect.softStart(firstBirthOffset = -0.25)
+    effect.softStart(firstBirthDelay = 0.25)
 
     assert (system.getBirthRate() == 1)
     assert (system.getTicsSinceBirth() == -0.25)
 
     # Update the system, advancing it far enough that it should
-    # have birthed a particle if not for the offset, but not
+    # have birthed a particle if not for the delay, but not
     # so far that it should have birthed a particle >with<
-    # the offset. Check thus that no particles have been birthed.
+    # the delay. Check thus that no particles have been birthed.
     system.update(1)
 
     assert (system.getLivingParticles() == 0)
 
     # Update the system again, this time far enough that with the
-    # offset it should have birthed just one particle, and
+    # delay it should have birthed just one particle, and
     # then check that this is the case.
     system.update(1)
 


### PR DESCRIPTION
As with #766, this pull request is intended to allow one to start a particle effect with a slight offset to particle birthing.

However, where that previous version introduced a new variable, "_initial_birth_offset", this one makes do without. Instead, it modifies the "soft_start" method to take an optional parameter that is used in setting "_tics_since_birth", where before it was being set to "0.0f", if I'm not much mistaken. 

The optional parameter has a default value of "0.0f", intended to result in extant code still producing the same effects.

There are then similar changes to related Python classes, allowing this offset to be passed in to the C++ "soft_start" method.

And as before, a "getter" method has been exposed to allow querying of the "_tics_since_birth" variable.

Finally, a simple demonstrative program for these changes:
```python
from direct.showbase.ShowBase import ShowBase
from direct.particles.ParticleEffect import ParticleEffect
from panda3d.core import Vec4

class Game(ShowBase):

    def __init__(self):
        ShowBase.__init__(self)
        self.enableParticles()
        self.win.setClearColor(Vec4(0, 0, 0, 1))

        self.accept("escape", base.userExit)

        self.basicEffect = ParticleEffect()
        self.basicEffect.loadConfig("testParticles.ptf")
        self.basicEffect.setPos(0.75, 5, -0.3)

        self.offsetEffect = ParticleEffect()
        self.offsetEffect.loadConfig("testParticles.ptf")
        self.offsetEffect.setPos(-0.75, 5, -0.3)

        self.basicEffect.start(parent = render, renderParent = render)
        self.offsetEffect.start(parent = render, renderParent = render)
        
        print (self.offsetEffect.getParticlesList()[0].getTicsSinceBirth())

        self.offsetEffect.softStart(firstBirthOffset = -0.25)

        print (self.offsetEffect.getParticlesList()[0].getTicsSinceBirth())

app = Game()
app.run()
```
"testParticles.ptf" is the same as in the previous version, being is a simple point-particle effect:
```python
self.reset()
self.setPos(0.000, 0.000, 0.000)
self.setHpr(0.000, 0.000, 0.000)
self.setScale(1.000, 1.000, 1.000)
p0 = Particles.Particles('particles-1')
# Particles parameters
p0.setFactory("PointParticleFactory")
p0.setRenderer("PointParticleRenderer")
p0.setEmitter("SphereSurfaceEmitter")
p0.setPoolSize(1024)
p0.setBirthRate(2.0000)
p0.setLitterSize(100)
p0.setLitterSpread(0)
p0.setSystemLifespan(0.0000)
p0.setLocalVelocityFlag(1)
p0.setSystemGrowsOlderFlag(0)
# Factory parameters
p0.factory.setLifespanBase(0.5000)
p0.factory.setLifespanSpread(0.0000)
p0.factory.setMassBase(1.0000)
p0.factory.setMassSpread(0.0000)
p0.factory.setTerminalVelocityBase(400.0000)
p0.factory.setTerminalVelocitySpread(0.0000)
# Point factory parameters
# Renderer parameters
p0.renderer.setAlphaMode(BaseParticleRenderer.PRALPHAOUT)
p0.renderer.setUserAlpha(1.00)
# Point parameters
p0.renderer.setPointSize(1.00)
p0.renderer.setStartColor(Vec4(1.00, 1.00, 1.00, 1.00))
p0.renderer.setEndColor(Vec4(1.00, 1.00, 1.00, 1.00))
p0.renderer.setBlendType(PointParticleRenderer.PPONECOLOR)
p0.renderer.setBlendMethod(BaseParticleRenderer.PPNOBLEND)
# Emitter parameters
p0.emitter.setEmissionType(BaseParticleEmitter.ETRADIATE)
p0.emitter.setAmplitude(1.0000)
p0.emitter.setAmplitudeSpread(0.0000)
p0.emitter.setOffsetForce(Vec3(0.0000, 0.0000, 1.0000))
p0.emitter.setExplicitLaunchVector(Vec3(1.0000, 0.0000, 0.0000))
p0.emitter.setRadiateOrigin(Point3(0.0000, 0.0000, 0.0000))
# Sphere Surface parameters
p0.emitter.setRadius(0.1000)
self.addParticles(p0)
```
![Screenshot from 2019-11-01 21-37-47](https://user-images.githubusercontent.com/36933600/68051358-e7ed9080-fcef-11e9-8642-30a716bba90f.png)

