### PR TITLE
Fix includes for Windows on case-sensitive filesystems

### DIFF
--- a/dtool/src/dtoolutil/win32ArgParser.cxx
+++ b/dtool/src/dtoolutil/win32ArgParser.cxx
@@ -22,7 +22,7 @@
 #include "executionEnvironment.h"
 
 #include <windows.h>
-#include <Tlhelp32.h>
+#include <tlhelp32.h>
 
 using std::string;
 

--- a/panda/src/device/winInputDeviceManager.h
+++ b/panda/src/device/winInputDeviceManager.h
@@ -20,7 +20,7 @@
 
 #include "xInputDevice.h"
 
-#include <CfgMgr32.h>
+#include <cfgmgr32.h>
 #include <devpkey.h>
 
 class WinRawInputDevice;

--- a/panda/src/device/winRawInputDevice.cxx
+++ b/panda/src/device/winRawInputDevice.cxx
@@ -19,7 +19,7 @@
 
 #if defined(_WIN32) && !defined(CPPPARSER)
 
-#include <CfgMgr32.h>
+#include <cfgmgr32.h>
 #include <devpkey.h>
 #include "phidsdi.h"
 

--- a/panda/src/device/xInputDevice.cxx
+++ b/panda/src/device/xInputDevice.cxx
@@ -19,8 +19,8 @@
 #include "inputDeviceManager.h"
 #include "string_utils.h"
 
-#include <XInput.h>
-#include <CfgMgr32.h>
+#include <xinput.h>
+#include <cfgmgr32.h>
 
 #ifndef XUSER_MAX_COUNT
 #define XUSER_MAX_COUNT 4

--- a/panda/src/device/xInputDevice.h
+++ b/panda/src/device/xInputDevice.h
@@ -19,7 +19,7 @@
 
 #if defined(_WIN32) && !defined(CPPPARSER)
 
-#include <CfgMgr32.h>
+#include <cfgmgr32.h>
 
 class InputDeviceManager;
 

--- a/panda/src/display/graphicsEngine.cxx
+++ b/panda/src/display/graphicsEngine.cxx
@@ -56,7 +56,7 @@
 
 #if defined(_WIN32)
   #define WINDOWS_LEAN_AND_MEAN
-  #include <WinSock2.h>
+  #include <winsock2.h>
   #include <wtypes.h>
   #undef WINDOWS_LEAN_AND_MEAN
 #else

--- a/panda/src/downloader/bioStreamBuf.cxx
+++ b/panda/src/downloader/bioStreamBuf.cxx
@@ -19,7 +19,7 @@
 #ifdef HAVE_OPENSSL
 
 #ifdef _WIN32
-  #include <WinSock2.h>
+  #include <winsock2.h>
   #include <windows.h>  // for WSAGetLastError()
   #undef X509_NAME
 #endif  // _WIN32

--- a/panda/src/downloader/httpChannel.cxx
+++ b/panda/src/downloader/httpChannel.cxx
@@ -30,7 +30,7 @@
 #include "openSSLWrapper.h"
 
 #ifdef _WIN32
-  #include <WinSock2.h>
+  #include <winsock2.h>
   #include <windows.h>  // for select()
   #undef X509_NAME
 #endif  // _WIN32

--- a/panda/src/nativenet/socket_portable.h
+++ b/panda/src/nativenet/socket_portable.h
@@ -53,7 +53,7 @@ typedef unsigned long SOCKET;
 ************************************************************************/
 #elif defined(_WIN32)
 #include <winsock2.h>
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 
 typedef u_short sa_family_t;
 

--- a/panda/src/net/connectionManager.cxx
+++ b/panda/src/net/connectionManager.cxx
@@ -25,7 +25,7 @@
 #if defined(CPPPARSER)
 #elif defined(_WIN32)
 #include <winsock2.h>  // For gethostname()
-#include <Iphlpapi.h> // For GetAdaptersAddresses()
+#include <iphlpapi.h> // For GetAdaptersAddresses()
 #elif defined(__ANDROID__)
 #include <net/if.h>
 #else

--- a/panda/src/pstatclient/pStatClientImpl.cxx
+++ b/panda/src/pstatclient/pStatClientImpl.cxx
@@ -28,7 +28,7 @@
 #include <algorithm>
 
 #ifdef _WIN32
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
This, in conjunction with #865, enables to cross-build in a minimal static configuration from a POSIX-system to Windows via GCC+MinGW64.