### PR TITLE
Added EXPCLs to fix linking errors with clang in windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ __pycache__/
 .tox/
 .cache/
 .pytest_cache/
+/.settings/
+/.cproject
+/.project

--- a/dtool/src/dtoolutil/textEncoder.h
+++ b/dtool/src/dtoolutil/textEncoder.h
@@ -140,6 +140,7 @@ private:
 
   static Encoding _default_encoding;
 };
+
 EXPCL_DTOOL_DTOOLUTIL std::ostream &
 operator << (std::ostream &out, TextEncoder::Encoding encoding);
 EXPCL_DTOOL_DTOOLUTIL std::istream &

--- a/dtool/src/dtoolutil/textEncoder.h
+++ b/dtool/src/dtoolutil/textEncoder.h
@@ -140,7 +140,6 @@ private:
 
   static Encoding _default_encoding;
 };
-
 EXPCL_DTOOL_DTOOLUTIL std::ostream &
 operator << (std::ostream &out, TextEncoder::Encoding encoding);
 EXPCL_DTOOL_DTOOLUTIL std::istream &
@@ -151,8 +150,7 @@ operator >> (std::istream &in, TextEncoder::Encoding &encoding);
 
 // This function is declared inline to minimize the risk of link conflicts
 // should another third-party module also define the same output operator.
-INLINE EXPCL_DTOOL_DTOOLUTIL std::ostream &
-operator << (std::ostream &out, const std::wstring &str);
+INLINE std::ostream & operator << (std::ostream &out, const std::wstring &str);
 
 #include "textEncoder.I"
 

--- a/panda/src/bullet/bulletDebugNode.h
+++ b/panda/src/bullet/bulletDebugNode.h
@@ -74,7 +74,7 @@ private:
     UnalignedLVecBase4 _color;
   };
 
