### PR TITLE
cocoadisplay: Fix switch to fullscreen on macOS 10.9 using current display resolution

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1143,13 +1143,14 @@ find_display_mode(int width, int height) {
   int refresh_rate;
   mode = CGDisplayCopyDisplayMode(_display);
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED < 1080
   // First check if the current mode is adequate.
-  if (CGDisplayModeGetWidth(mode) == width &&
+  // This test not done for macOS 10.15 and above as the mode resolution is
+  // not enough to identify a mode.
+  if (floor(NSAppKitVersionNumber) <= NSAppKitVersionNumber10_14 &&
+      CGDisplayModeGetWidth(mode) == width &&
       CGDisplayModeGetHeight(mode) == height) {
     return mode;
   }
-#endif
 
   current_pixel_encoding = CGDisplayModeCopyPixelEncoding(mode);
   refresh_rate = CGDisplayModeGetRefreshRate(mode);


### PR DESCRIPTION
While testing on a screen with a scale factor of 1.75 instead of the usual factor 2.0 I discovered a difference of behaviour between Panda3D compiled with macOS SDK 10.6 vs macOS SDK 10.9 if the fullscreen resolution used is the resolution of the screen (as seen by the application) and not one of the resolution returned by getDisplayInformation()

On that screen, the screen resolution seen by the application is 1920x1200 (i.e. 3360, 2100 / 1.75), the list of supported resolution is [[3360, 2100], [2880, 1800], [2560, 1600], [2048, 1280], [1650, 1050], [1440, 900], [1280, 800], [1152, 720], [1024, 768], [840, 524], [800, 600], [640, 480]] (getDisplayInformation() returns the screen resolutions with scale factor 1.0)

On Panda3D macOS 10.6, if the current mode resolution is the same as the requested resolution, we don't switch mode. On Panda3D 10.9 this is no longer the case with the current code. The problem is the scale factor or 1.75 means that there is no "official" mode with that resolution and so the switch to fullscreen fails. On a screen with scale factor 2.0 there is always a valid screen mode having the requested resolution.

To keep the behaviour pre-10.15 unchanged, I modified the test to always reuse the existing mode if the resolution is identical and we are not on 10.15 or above...

