### PR TITLE
Add DirectGui events for wheel up and down mouse events

### DIFF
--- a/direct/src/gui/DirectGuiGlobals.py
+++ b/direct/src/gui/DirectGuiGlobals.py
@@ -70,6 +70,8 @@ B3PRESS = PGButton.getPressPrefix() + MouseButton.three().getName() + '-'
 B1RELEASE = PGButton.getReleasePrefix() + MouseButton.one().getName() + '-'
 B2RELEASE = PGButton.getReleasePrefix() + MouseButton.two().getName() + '-'
 B3RELEASE = PGButton.getReleasePrefix() + MouseButton.three().getName() + '-'
+WHEELUP = PGButton.getReleasePrefix() + p3d.MouseButton.wheelUp().getName() + '-'
+WHEELDOWN = PGButton.getReleasePrefix() + p3d.MouseButton.wheelDown().getName() + '-'
 # For DirectEntry widgets
 OVERFLOW = PGEntry.getOverflowPrefix()
 ACCEPT = PGEntry.getAcceptPrefix() + KeyboardButton.enter().getName() + '-'


### PR DESCRIPTION
Trivial PR to add WHEELUP and WHEELDOWN events in DirectGuiGlobals to help using the wheel with DirectGui widgets, see https://discourse.panda3d.org/t/directgui-mouse-wheel-scrolling/25429