### PR TITLE
python3: Fix DirectScrolledList scrollTo regression

### DIFF
--- a/direct/src/gui/DirectScrolledList.py
+++ b/direct/src/gui/DirectScrolledList.py
@@ -210,7 +210,7 @@ class DirectScrolledList(DirectFrame):
         numItemsVisible = self["numItemsVisible"]
         numItemsTotal = len(self["items"])
         if(centered):
-            self.index = index - (numItemsVisible/2)
+            self.index = index - (numItemsVisible // 2)
         else:
             self.index = index
 


### PR DESCRIPTION
As a rule of thumb, Python 3 divisions always have float results. Unfortunately, this piece of code is still relying on the old Python 2.7 behavior.

As such, every time `scrollTo` is called with `centered` set to True, the following error is thrown:

```
File "direct.gui.DirectScrolledList", line 256, in scrollTo
TypeError: 'float' object cannot be interpreted as an integer
```

This commit resolves the problem by forcing floor division, which results in the expected behaviour.