### PR TITLE
cocoadisplay: Fix regression introduced by fullscreen workaround for Catalina

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1131,7 +1131,9 @@ find_display_mode(int width, int height) {
   }
 #endif
   CFArrayRef modes = CGDisplayCopyAllDisplayModes(_display, options);
-  CFRelease(options);
+  if (options != NULL) {
+    CFRelease(options);
+  }
 
   size_t num_modes = CFArrayGetCount(modes);
   CGDisplayModeRef mode;
@@ -1166,12 +1168,12 @@ find_display_mode(int width, int height) {
 
     // As explained above, we want to select the fullscreen display mode using
     // the same scaling factor, but only for MacOS 10.15+ To do this we check
-    // the mode width and heightbut also actual pixel widh and height.
+    // the mode width and height but also actual pixel widh and height.
     if (CGDisplayModeGetWidth(mode) == width &&
         CGDisplayModeGetHeight(mode) == height &&
         CGDisplayModeGetRefreshRate(mode) == refresh_rate &&
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
-        (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_14 ||
+        (floor(NSAppKitVersionNumber) <= NSAppKitVersionNumber10_14 ||
         (CGDisplayModeGetPixelWidth(mode) == expected_pixel_width &&
          CGDisplayModeGetPixelHeight(mode) == expected_pixel_height)) &&
 #endif


### PR DESCRIPTION
When switching from compile-time to runtime check of the fullscreen switch of #813, I only superficially tested it, and, to my great horror!, I let though one critical regression which causes app to crash when switching to fullscreen mode on non-Catalina macOS.

Actually, CFRelease() causes an assert when called with NULL (contrary to Objective-C Release() which handles it gracefully). With the compile-time check, that part of the code was never used on non-Catalina.

There is also a fix for a minor bug which cause the code to select the wrong scaling factor when switching fullscreen mode in app.
