### PR TITLE
particle panel: catch file not found errors

### DIFF
--- a/direct/src/tkpanels/ParticlePanel.py
+++ b/direct/src/tkpanels/ParticlePanel.py
@@ -1274,11 +1274,14 @@ class ParticlePanel(AppShell):
             parent = self.parent)
         if particleFilename:
             # Delete existing particles and forces
-            self.particleEffect.loadConfig(
-                Filename.fromOsSpecific(particleFilename))
-            self.selectEffectNamed(self.particleEffect.getName())
-            # Enable effect
-            self.particleEffect.enable()
+            try:
+                self.particleEffect.loadConfig(
+                    Filename.fromOsSpecific(particleFilename))
+                self.selectEffectNamed(self.particleEffect.getName())
+                # Enable effect
+                self.particleEffect.enable()
+            except OSError as e:
+                print(e)
 
     def saveParticleEffectToFile(self):
         # Find path to particle directory


### PR DESCRIPTION
tkinter.filedialog.askopenfilename sometimes returns a string 'None'
when the user click cancel in the file picker dialog. This catches
errors like this, where the file is not found.

No error is displayed in the GUI, but the text of the error is printed
to stdout.

This stems from #811.