### PR TITLE
config: Allow equal signs (=) between variable names and value

### DIFF
--- a/dtool/src/prc/configPage.cxx
+++ b/dtool/src/prc/configPage.cxx
@@ -397,7 +397,7 @@ read_prc_line(const string &line) {
   EVP_VerifyUpdate((EVP_MD_CTX *)_md_ctx, line.data(), line.size());
 #endif  // HAVE_OPENSSL
 
-  // Separate the line into a variable and a value.
+  // Parse leading whitespace
   size_t p = 0;
   while (p < line.length() && isspace((unsigned char)line[p])) {
     p++;
@@ -408,14 +408,22 @@ read_prc_line(const string &line) {
     return;
   }
 
+  // Separate the line into a variable and a value (ASCII 61 is "=")
   size_t variable_begin = p;
-  while (p < line.length() && !isspace((unsigned char)line[p])) {
+  while (p < line.length() && !(isspace((unsigned char)line[p]) || line[p] == 61)) {
     p++;
   }
   size_t variable_end = p;
 
   while (p < line.length() && isspace((unsigned char)line[p])) {
     p++;
+  }
+  if (line[p] == 61) {
+    // if we stopped on an =, consume it and keep grabbing whitespace
+    p++;
+    while (p < line.length() && isspace((unsigned char)line[p])) {
+      p++;
+    }
   }
   size_t value_begin = p;
 

--- a/tests/prc/test_config_page.py
+++ b/tests/prc/test_config_page.py
@@ -10,3 +10,16 @@ def test_load_unload_page():
 
     assert core.unload_prc_file(page)
     assert var.value == 1
+
+def test_ini_syntax():
+    page = core.load_prc_file_data("test_ini_syntax", "test-var=true\ntest-var2 = foo")
+    assert page
+
+    for decl in page.declarations:
+        print(decl.variable)
+
+    var = core.ConfigVariableBool("test-var", False)
+    assert var.value == True
+
+    var = core.ConfigVariableString("test-var2", "")
+    assert var.value == "foo"


### PR DESCRIPTION
This allows for more INI-style syntax as proposed by #523. Sections are
still not supported.