### PR TITLE
Fix compilation warning on macOS 10.6 related to setWantsBestResolutionOpenGLSurface

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -549,11 +549,11 @@ open_window() {
     _parent_window_handle->attach_child(_window_handle);
   }
 
-  // Always disable application HiDPI support, Cocoa will do the eventual upscaling for us.
-  // Note: setWantsBestResolutionOpenGLSurface method is supported from MacOS 10.7 onwards
-  if ([_view respondsToSelector:@selector(setWantsBestResolutionOpenGLSurface:)]) {
-    [_view setWantsBestResolutionOpenGLSurface:NO];
-  }
+  // Always disable application HiDPI support, Cocoa will do the eventual
+  // upscaling for us.
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+  [_view setWantsBestResolutionOpenGLSurface:NO];
+#endif
   if (_properties.has_icon_filename()) {
     NSImage *image = load_image(_properties.get_icon_filename());
     if (image != nil) {


### PR DESCRIPTION
#797 introduced a (harmless but annoying) compilation warning on macOS 10.6 as setWantsBestResolutionOpenGLSurface is unknown on macOS 10.6.

This replaces the respondsToSelector with a good old conditional compilation activating the code on mac0S 10.7+