### PR TITLE
direct: Fix RuntimeError during ControlManager deletion

### DIFF
--- a/direct/src/controls/ControlManager.py
+++ b/direct/src/controls/ControlManager.py
@@ -144,7 +144,7 @@ class ControlManager:
     def delete(self):
         assert self.notify.debugCall(id(self))
         self.disable()
-        for controls in self.controls.keys():
+        for controls in list(self.controls.keys()):
             self.remove(controls)
         del self.controls
         del self.currentControls


### PR DESCRIPTION
Deleting a ControlManager on Python 3 results in the following error:

```
  File "direct.controls.ControlManager", line 147, in delete
RuntimeError: dictionary changed size during iteration
```