### PR TITLE
Fix BulletHeightfieldShape::fillin

### DIFF
--- a/panda/src/bullet/bulletHeightfieldShape.cxx
+++ b/panda/src/bullet/bulletHeightfieldShape.cxx
@@ -200,7 +200,7 @@ fillin(DatagramIterator &scan, BamReader *manager) {
 
   size_t size = (size_t)_num_rows * (size_t)_num_cols;
   delete [] _data;
-  _data = new float[size];
+  _data = new btScalar[size];
 
   for (size_t i = 0; i < size; ++i) {
     _data[i]  = scan.get_stdfloat();


### PR DESCRIPTION
In this https://github.com/panda3d/panda3d/pull/152 ~~PR~~ Issue (commit: https://github.com/panda3d/panda3d/commit/86cbdddd76017f196bd18eca6a89d2da9b33403d) the type of `BulletHeightfieldShape` it's private member `_data` is changed from `float*` to `btScalar*`. But inside `BulletHeightfieldShape` it's `fillin` method there still is a pointer to a new `float` assigned to `_data`.

This fixes that.