### PR TITLE
dist: glob pattern must be lowercase as it is compared to lowercase filenames

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -834,7 +834,7 @@ class build_apps(setuptools.Command):
                 whlfile = self._get_zip_file(whl)
                 filenames = whlfile.namelist()
                 for source_pattern, target_dir, flags in datadesc:
-                    srcglob = p3d.GlobPattern(source_pattern)
+                    srcglob = p3d.GlobPattern(source_pattern.lower())
                     source_dir = os.path.dirname(source_pattern)
                     # Relocate the target dir to the build directory.
                     target_dir = target_dir.replace('/', os.sep)


### PR DESCRIPTION
When selecting the files to be copied into the bundle, we loop over the files in the wheels and check them against the packag_data_dirs glob patterns.

However the pattern is checked as-is with lowercased filenames, so if there are uppercase characters in the pattern, the file is not selected (This is the case with some files in CEFPython).