### PR TITLE
macOS: Remove now useless respondsToSelector for setWantsBestResolutionOpenGlSurface

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -550,10 +550,7 @@ open_window() {
   }
 
   // Always disable application HiDPI support, Cocoa will do the eventual upscaling for us.
-  // Note: setWantsBestResolutionOpenGLSurface method is supported from MacOS 10.7 onwards
-  if ([_view respondsToSelector:@selector(setWantsBestResolutionOpenGLSurface:)]) {
-    [_view setWantsBestResolutionOpenGLSurface:NO];
-  }
+  [_view setWantsBestResolutionOpenGLSurface:NO];
   if (_properties.has_icon_filename()) {
     NSImage *image = load_image(_properties.get_icon_filename());
     if (image != nil) {


### PR DESCRIPTION
As master branch requires macOS 10.9 or greater, the respondsToSelector on setWantsBestResolutionOpenGlSurface is no longer needed as setWantsBestResolutionOpenGlSurface has been introduced in macOS 10.7