### PR TITLE
MacOS: Force disable HiDPI on NSView

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -549,6 +549,11 @@ open_window() {
     _parent_window_handle->attach_child(_window_handle);
   }
 
+  // Always disable application HiDPI support, Cocoa will do the eventual upscaling for us.
+  // Note: setWantsBestResolutionOpenGLSurface method is supported from MacOS 10.7 onwards
+  if ([_view respondsToSelector:@selector(setWantsBestResolutionOpenGLSurface:)]) {
+    [_view setWantsBestResolutionOpenGLSurface:NO];
+  }
   if (_properties.has_icon_filename()) {
     NSImage *image = load_image(_properties.get_icon_filename());
     if (image != nil) {


### PR DESCRIPTION
Simple fix for #794, HiDPI mode is always disabled when creating the NSView for the current window.

(Note: only tested on Catalina I want to see if it passes the CI, I will test later on Mojave)