### PR TITLE
dist: Add missing dependency for CEFPython on macOS

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -112,6 +112,7 @@ PACKAGE_DATA_DIRS = {
         ('cefpython3/subprocess*', '', {'PKG_DATA_MAKE_EXECUTABLE'}),
         ('cefpython3/locals/*', 'locals', {}),
         ('cefpython3/Chromium Embedded Framework.framework/Resources', 'Chromium Embedded Framework.framework/Resources', {}),
+        ('cefpython3/Chromium Embedded Framework.framework/Chromium Embedded Framework', '', {'PKG_DATA_MAKE_EXECUTABLE'}),
     ],
 }
 


### PR DESCRIPTION
Add the missing dependency for CEFPython on macOS ```cefpython3/Chromium Embedded Framework.framework/Chromium Embedded Framework```