### PR TITLE
CMake: Fix Windows library names for case-sensitive filesystems

### DIFF
--- a/panda/src/device/CMakeLists.txt
+++ b/panda/src/device/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries(p3device p3dgraph)
 target_interrogate(p3device ALL)
 
 if(WIN32)
-  target_link_libraries(p3device Cfgmgr32.lib)
+  target_link_libraries(p3device cfgmgr32.lib)
 
 elseif(APPLE)
   find_library(IOKIT_LIBRARY IOKit)

--- a/panda/src/net/CMakeLists.txt
+++ b/panda/src/net/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(p3net p3nativenet p3pipeline p3pandabase pandaexpress)
 target_interrogate(p3net ALL)
 
 if(WIN32)
-  target_link_libraries(p3net Iphlpapi.lib)
+  target_link_libraries(p3net iphlpapi.lib)
 endif()
 
 if(NOT BUILD_METALIBS)

--- a/panda/src/windisplay/CMakeLists.txt
+++ b/panda/src/windisplay/CMakeLists.txt
@@ -18,7 +18,7 @@ set(P3WINDISPLAY_SOURCES
 composite_sources(p3windisplay P3WINDISPLAY_SOURCES)
 add_component_library(p3windisplay SYMBOL BUILDING_PANDAWIN
   ${P3WINDISPLAY_HEADERS} ${P3WINDISPLAY_SOURCES})
-target_link_libraries(p3windisplay panda User32.lib Imm32.lib)
+target_link_libraries(p3windisplay panda user32.lib imm32.lib)
 
 if(HAVE_DX9)
   target_compile_definitions(p3windisplay PRIVATE HAVE_DX9)


### PR DESCRIPTION
This improves cross-compiling from a POSIX-system to Windows via GCC+MinGW64.