### PR TITLE
build_apps: Fix running with Pip 20

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -401,7 +401,7 @@ class build_apps(setuptools.Command):
 
         whldir = os.path.join(self.build_base, '__whl_cache__')
 
-        pip_version = [int(i) for i in pip.__version__.split('.')][0]
+        pip_version = int(pip.__version__.split('.')[0])
         if pip_version < 9:
             raise RuntimeError("pip 9.0 or greater is required, but found {}".format(pip.__version__))
 

--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -405,20 +405,9 @@ class build_apps(setuptools.Command):
         if pip_version < 9:
             raise RuntimeError("pip 9.0 or greater is required, but found {}".format(pip.__version__))
 
-        #TODO find a better way to get abi tag than from internal/private pip APIs
-        if hasattr(pip, 'pep425tags'):
-            pep425tags = pip.pep425tags
-        else:
-            from pip._internal import pep425tags
-
-        if pip_version >= 20:
-            from pip._vendor.packaging.tags import cpython_tags
-            abi_tag = list(cpython_tags())[0].abi
-        else:
-            abi_tag = pep425tags.get_abi_tag()
-
-        if 'u' in abi_tag and (platform.startswith('win') or platform.startswith('macosx')):
-            abi_tag = abi_tag.replace('u', '')
+        abi_tag = 'cp%d%d' % (sys.version_info[:2])
+        if sys.version_info < (3, 8):
+            abi_tag += 'm'
 
         # For these distributions, we need to append 'u' on Linux
         if abi_tag in ('cp26m', 'cp27m', 'cp32m') and not platform.startswith('win') and not platform.startswith('macosx'):


### PR DESCRIPTION
This is a pretty quick and dirty fix. We may want to explore pip-independent ways to get tags so we can clean all this up. It's quite unfortunate that this showed up right after 1.10.6...