### PR TITLE
corrects bug: wrong case entered in :Output::MultiplexStreamBuf:write…

### DIFF
--- a/panda/src/downloader/multiplexStream.I
+++ b/panda/src/downloader/multiplexStream.I
@@ -37,7 +37,7 @@ add_ostream(std::ostream *out, bool delete_later) {
 INLINE bool MultiplexStream::
 add_stdio_file(FILE *fout, bool close_when_done) {
   _msb.add_output(MultiplexStreamBuf::BT_line,
-                  MultiplexStreamBuf::OT_ostream,
+                  MultiplexStreamBuf::OT_stdio,
                   nullptr, fout, close_when_done);
   return true;
 }


### PR DESCRIPTION
add_stdio_file() of MultiplexStream caused an assert to fail in MultiplexStreamBuf.cxx in write_string(), because it entered the OT_ostream case instead of the OT_stdio case.