-  class DebugDraw : public btIDebugDraw {
+  class EXPCL_PANDABULLET DebugDraw : public btIDebugDraw {
 
   public:
     DebugDraw() {};

--- a/panda/src/express/virtualFileMountRamdisk.h
+++ b/panda/src/express/virtualFileMountRamdisk.h
@@ -65,7 +65,7 @@ private:
   class File;
   class Directory;
 
-  class FileBase : public TypedReferenceCount {
+  class EXPCL_PANDA_EXPRESS FileBase : public TypedReferenceCount {
   public:
     INLINE FileBase(const std::string &basename);
     virtual ~FileBase();
@@ -94,7 +94,7 @@ private:
     static TypeHandle _type_handle;
   };
 
-  class File : public FileBase {
+  class EXPCL_PANDA_EXPRESS File : public FileBase {
   public:
     INLINE File(const std::string &basename);
 
@@ -121,7 +121,7 @@ private:
 
   typedef pset<PT(FileBase), indirect_less<FileBase *> > Files;
 
-  class Directory : public FileBase {
+  class EXPCL_PANDA_EXPRESS Directory : public FileBase {
   public:
     INLINE Directory(const std::string &basename);
 

--- a/panda/src/gobj/geom.h
+++ b/panda/src/gobj/geom.h
@@ -295,7 +295,7 @@ public:
     }
 
   private:
-    static TypeHandle _type_handle;
+    static EXPCL_PANDA_GOBJ TypeHandle _type_handle;
   };
   typedef pmap<const CacheKey *, PT(CacheEntry), IndirectLess<CacheKey> > Cache;
 

--- a/panda/src/gobj/lens.h
+++ b/panda/src/gobj/lens.h
@@ -399,7 +399,7 @@ private:
   static TypeHandle _type_handle;
 };
 
-EXPCL_PANDA_GOBJ INLINE std::ostream &operator << (std::ostream &out, const Lens &lens);
+std::ostream &operator << (std::ostream &out, const Lens &lens);
 
 #include "lens.I"
 

--- a/panda/src/gobj/lens.h
+++ b/panda/src/gobj/lens.h
@@ -399,7 +399,7 @@ private:
   static TypeHandle _type_handle;
 };
 
-std::ostream &operator << (std::ostream &out, const Lens &lens);
+INLINE std::ostream &operator << (std::ostream &out, const Lens &lens);
 
 #include "lens.I"
 

--- a/panda/src/gobj/vertexDataSaveFile.cxx
+++ b/panda/src/gobj/vertexDataSaveFile.cxx
@@ -313,7 +313,7 @@ read_data(unsigned char *data, size_t size, VertexDataSaveBlock *block) {
     }
     success = GetOverlappedResult(_handle, &overlapped, &bytes_read, false);
   }
-  nassertr(bytes_read == size, nullptr);
+  nassertr(bytes_read == size, false);
   double finish_time = ClockObject::get_global_clock()->get_real_time();
   if (gobj_cat.is_debug()) {
     gobj_cat.debug()

--- a/panda/src/pnmimage/convert_srgb.h
+++ b/panda/src/pnmimage/convert_srgb.h
@@ -27,29 +27,25 @@ extern EXPCL_PANDA_PNMIMAGE const float to_linear_float_table[256];
 
 BEGIN_PUBLISH
 
-EXPCL_PANDA_PNMIMAGE INLINE float decode_sRGB_float(unsigned char val);
-EXPCL_PANDA_PNMIMAGE INLINE float decode_sRGB_float(float val);
-EXPCL_PANDA_PNMIMAGE INLINE unsigned char decode_sRGB_uchar(unsigned char val);
-EXPCL_PANDA_PNMIMAGE INLINE unsigned char decode_sRGB_uchar(float val);
+INLINE float decode_sRGB_float(unsigned char val);
+INLINE float decode_sRGB_float(float val);
+INLINE unsigned char decode_sRGB_uchar(unsigned char val);
+INLINE unsigned char decode_sRGB_uchar(float val);
 
-EXPCL_PANDA_PNMIMAGE INLINE float encode_sRGB_float(unsigned char val);
-EXPCL_PANDA_PNMIMAGE INLINE float encode_sRGB_float(float val);
-EXPCL_PANDA_PNMIMAGE INLINE unsigned char encode_sRGB_uchar(unsigned char val);
-EXPCL_PANDA_PNMIMAGE INLINE unsigned char encode_sRGB_uchar(float val);
+INLINE float encode_sRGB_float(unsigned char val);
+INLINE float encode_sRGB_float(float val);
+INLINE unsigned char encode_sRGB_uchar(unsigned char val);
+INLINE unsigned char encode_sRGB_uchar(float val);
 
 END_PUBLISH
 
 // These functions convert more than one component in one go, which can be
 // faster due to vectorization.
-EXPCL_PANDA_PNMIMAGE INLINE void encode_sRGB_uchar(const LColorf &from,
-                                                   xel &into);
-EXPCL_PANDA_PNMIMAGE INLINE void encode_sRGB_uchar(const LColorf &from,
-                                                   xel &into, xelval &into_alpha);
+INLINE void encode_sRGB_uchar(const LColorf &from, xel &into);
+INLINE void encode_sRGB_uchar(const LColorf &from, xel &into, xelval &into_alpha);
 
-EXPCL_PANDA_PNMIMAGE INLINE void encode_sRGB_uchar(const LColord &from,
-                                                   xel &into);
-EXPCL_PANDA_PNMIMAGE INLINE void encode_sRGB_uchar(const LColord &from,
-                                                   xel &into, xelval &into_alpha);
+INLINE void encode_sRGB_uchar(const LColord &from, xel &into);
+INLINE void encode_sRGB_uchar(const LColord &from, xel &into, xelval &into_alpha);
 
 // Use these functions if you know that SSE2 support is available.  Otherwise,
 // they will crash!


### PR DESCRIPTION
I am dividing the pull request #791 and adding into the main branch as requested

Those changes add EXPCLs to sub classes in some classes. Because without then, linking errors ocurred with clang in windows while using mingw32 in Msys2