### PR TITLE
[webgl-port] wasm/wasi should use .so suffix whereever possible

### DIFF
--- a/makepanda/makepandacore.py
+++ b/makepanda/makepandacore.py
@@ -3245,8 +3245,8 @@ def SetOrigExt(x, v):
     ORIG_EXT[x] = v
 
 def GetExtensionSuffix():
-    if target == 'emscripten':
-        return '.bc'
+    if GetTarget() == 'emscripten':
+        return '.so'
 
     import _imp
     return _imp.extension_suffixes()[0]


### PR DESCRIPTION
see chrome specific preloading at https://emscripten.org/docs/porting/files/packaging_files.html#preloading-files