### PR TITLE
SceneGraphAnalyzer: Use smarter units for byte sizes in write()

### DIFF
--- a/panda/src/pgraphnodes/sceneGraphAnalyzer.cxx
+++ b/panda/src/pgraphnodes/sceneGraphAnalyzer.cxx
@@ -32,6 +32,22 @@
 #include "pta_ushort.h"
 #include "geomVertexReader.h"
 
+static std::string smart_mem_string(size_t bytes) {
+  std::ostringstream out;
+  float fbytes = static_cast<float>(bytes);
+  if (bytes > 4294967296) { // 4 GiB
+    out << std::setprecision(3) << fbytes / 1024.0 / 1024.0 / 1024.0 << " GiB";
+  }
+  else if (bytes > 10485760) { // 10 MiB
+    out << std::setprecision(3) << fbytes / 1024.0 / 1024.0 << " MiB";
+  }
+  else {
+    out << std::setprecision(3) << fbytes / 1024.0 << " KiB";
+  }
+
+  return out.str();
+}
+
 /**
  *
  */
@@ -153,12 +169,12 @@ write(std::ostream &out, int indent_level) const {
   }
 
   indent(out, indent_level)
-    << "GeomVertexData arrays occupy " << (_vertex_data_size + 1023) / 1024
-    << "K memory.\n";
+    << "GeomVertexData arrays occupy " << smart_mem_string(_vertex_data_size)
+    << " memory.\n";
 
   indent(out, indent_level)
-    << "GeomPrimitive arrays occupy " << (_prim_data_size + 1023) / 1024
-    << "K memory.\n";
+    << "GeomPrimitive arrays occupy " << smart_mem_string(_prim_data_size)
+    << " memory.\n";
 
   int unreferenced_vertices = 0;
   VDatas::const_iterator vdi;
@@ -257,7 +273,7 @@ write(std::ostream &out, int indent_level) const {
 
   indent(out, indent_level)
     << _textures.size() << " textures, estimated minimum "
-    << (_texture_bytes + 1023) / 1024 << "K texture memory required.\n";
+    << smart_mem_string(_texture_bytes) << " texture memory required.\n";
 }
 
 /**


### PR DESCRIPTION
Values above 10 MiB are displayed in MiB and values above 4 GiB are
displayed in GiB.

The values for the limits are pretty arbitrary, and I am open to suggestions for other values.

Example output:
```
14 total nodes (including 0 instances); 0 LODNodes.
6 transforms; 0% of nodes have some render attribute.
6 Geoms, with 6 GeomVertexDatas and 1 GeomVertexFormats, appear on 6 GeomNodes.
19583 vertices, 19583 normals, 0 colors, 19583 texture coordinates.
GeomVertexData arrays occupy 918 KiB memory.
GeomPrimitive arrays occupy 186 KiB memory.
31713 triangles:
  0 of these are on 0 tristrips.
  31713 of these are independent triangles.
10 textures, estimated minimum 448 MiB texture memory required.
```