### PR TITLE
dcparser: The dcparser now compiles outside of panda

### DIFF
--- a/direct/src/dcparser/dcClass.cxx
+++ b/direct/src/dcparser/dcClass.cxx
@@ -77,7 +77,9 @@ DCClass(DCFile *dc_file, const string &name, bool is_struct, bool bogus_class) :
   _number = -1;
   _constructor = nullptr;
 
+#ifdef WITHIN_PANDA
   _python_class_defs = nullptr;
+#endif
 }
 
 /**

--- a/direct/src/dcparser/dcClass.h
+++ b/direct/src/dcparser/dcClass.h
@@ -172,15 +172,16 @@ private:
   typedef pmap<int, DCField *> FieldsByIndex;
   FieldsByIndex _fields_by_index;
 
+  friend class DCField;
+
+#ifdef WITHIN_PANDA
   // See pandaNode.h for an explanation of this trick
   class PythonClassDefs : public ReferenceCount {
   public:
     virtual ~PythonClassDefs() {};
   };
   PT(PythonClassDefs) _python_class_defs;
-
-  friend class DCField;
-#ifdef WITHIN_PANDA
+  
   friend class Extension<DCClass>;
 #endif
 };

--- a/direct/src/dcparser/dcLexer.cxx.prebuilt
+++ b/direct/src/dcparser/dcLexer.cxx.prebuilt
@@ -599,7 +599,10 @@ char *dcyytext;
 #include "dcParser.h"
 #include "dcFile.h"
 #include "dcindent.h"
+
+#ifdef WITHIN_PANDA
 #include "pstrtod.h"
+#endif
 
 
 static int yyinput(void);        // declared by flex.

--- a/direct/src/dcparser/dcLexer.lxx
+++ b/direct/src/dcparser/dcLexer.lxx
@@ -11,8 +11,10 @@
 #include "dcParser.h"
 #include "dcFile.h"
 #include "dcindent.h"
-#include "pstrtod.h"
 
+#ifdef WITHIN_PANDA
+#include "pstrtod.h"
+#endif
 
 static int yyinput(void);        // declared by flex.
 extern "C" int dcyywrap();

--- a/direct/src/dcparser/dcbase.h
+++ b/direct/src/dcparser/dcbase.h
@@ -70,6 +70,7 @@
 #define BEGIN_PUBLISH
 #define END_PUBLISH
 #define BLOCKING
+#define EXTENSION(x)
 
 // These control the declspec(dllexport/dllimport) on Windows.  When compiling
 // outside of Panda, we assume we aren't part of a DLL.
@@ -100,6 +101,7 @@ typedef std::string Filename;
 #define pmap std::map
 #define pset std::set
 #define vector_uchar std::vector<unsigned char>
+#define patof(x) atof(x)
 
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
The dcparser now compiles outside of panda as it once did. This has been tested inside/outside of panda.

This fixes https://github.com/panda3d/panda3d/issues/944