### PR TITLE
dgui: resolve DirectFrame regression caused by 2ca37b8

### DIFF
--- a/direct/src/gui/DirectFrame.py
+++ b/direct/src/gui/DirectFrame.py
@@ -67,13 +67,14 @@ class DirectFrame(DirectGuiWidget):
         """Recreates the given component using the given keyword args."""
         assert name in ("geom", "image", "text")
 
-        if len(states) != self['numStates']:
-            raise ValueError
-
         # constants should be local to or default arguments of constructors
         for c in range(self['numStates']):
             component_name = name + str(c)
-            state = states[c]
+
+            try:
+                state = states[c]
+            except IndexError:
+                state = states[-1]
 
             if self.hascomponent(component_name):
                 if state is None:


### PR DESCRIPTION
2ca37b8c97d67401bea08960e50989787b41f3ec caused a regression in direct/src/gui/DirectFrame.py. 

Sometimes, there are less states specified in `image`, `text` or `geom` option tuples than would be necessary. The most common case is when the "disabled" state is omitted from the tuple, because the GUI element is never expected to be disabled.

Code written before this commit can throw the following traceback:
```
  File "C:\Panda3D-1.11.0\direct\gui\DirectButton.py", line 66, in __init__
    self.initialiseoptions(DirectButton)
  File "C:\Panda3D-1.11.0\direct\gui\DirectGuiBase.py", line 253, in initialiseoptions
    func()
  File "C:\Panda3D-1.11.0\direct\gui\DirectFrame.py", line 135, in setGeom
    sort=DGG.GEOM_SORT_INDEX)
  File "C:\Panda3D-1.11.0\direct\gui\DirectFrame.py", line 71, in __reinitComponent
    raise ValueError
ValueError
```

Originally, before the refactoring, the last state was used as a placeholder for all missing states. This commit restores the past behavior.