### PR TITLE
pgui: Ignore PGEntry tab keypress

### DIFF
--- a/panda/src/pgui/pgEntry.cxx
+++ b/panda/src/pgui/pgEntry.cxx
@@ -203,6 +203,11 @@ press(const MouseWatcherParameter &param, bool background) {
 
       ButtonHandle button = param.get_button();
 
+      if (button == KeyboardButton::tab()) {
+        // Tab. Ignore the entry.
+        return;
+      }
+
       if (button == MouseButton::one() ||
           button == MouseButton::two() ||
           button == MouseButton::three() ||


### PR DESCRIPTION
Pressing Tab on a DirectEntry or simply a PGEntry currently results in the `\t` character being appended to the end of the string. This is, I presume, unwanted behavior.

This commit forces PGEntry and all descendants to ignore Tab keypresses. As such, press events will not be raised for the Tab key anymore, neither will pressing the Tab key play the type sound. I'm not sure when the Tab key started raising events again, but I don't think it did in the past.

If there is a better way to handle this, please mention ideas by all means. Thank you!