### PR TITLE
task: Fix memory leak related to Python 3 signal API changes

### DIFF
--- a/direct/src/task/Task.py
+++ b/direct/src/task/Task.py
@@ -17,9 +17,13 @@ from direct.showbase.MessengerGlobal import messenger
 import types
 import random
 import importlib
+import sys
 
 try:
-    import signal
+    if sys.version_info >= (3, 0):
+        import _signal as signal
+    else:
+        import signal
 except ImportError:
     signal = None
 


### PR DESCRIPTION
Python 3's signal.py API does not properly support custom signal handlers.

An exception is created every frame because of this during taskMgr.run(), which fills up the memory of the application.

The error message is the following:
`<built-in function default_int_handler> is not a valid Handlers`

Full error log at: https://pastebin.com/raw/Zi8S2zfC

`signal` on Python 2 is implemented as a built-in module, whereas on Python 3 the built-in module is called `_signal`. `signal` on Python 3 is simply a wrapper over the `_signal` module, with helper methods to convert `SIGINT`, `SIG_DFL` and other enums to integers to communicate to the `_signal` module.

However, `signal.signal` also returns the `previous` handler associated with the signal, converted from an integer to an enum. If you have a custom handler though, that value is not an integer, but a function. Hence the error.

This commit sidesteps the `signal` API altogether on Python 3 and uses the `_signal` module directly, resolving the memory leak.