### PR TITLE
gobj: Implement PythonTexturePoolFilter

### DIFF
--- a/panda/src/gobj/CMakeLists.txt
+++ b/panda/src/gobj/CMakeLists.txt
@@ -167,6 +167,8 @@ set(P3GOBJ_IGATEEXT
   texture_ext.h
   textureCollection_ext.cxx
   textureCollection_ext.h
+  pythonTexturePoolFilter.cxx
+  pythonTexturePoolFilter.h
 )
 
 composite_sources(p3gobj P3GOBJ_SOURCES)

--- a/panda/src/gobj/CMakeLists.txt
+++ b/panda/src/gobj/CMakeLists.txt
@@ -167,6 +167,8 @@ set(P3GOBJ_IGATEEXT
   texture_ext.h
   textureCollection_ext.cxx
   textureCollection_ext.h
+  texturePool_ext.cxx
+  texturePool_ext.h
   pythonTexturePoolFilter.cxx
   pythonTexturePoolFilter.h
 )

--- a/panda/src/gobj/p3gobj_ext_composite.cxx
+++ b/panda/src/gobj/p3gobj_ext_composite.cxx
@@ -2,4 +2,5 @@
 #include "geomVertexArrayData_ext.cxx"
 #include "texture_ext.cxx"
 #include "textureCollection_ext.cxx"
+#include "texturePool_ext.cxx"
 #include "pythonTexturePoolFilter.cxx"

--- a/panda/src/gobj/p3gobj_ext_composite.cxx
+++ b/panda/src/gobj/p3gobj_ext_composite.cxx
@@ -2,3 +2,4 @@
 #include "geomVertexArrayData_ext.cxx"
 #include "texture_ext.cxx"
 #include "textureCollection_ext.cxx"
+#include "pythonTexturePoolFilter.cxx"

--- a/panda/src/gobj/pythonTexturePoolFilter.cxx
+++ b/panda/src/gobj/pythonTexturePoolFilter.cxx
@@ -107,7 +107,7 @@ pre_load(const Filename &orig_filename, const Filename &orig_alpha_filename,
     DTool_CreatePyInstance((void *)&options, Dtool_LoaderOptions, false, true)
   );
 
-  PT(Texture) tex;
+  PT(Texture) tex = nullptr;
   PyObject *result = PythonThread::call_python_func(_pre_load_func, args);
 
   Py_DECREF(args);
@@ -154,7 +154,7 @@ post_load(Texture *tex) {
   // Wrap the arguments.
   PyObject *args = PyTuple_Pack(1, DTool_CreatePyInstance(tex, Dtool_Texture, true, false));
   PyObject *result = PythonThread::call_python_func(_post_load_func, args);
-  Texture *tex_res;
+  Texture *tex_res = nullptr;
 
   Py_DECREF(args);
 

--- a/panda/src/gobj/pythonTexturePoolFilter.cxx
+++ b/panda/src/gobj/pythonTexturePoolFilter.cxx
@@ -116,14 +116,17 @@ pre_load(const Filename &orig_filename, const Filename &orig_alpha_filename,
 
   Py_DECREF(args);
 
-  if (result != nullptr) {
+  if (result == Py_None) {
+    // We've got None as our result, so we shouldn't return any Texture
+    Py_DECREF(result);
+  } else if (result != nullptr) {
     if (DtoolInstance_Check(result)) {
       tex = (Texture *)DtoolInstance_UPCAST(result, Dtool_Texture);
     }
 
     if (tex == nullptr) {
       gobj_cat.error()
-        << "Preloading " << orig_filename.get_basename() << " failed as"
+        << "Preloading " << orig_filename.get_basename() << " failed as "
         << "preloaded texture is not of Texture type.\n";
     }
 
@@ -170,7 +173,10 @@ post_load(Texture *tex) {
 
   Py_DECREF(args);
 
-  if (result != nullptr) {
+  if (result == Py_None) {
+    // We've got None as our result, so we shouldn't return any Texture
+    Py_DECREF(result);
+  } else if (result != nullptr) {
     PT(Texture) result_tex;
 
     // Check if the call returned a texture pointer.

--- a/panda/src/gobj/pythonTexturePoolFilter.cxx
+++ b/panda/src/gobj/pythonTexturePoolFilter.cxx
@@ -72,7 +72,7 @@ init(PyObject *tex_filter) {
   if (_pre_load_func == nullptr && _post_load_func == nullptr) {
     PyErr_Format(PyExc_TypeError,
                  "texture pool filter plug-in %R does not define pre_load or post_load function",
-				 tex_filter);
+                 tex_filter);
     return false;
   }
 

--- a/panda/src/gobj/pythonTexturePoolFilter.cxx
+++ b/panda/src/gobj/pythonTexturePoolFilter.cxx
@@ -1,0 +1,201 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file pythonTexturePoolFilter.cxx
+ * @author Derzsi Daniel
+ * @date 2020-06-14
+ */
+
+#include "pythonTexturePoolFilter.h"
+
+#ifdef HAVE_PYTHON
+
+#include "pythonThread.h"
+#include "py_panda.h"
+
+extern struct Dtool_PyTypedObject Dtool_Filename;
+extern struct Dtool_PyTypedObject Dtool_LoaderOptions;
+extern struct Dtool_PyTypedObject Dtool_Texture;
+extern struct Dtool_PyTypedObject Dtool_PythonTexturePoolFilter;
+
+TypeHandle PythonTexturePoolFilter::_type_handle;
+
+/**
+ * Constructor.
+ */
+PythonTexturePoolFilter::
+PythonTexturePoolFilter() {
+  init_type();
+}
+
+/**
+ * Destructor.
+ */
+PythonTexturePoolFilter::
+~PythonTexturePoolFilter() {
+  if (_pre_load_func != nullptr || _post_load_func != nullptr) {
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+#endif
+
+    Py_CLEAR(_pre_load_func);
+    Py_CLEAR(_post_load_func);
+
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+    PyGILState_Release(gstate);
+#endif
+  }
+}
+
+/**
+ * Initializes the fields from the given Python texture pool object,
+ * then registers the filter at a texture pool.
+ */
+bool PythonTexturePoolFilter::
+register_filter(PyObject *tex_filter, TexturePool *tex_pool) {
+  nassertr(tex_filter != nullptr, false);
+  nassertr(_pre_load_func == nullptr, false);
+  nassertr(_post_load_func == nullptr, false);
+
+  _pre_load_func = PyObject_GetAttrString(tex_filter, "pre_load");
+  _post_load_func = PyObject_GetAttrString(tex_filter, "post_load");
+  PyErr_Clear();
+
+  if (_pre_load_func == nullptr && _post_load_func == nullptr) {
+    PyErr_Format(PyExc_TypeError,
+                 "texture pool filter plug-in %R does not define pre_load or post_load function",
+                 tex_filter);
+    return false;
+  }
+
+  if (tex_pool != nullptr) {
+    tex_pool->register_filter(this);
+  }
+
+  return true;
+}
+
+/**
+ * Initializes the fields from the given Python texture pool object,
+ * then registers the filter at the global texture pool.
+ */
+bool PythonTexturePoolFilter::
+register_filter(PyObject *tex_filter) {
+  return register_filter(tex_filter, TexturePool::get_global_ptr());
+}
+
+/**
+ * This method is called before each texture is loaded from disk, via the
+ * TexturePool, for the first time. We delegate this functionality to
+ * our Python module, loaded through the init function.
+ */
+PT(Texture) PythonTexturePoolFilter::
+pre_load(const Filename &orig_filename, const Filename &orig_alpha_filename,
+          int primary_file_num_channels, int alpha_file_channel,
+          bool read_mipmaps, const LoaderOptions &options) {
+  if (_pre_load_func == nullptr) {
+    return nullptr;
+  }
+
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+#endif
+
+  // Wrap the arguments.
+  PyObject *args = PyTuple_Pack(6,
+    DTool_CreatePyInstance((void *)&orig_filename, Dtool_Filename, false, true),
+    DTool_CreatePyInstance((void *)&orig_alpha_filename, Dtool_Filename, false, true),
+    Dtool_WrapValue(primary_file_num_channels),
+    Dtool_WrapValue(alpha_file_channel),
+    Dtool_WrapValue(read_mipmaps),
+    DTool_CreatePyInstance((void *)&options, Dtool_LoaderOptions, false, true)
+  );
+
+  PT(Texture) tex;
+  PyObject *result = PythonThread::call_python_func(_pre_load_func, args);
+
+  Py_DECREF(args);
+
+  if (result != nullptr) {
+    if (DtoolInstance_Check(result)) {
+      tex = (Texture *)DtoolInstance_UPCAST(result, Dtool_Texture);
+    }
+    Py_DECREF(result);
+  }
+
+  PyObject *exc_type = _PyErr_OCCURRED();
+
+  if (exc_type) {
+    gobj_cat.error()
+      << "Preloading " << orig_filename.get_basename() << " failed with "
+      << ((PyTypeObject *)exc_type)->tp_name << " exception.\n";
+    PyErr_Clear();
+  }
+
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+  PyGILState_Release(gstate);
+#endif
+
+  return tex;
+}
+
+/**
+ * This method is called after each texture has been loaded from disk, via the
+ * TexturePool, for the first time. We delegate this functionality to
+ * our Python module, loaded through the init function.
+ */
+PT(Texture) PythonTexturePoolFilter::
+post_load(Texture *tex) {
+  if (_post_load_func == nullptr) {
+    return tex;
+  }
+
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+#endif
+
+  // Wrap the arguments.
+  PyObject *args = PyTuple_Pack(1, DTool_CreatePyInstance(tex, Dtool_Texture, true, false));
+  PyObject *result = PythonThread::call_python_func(_post_load_func, args);
+  Texture *tex_res;
+
+  Py_DECREF(args);
+
+  if (result != nullptr) {
+    if (DtoolInstance_Check(result)) {
+      tex_res = (Texture *)DtoolInstance_UPCAST(result, Dtool_Texture);
+    }
+    Py_DECREF(result);
+  }
+
+  PyObject *exc_type = _PyErr_OCCURRED();
+
+  if (exc_type) {
+    gobj_cat.error()
+      << "Postloading failed with " << ((PyTypeObject *)exc_type)->tp_name
+      << " exception.\n";
+    PyErr_Clear();
+  }
+
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+  PyGILState_Release(gstate);
+#endif
+
+  if (tex_res != nullptr) {
+    return tex_res;
+  } else {
+    // The Python function did not return anything.
+    // We'll return our original texture instead!
+    return tex;
+  }
+}
+
+#endif  // HAVE_PYTHON

--- a/panda/src/gobj/pythonTexturePoolFilter.cxx
+++ b/panda/src/gobj/pythonTexturePoolFilter.cxx
@@ -154,13 +154,12 @@ post_load(Texture *tex) {
   // Wrap the arguments.
   PyObject *args = PyTuple_Pack(1, DTool_CreatePyInstance(tex, Dtool_Texture, true, false));
   PyObject *result = PythonThread::call_python_func(_post_load_func, args);
-  Texture *tex_res = nullptr;
 
   Py_DECREF(args);
 
   if (result != nullptr) {
     if (DtoolInstance_Check(result)) {
-      tex_res = (Texture *)DtoolInstance_UPCAST(result, Dtool_Texture);
+      tex = (Texture *)DtoolInstance_UPCAST(result, Dtool_Texture);
     }
     Py_DECREF(result);
   }
@@ -178,13 +177,7 @@ post_load(Texture *tex) {
   PyGILState_Release(gstate);
 #endif
 
-  if (tex_res != nullptr) {
-    return tex_res;
-  } else {
-    // The Python function did not return anything.
-    // We'll return our original texture instead!
-    return tex;
-  }
+  return tex;
 }
 
 #endif  // HAVE_PYTHON

--- a/panda/src/gobj/pythonTexturePoolFilter.h
+++ b/panda/src/gobj/pythonTexturePoolFilter.h
@@ -27,21 +27,18 @@
  * This defines a Python-based texture pool filter plug-in. Instances of
  * this must be constructed by inheritance and explicitly registered.
  *
- * Registration can be performed using register_filter.
  * The Python texture pool filter must implement either the pre_load
  * or the post_load function of a typical texture pool filter.
  *
  * @since 1.11.0
  */
 class PythonTexturePoolFilter : public TexturePoolFilter {
-PUBLISHED:
+public:
   PythonTexturePoolFilter();
   ~PythonTexturePoolFilter();
 
-  bool register_filter(PyObject *tex_filter, TexturePool *tex_pool);
-  bool register_filter(PyObject *tex_filter);
+  bool init(PyObject *tex_filter);
 
-public:
   virtual PT(Texture) pre_load(const Filename &orig_filename,
                                const Filename &orig_alpha_filename,
                                int primary_file_num_channels,
@@ -53,6 +50,9 @@ public:
 private:
   PyObject *_pre_load_func = nullptr;
   PyObject *_post_load_func = nullptr;
+  long _filter_hash = -1;
+
+  friend class Extension<TexturePool>;
 
 public:
   static TypeHandle get_class_type() {

--- a/panda/src/gobj/pythonTexturePoolFilter.h
+++ b/panda/src/gobj/pythonTexturePoolFilter.h
@@ -50,7 +50,7 @@ public:
 private:
   PyObject *_pre_load_func = nullptr;
   PyObject *_post_load_func = nullptr;
-  long _filter_hash = -1;
+  PyObject *_entry_point = nullptr;
 
   friend class Extension<TexturePool>;
 

--- a/panda/src/gobj/pythonTexturePoolFilter.h
+++ b/panda/src/gobj/pythonTexturePoolFilter.h
@@ -1,0 +1,80 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file pythonTexturePoolFilter.h
+ * @author Derzsi Daniel
+ * @date 2020-06-14
+ */
+
+#ifndef PYTHONTEXTUREPOOLFILTER_H
+#define PYTHONTEXTUREPOOLFILTER_H
+
+#include "filename.h"
+#include "loaderOptions.h"
+#include "texture.h"
+#include "texturePool.h"
+#include "texturePoolFilter.h"
+#include "pandabase.h"
+
+#ifdef HAVE_PYTHON
+
+/**
+ * This defines a Python-based texture pool filter plug-in. Instances of
+ * this must be constructed by inheritance and explicitly registered.
+ *
+ * Registration can be performed using register_filter.
+ * The Python texture pool filter must implement either the pre_load
+ * or the post_load function of a typical texture pool filter.
+ *
+ * @since 1.11.0
+ */
+class PythonTexturePoolFilter : public TexturePoolFilter {
+PUBLISHED:
+  PythonTexturePoolFilter();
+  ~PythonTexturePoolFilter();
+
+  bool register_filter(PyObject *tex_filter, TexturePool *tex_pool);
+  bool register_filter(PyObject *tex_filter);
+
+public:
+  virtual PT(Texture) pre_load(const Filename &orig_filename,
+                               const Filename &orig_alpha_filename,
+                               int primary_file_num_channels,
+                               int alpha_file_channel,
+                               bool read_mipmaps,
+                               const LoaderOptions &options) override;
+  virtual PT(Texture) post_load(Texture *tex) override;
+
+private:
+  PyObject *_pre_load_func = nullptr;
+  PyObject *_post_load_func = nullptr;
+
+public:
+  static TypeHandle get_class_type() {
+    return _type_handle;
+  }
+  static void init_type() {
+    TexturePoolFilter::init_type();
+    register_type(_type_handle, "PythonTexturePoolFilter",
+                  TexturePoolFilter::get_class_type());
+  }
+  virtual TypeHandle get_type() const override {
+    return get_class_type();
+  }
+  virtual TypeHandle force_init_type() override {
+    init_type();
+    return get_class_type();
+  }
+
+private:
+  static TypeHandle _type_handle;
+};
+
+#endif  // HAVE_PYTHON
+
+#endif

--- a/panda/src/gobj/texturePool.I
+++ b/panda/src/gobj/texturePool.I
@@ -311,22 +311,6 @@ unregister_filter(TexturePoolFilter *tex_filter) {
 }
 
 /**
- * Returns the total number of registered texture pool filters.
- */
-INLINE size_t TexturePool::
-get_num_filters() {
-  return get_global_ptr()->ns_get_num_filters();
-}
-
-/**
- * Returns the nth texture pool filter registered.
- */
-INLINE TexturePoolFilter *TexturePool::
-get_filter(size_t i) {
-  return get_global_ptr()->ns_get_filter(i);
-}
-
-/**
  * Defines relative ordering between LookupKey instances.
  */
 INLINE bool TexturePool::LookupKey::

--- a/panda/src/gobj/texturePool.I
+++ b/panda/src/gobj/texturePool.I
@@ -277,6 +277,56 @@ make_texture(const std::string &extension) {
 }
 
 /**
+ * Records a TexturePoolFilter object that may operate on texture images as
+ * they are loaded from disk.
+ */
+INLINE bool TexturePool::
+register_filter(TexturePoolFilter *tex_filter) {
+  return get_global_ptr()->ns_register_filter(tex_filter);
+}
+
+/**
+ * Stops all TexturePoolFilter objects from operating on this pool.
+ */
+INLINE void TexturePool::
+clear_filters() {
+  get_global_ptr()->ns_clear_filters();
+}
+
+/**
+ * Checks whether the given TexturePoolFilter object is
+ * currently registered in the texture pool or not.
+ */
+INLINE bool TexturePool::
+is_filter_registered(TexturePoolFilter *tex_filter) {
+  return get_global_ptr()->ns_is_filter_registered(tex_filter);
+}
+
+/**
+ * Stops a TexturePoolFilter object from operating on this pool.
+ */
+INLINE bool TexturePool::
+unregister_filter(TexturePoolFilter *tex_filter) {
+  return get_global_ptr()->ns_unregister_filter(tex_filter);
+}
+
+/**
+ * Returns the total number of registered texture pool filters.
+ */
+INLINE size_t TexturePool::
+get_num_filters() {
+  return get_global_ptr()->ns_get_num_filters();
+}
+
+/**
+ * Returns the nth texture pool filter registered.
+ */
+INLINE TexturePoolFilter *TexturePool::
+get_filter(size_t i) {
+  return get_global_ptr()->ns_get_filter(i);
+}
+
+/**
  * Defines relative ordering between LookupKey instances.
  */
 INLINE bool TexturePool::LookupKey::

--- a/panda/src/gobj/texturePool.cxx
+++ b/panda/src/gobj/texturePool.cxx
@@ -73,7 +73,7 @@ ns_register_filter(TexturePoolFilter *tex_filter) {
   MutexHolder holder(_filter_lock);
 
   // Make sure we haven't already registered this filter.
-  if (find(_filter_registry.begin(), _filter_registry.end(), tex_filter) != _filter_registry.end()) {
+  if (std::find(_filter_registry.begin(), _filter_registry.end(), tex_filter) != _filter_registry.end()) {
     gobj_cat->warning()
       << "Attempted to register texture filter " << *tex_filter
       << " more than once.\n";
@@ -104,7 +104,7 @@ bool TexturePool::
 ns_is_filter_registered(TexturePoolFilter *tex_filter) {
   MutexHolder holder(_filter_lock);
 
-  return find(_filter_registry.begin(), _filter_registry.end(), tex_filter) != _filter_registry.end();
+  return std::find(_filter_registry.begin(), _filter_registry.end(), tex_filter) != _filter_registry.end();
 }
 
 /**
@@ -114,7 +114,7 @@ bool TexturePool::
 ns_unregister_filter(TexturePoolFilter *tex_filter) {
   MutexHolder holder(_filter_lock);
 
-  FilterRegistry::iterator fi = find(_filter_registry.begin(), _filter_registry.end(), tex_filter);
+  FilterRegistry::iterator fi = std::find(_filter_registry.begin(), _filter_registry.end(), tex_filter);
 
   if (fi == _filter_registry.end()) {
     gobj_cat.warning()
@@ -133,7 +133,7 @@ ns_unregister_filter(TexturePoolFilter *tex_filter) {
  * Returns the total number of registered texture pool filters.
  */
 size_t TexturePool::
-ns_get_num_filters() const {
+get_num_filters() const {
   return _filter_registry.size();
 }
 
@@ -141,7 +141,7 @@ ns_get_num_filters() const {
  * Returns the nth texture pool filter registered.
  */
 TexturePoolFilter *TexturePool::
-ns_get_filter(size_t i) const {
+get_filter(size_t i) const {
   MutexHolder holder(_filter_lock);
 
   if (i >= 0 && i < _filter_registry.size()) {
@@ -299,7 +299,7 @@ ns_load_texture(const Filename &orig_filename, int primary_file_num_channels,
   PT(Texture) tex;
   PT(BamCacheRecord) record;
   bool store_record = false;
-  bool use_filters = (options.get_flags() & LoaderOptions::LF_no_filters) == 0;
+  bool use_filters = (options.get_texture_flags() & LoaderOptions::TF_no_filters) == 0;
 
   // Can one of our texture filters supply the texture?
   if (use_filters) {
@@ -467,7 +467,7 @@ ns_load_texture(const Filename &orig_filename,
   PT(Texture) tex;
   PT(BamCacheRecord) record;
   bool store_record = false;
-  bool use_filters = (options.get_flags() & LoaderOptions::LF_no_filters) == 0;
+  bool use_filters = (options.get_texture_flags() & LoaderOptions::TF_no_filters) == 0;
 
   // Can one of our texture filters supply the texture?
   if (use_filters) {

--- a/panda/src/gobj/texturePool.cxx
+++ b/panda/src/gobj/texturePool.cxx
@@ -68,7 +68,7 @@ register_texture_type(MakeTextureFunc *func, const string &extensions) {
  */
 void TexturePool::
 register_filter(TexturePoolFilter *filter) {
-  MutexHolder holder(_lock);
+  MutexHolder holder(_filter_lock);
 
   gobj_cat.info()
     << "Registering Texture filter " << *filter << "\n";
@@ -223,10 +223,13 @@ ns_load_texture(const Filename &orig_filename, int primary_file_num_channels,
   PT(Texture) tex;
   PT(BamCacheRecord) record;
   bool store_record = false;
+  bool use_filters = (options.get_flags() & LoaderOptions::LF_no_filters) == 0;
 
   // Can one of our texture filters supply the texture?
-  tex = pre_load(orig_filename, Filename(), primary_file_num_channels, 0,
-                 read_mipmaps, options);
+  if (use_filters) {
+    tex = pre_load(orig_filename, Filename(), primary_file_num_channels, 0,
+                   read_mipmaps, options);
+  }
 
   BamCache *cache = BamCache::get_global_ptr();
   bool compressed_cache_record = false;
@@ -346,7 +349,9 @@ ns_load_texture(const Filename &orig_filename, int primary_file_num_channels,
   nassertr(!tex->get_fullpath().empty(), tex);
 
   // Finally, apply any post-loading texture filters.
-  tex = post_load(tex);
+  if (use_filters) {
+    tex = post_load(tex);
+  }
 
   return tex;
 }
@@ -386,10 +391,13 @@ ns_load_texture(const Filename &orig_filename,
   PT(Texture) tex;
   PT(BamCacheRecord) record;
   bool store_record = false;
+  bool use_filters = (options.get_flags() & LoaderOptions::LF_no_filters) == 0;
 
   // Can one of our texture filters supply the texture?
-  tex = pre_load(orig_filename, orig_alpha_filename, primary_file_num_channels,
-                 alpha_file_channel, read_mipmaps, options);
+  if (use_filters) {
+    tex = pre_load(orig_filename, orig_alpha_filename, primary_file_num_channels,
+                   alpha_file_channel, read_mipmaps, options);
+  }
 
   BamCache *cache = BamCache::get_global_ptr();
   bool compressed_cache_record = false;
@@ -476,7 +484,9 @@ ns_load_texture(const Filename &orig_filename,
   nassertr(!tex->get_fullpath().empty(), tex);
 
   // Finally, apply any post-loading texture filters.
-  tex = post_load(tex);
+  if (use_filters) {
+    tex = post_load(tex);
+  }
 
   return tex;
 }
@@ -1212,8 +1222,7 @@ pre_load(const Filename &orig_filename, const Filename &orig_alpha_filename,
          int primary_file_num_channels, int alpha_file_channel,
          bool read_mipmaps, const LoaderOptions &options) {
   PT(Texture) tex;
-
-  MutexHolder holder(_lock);
+  MutexHolder holder(_filter_lock);
 
   FilterRegistry::iterator fi;
   for (fi = _filter_registry.begin();
@@ -1237,7 +1246,7 @@ PT(Texture) TexturePool::
 post_load(Texture *tex) {
   PT(Texture) result = tex;
 
-  MutexHolder holder(_lock);
+  MutexHolder holder(_filter_lock);
 
   FilterRegistry::iterator fi;
   for (fi = _filter_registry.begin();

--- a/panda/src/gobj/texturePool.cxx
+++ b/panda/src/gobj/texturePool.cxx
@@ -69,7 +69,7 @@ register_texture_type(MakeTextureFunc *func, const string &extensions) {
  * they are loaded from disk.
  */
 bool TexturePool::
-register_filter(TexturePoolFilter *tex_filter) {
+ns_register_filter(TexturePoolFilter *tex_filter) {
   MutexHolder holder(_filter_lock);
 
   // Make sure we haven't already registered this filter.
@@ -87,31 +87,31 @@ register_filter(TexturePoolFilter *tex_filter) {
 }
 
 /**
- * Checks whether the given TexturePoolFilter object is
- * currently registered in the texture pool or not.
- */
-bool TexturePool::
-is_filter_registered(TexturePoolFilter *tex_filter) {
-  MutexHolder holder(_filter_lock);
-
-  return find(_filter_registry.begin(), _filter_registry.end(), tex_filter) != _filter_registry.end();
-}
-
-/**
  * Stops all TexturePoolFilter objects from operating on this pool.
  */
 void TexturePool::
-clear_filters() {
+ns_clear_filters() {
   MutexHolder holder(_filter_lock);
 
   _filter_registry.clear();
 }
 
 /**
+ * Checks whether the given TexturePoolFilter object is
+ * currently registered in the texture pool or not.
+ */
+bool TexturePool::
+ns_is_filter_registered(TexturePoolFilter *tex_filter) {
+  MutexHolder holder(_filter_lock);
+
+  return find(_filter_registry.begin(), _filter_registry.end(), tex_filter) != _filter_registry.end();
+}
+
+/**
  * Stops a TexturePoolFilter object from operating on this pool.
  */
 bool TexturePool::
-unregister_filter(TexturePoolFilter *tex_filter) {
+ns_unregister_filter(TexturePoolFilter *tex_filter) {
   MutexHolder holder(_filter_lock);
 
   FilterRegistry::iterator fi = find(_filter_registry.begin(), _filter_registry.end(), tex_filter);
@@ -133,7 +133,7 @@ unregister_filter(TexturePoolFilter *tex_filter) {
  * Returns the total number of registered texture pool filters.
  */
 size_t TexturePool::
-get_num_filters() const {
+ns_get_num_filters() const {
   return _filter_registry.size();
 }
 
@@ -141,10 +141,10 @@ get_num_filters() const {
  * Returns the nth texture pool filter registered.
  */
 TexturePoolFilter *TexturePool::
-get_filter(size_t i) const {
+ns_get_filter(size_t i) const {
   MutexHolder holder(_filter_lock);
 
-  nassertr(i >= 0 && i < _filter_registry.size(), nullptr);
+  nassertr_always(i >= 0 && i < _filter_registry.size(), nullptr);
   return _filter_registry[i];
 }
 

--- a/panda/src/gobj/texturePool.cxx
+++ b/panda/src/gobj/texturePool.cxx
@@ -87,6 +87,17 @@ register_filter(TexturePoolFilter *tex_filter) {
 }
 
 /**
+ * Checks whether the given TexturePoolFilter object is
+ * currently registered in the texture pool or not.
+ */
+bool TexturePool::
+is_filter_registered(TexturePoolFilter *tex_filter) {
+  MutexHolder holder(_filter_lock);
+
+  return find(_filter_registry.begin(), _filter_registry.end(), tex_filter) != _filter_registry.end();
+}
+
+/**
  * Stops a TexturePoolFilter object from operating on this pool.
  */
 bool TexturePool::

--- a/panda/src/gobj/texturePool.cxx
+++ b/panda/src/gobj/texturePool.cxx
@@ -98,6 +98,16 @@ is_filter_registered(TexturePoolFilter *tex_filter) {
 }
 
 /**
+ * Stops all TexturePoolFilter objects from operating on this pool.
+ */
+void TexturePool::
+clear_filters() {
+  MutexHolder holder(_filter_lock);
+
+  _filter_registry.clear();
+}
+
+/**
  * Stops a TexturePoolFilter object from operating on this pool.
  */
 bool TexturePool::

--- a/panda/src/gobj/texturePool.cxx
+++ b/panda/src/gobj/texturePool.cxx
@@ -144,8 +144,11 @@ TexturePoolFilter *TexturePool::
 ns_get_filter(size_t i) const {
   MutexHolder holder(_filter_lock);
 
-  nassertr_always(i >= 0 && i < _filter_registry.size(), nullptr);
-  return _filter_registry[i];
+  if (i >= 0 && i < _filter_registry.size()) {
+    return _filter_registry[i];
+  }
+
+  return nullptr;
 }
 
 /**

--- a/panda/src/gobj/texturePool.h
+++ b/panda/src/gobj/texturePool.h
@@ -149,6 +149,8 @@ private:
   static TexturePool *_global_ptr;
 
   Mutex _lock;
+  Mutex _filter_lock;
+
   struct LookupKey {
     Filename _fullpath;
     Filename _alpha_fullpath;

--- a/panda/src/gobj/texturePool.h
+++ b/panda/src/gobj/texturePool.h
@@ -80,19 +80,18 @@ PUBLISHED:
   INLINE static const Filename &get_fake_texture_image();
   INLINE static PT(Texture) make_texture(const std::string &extension);
 
+  INLINE static bool register_filter(TexturePoolFilter *tex_filter);
+  INLINE static bool unregister_filter(TexturePoolFilter *tex_filter);
+  INLINE static void clear_filters();
+
+  INLINE static bool is_filter_registered(TexturePoolFilter *tex_filter);
+
+  INLINE static size_t get_num_filters();
+  INLINE static TexturePoolFilter *get_filter(size_t i);
+
   EXTENSION(bool register_filter(PyObject *tex_filter));
   EXTENSION(bool unregister_filter(PyObject *tex_filter));
   EXTENSION(bool is_filter_registered(PyObject *tex_filter));
-
-  bool register_filter(TexturePoolFilter *tex_filter);
-  bool unregister_filter(TexturePoolFilter *tex_filter);
-  void clear_filters();
-
-  bool is_filter_registered(TexturePoolFilter *tex_filter);
-
-  size_t get_num_filters() const;
-  TexturePoolFilter *get_filter(size_t i) const;
-  MAKE_SEQ(get_filters, get_num_filters, get_filter);
 
   static TexturePool *get_global_ptr();
 
@@ -157,6 +156,15 @@ private:
                        bool read_mipmaps, const LoaderOptions &options);
   PT(Texture) post_load(Texture *tex);
 
+  bool ns_register_filter(TexturePoolFilter *tex_filter);
+  bool ns_unregister_filter(TexturePoolFilter *tex_filter);
+  void ns_clear_filters();
+
+  bool ns_is_filter_registered(TexturePoolFilter *tex_filter);
+
+  size_t ns_get_num_filters() const;
+  TexturePoolFilter *ns_get_filter(size_t i) const;
+
   void load_filters();
 
   static TexturePool *_global_ptr;
@@ -188,6 +196,8 @@ private:
 
   typedef pvector<TexturePoolFilter *> FilterRegistry;
   FilterRegistry _filter_registry;
+
+  friend class Extension<TexturePool>;
 };
 
 #include "texturePool.I"

--- a/panda/src/gobj/texturePool.h
+++ b/panda/src/gobj/texturePool.h
@@ -82,6 +82,7 @@ PUBLISHED:
 
   EXTENSION(bool register_filter(PyObject *tex_filter));
   EXTENSION(bool unregister_filter(PyObject *tex_filter));
+  EXTENSION(bool is_filter_registered(PyObject *tex_filter));
 
   bool register_filter(TexturePoolFilter *tex_filter);
   bool unregister_filter(TexturePoolFilter *tex_filter);

--- a/panda/src/gobj/texturePool.h
+++ b/panda/src/gobj/texturePool.h
@@ -80,17 +80,26 @@ PUBLISHED:
   INLINE static const Filename &get_fake_texture_image();
   INLINE static PT(Texture) make_texture(const std::string &extension);
 
+  EXTENSION(bool register_filter(PyObject *tex_filter));
+  EXTENSION(bool unregister_filter(PyObject *tex_filter));
+
+  bool register_filter(TexturePoolFilter *tex_filter);
+  bool unregister_filter(TexturePoolFilter *tex_filter);
+
+  size_t get_num_filters() const;
+  TexturePoolFilter *get_filter(size_t i) const;
+  MAKE_SEQ(get_filters, get_num_filters, get_filter);
+
+  static TexturePool *get_global_ptr();
+
   static void write(std::ostream &out);
 
 public:
   typedef Texture::MakeTextureFunc MakeTextureFunc;
   void register_texture_type(MakeTextureFunc *func, const std::string &extensions);
-  void register_filter(TexturePoolFilter *filter);
 
   MakeTextureFunc *get_texture_type(const std::string &extension) const;
   void write_texture_types(std::ostream &out, int indent_level) const;
-
-  static TexturePool *get_global_ptr();
 
 private:
   TexturePool();

--- a/panda/src/gobj/texturePool.h
+++ b/panda/src/gobj/texturePool.h
@@ -86,6 +86,8 @@ PUBLISHED:
 
   bool register_filter(TexturePoolFilter *tex_filter);
   bool unregister_filter(TexturePoolFilter *tex_filter);
+  void clear_filters();
+
   bool is_filter_registered(TexturePoolFilter *tex_filter);
 
   size_t get_num_filters() const;

--- a/panda/src/gobj/texturePool.h
+++ b/panda/src/gobj/texturePool.h
@@ -85,6 +85,7 @@ PUBLISHED:
 
   bool register_filter(TexturePoolFilter *tex_filter);
   bool unregister_filter(TexturePoolFilter *tex_filter);
+  bool is_filter_registered(TexturePoolFilter *tex_filter);
 
   size_t get_num_filters() const;
   TexturePoolFilter *get_filter(size_t i) const;

--- a/panda/src/gobj/texturePool.h
+++ b/panda/src/gobj/texturePool.h
@@ -86,8 +86,9 @@ PUBLISHED:
 
   INLINE static bool is_filter_registered(TexturePoolFilter *tex_filter);
 
-  INLINE static size_t get_num_filters();
-  INLINE static TexturePoolFilter *get_filter(size_t i);
+  size_t get_num_filters() const;
+  TexturePoolFilter *get_filter(size_t i) const;
+  MAKE_SEQ_PROPERTY(filters, get_num_filters, get_filter);
 
   EXTENSION(bool register_filter(PyObject *tex_filter));
   EXTENSION(bool unregister_filter(PyObject *tex_filter));
@@ -161,9 +162,6 @@ private:
   void ns_clear_filters();
 
   bool ns_is_filter_registered(TexturePoolFilter *tex_filter);
-
-  size_t ns_get_num_filters() const;
-  TexturePoolFilter *ns_get_filter(size_t i) const;
 
   void load_filters();
 

--- a/panda/src/gobj/texturePoolFilter.cxx
+++ b/panda/src/gobj/texturePoolFilter.cxx
@@ -16,13 +16,6 @@
 TypeHandle TexturePoolFilter::_type_handle;
 
 /**
- *
- */
-TexturePoolFilter::
-~TexturePoolFilter() {
-}
-
-/**
  * This method is called before each texture is loaded from disk, via the
  * TexturePool, for the first time.  If this method returns NULL, then a new
  * Texture will be allocated and loaded from disk normally by the TexturePool;

--- a/panda/src/gobj/texturePoolFilter.h
+++ b/panda/src/gobj/texturePoolFilter.h
@@ -41,7 +41,7 @@ class LoaderOptions;
  */
 class EXPCL_PANDA_GOBJ TexturePoolFilter : public TypedObject {
 public:
-  virtual ~TexturePoolFilter();
+  virtual ~TexturePoolFilter() = default;
 
   virtual PT(Texture) pre_load(const Filename &orig_filename,
                                const Filename &orig_alpha_filename,

--- a/panda/src/gobj/texturePoolFilter.h
+++ b/panda/src/gobj/texturePoolFilter.h
@@ -40,9 +40,11 @@ class LoaderOptions;
  * problem should call tex->set_keep_ram_image(true).
  */
 class EXPCL_PANDA_GOBJ TexturePoolFilter : public TypedObject {
-public:
+PUBLISHED:
+  TexturePoolFilter() = default;
   virtual ~TexturePoolFilter() = default;
 
+public:
   virtual PT(Texture) pre_load(const Filename &orig_filename,
                                const Filename &orig_alpha_filename,
                                int primary_file_num_channels,

--- a/panda/src/gobj/texturePool_ext.cxx
+++ b/panda/src/gobj/texturePool_ext.cxx
@@ -49,10 +49,9 @@ bool Extension<TexturePool>::
 unregister_filter(PyObject *tex_filter) {
   // Keep looping until we've removed all instances of it.
   bool unregistered = false;
-  TexturePoolFilter *filter;
 
   while (true) {
-    filter = find_existing_filter(tex_filter);
+    TexturePoolFilter *filter = find_existing_filter(tex_filter);
 
     if (filter == nullptr) {
       // Last filter has been removed.

--- a/panda/src/gobj/texturePool_ext.cxx
+++ b/panda/src/gobj/texturePool_ext.cxx
@@ -89,7 +89,6 @@ is_filter_registered(PyObject *tex_filter) {
 TexturePoolFilter *Extension<TexturePool>::
 find_existing_filter(PyObject *tex_filter) {
   size_t num_filters = _this->get_num_filters();
-  long filter_hash = PyObject_Hash(tex_filter);
 
   for (size_t i = 0; i < num_filters; ++i) {
     TexturePoolFilter *filter = _this->get_filter(i);
@@ -97,7 +96,7 @@ find_existing_filter(PyObject *tex_filter) {
     if (filter != nullptr && filter->is_of_type(PythonTexturePoolFilter::get_class_type())) {
       PythonTexturePoolFilter *py_filter = (PythonTexturePoolFilter *)filter;
 
-      if (py_filter->_filter_hash == filter_hash) {
+      if (py_filter->_entry_point == tex_filter) {
         return filter;
       }
     }

--- a/panda/src/gobj/texturePool_ext.cxx
+++ b/panda/src/gobj/texturePool_ext.cxx
@@ -1,0 +1,103 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file texturePool_ext.cxx
+ * @author Derzsi Daniel
+ * @date 2020-06-24
+ */
+
+#include "texturePool_ext.h"
+
+#ifdef HAVE_PYTHON
+
+#include "pythonTexturePoolFilter.h"
+#include "texturePoolFilter.h"
+
+/**
+ * Registers a texture pool filter that is implemented in Python.
+ */
+bool Extension<TexturePool>::
+register_filter(PyObject *tex_filter) {
+  if (find_existing_filter(tex_filter) != nullptr) {
+    PyObject *repr = PyObject_Repr(tex_filter);
+
+    gobj_cat->warning()
+      << "Attempted to register Python texture filter " << PyUnicode_AsUTF8(repr)
+      << " more than once.\n";
+    return false;
+  }
+
+  PythonTexturePoolFilter *filter = new PythonTexturePoolFilter();
+
+  if (filter->init(tex_filter)) {
+    return _this->register_filter(filter);
+  }
+
+  delete filter;
+  return false;
+}
+
+/**
+ * If the given Python texture pool filter is registered, unregisters it.
+ */
+bool Extension<TexturePool>::
+unregister_filter(PyObject *tex_filter) {
+  // Keep looping until we've removed all instances of it.
+  bool unregistered = false;
+  TexturePoolFilter *filter;
+
+  while (true) {
+    filter = find_existing_filter(tex_filter);
+
+    if (filter == nullptr) {
+      // Last filter has been removed.
+      break;
+    }
+
+    unregistered = _this->unregister_filter(filter);
+  }
+
+  if (!unregistered) {
+    PyObject *repr = PyObject_Repr(tex_filter);
+
+    gobj_cat->warning()
+      << "Attempted to unregister Python texture filter " << PyUnicode_AsUTF8(repr)
+      << " which was not registered.\n";
+  }
+
+  return unregistered;
+}
+
+/**
+ * Looks for a texture pool filter that is using the
+ * given Python implementation of the texture filter.
+ *
+ * Returns nullptr if none has been found.
+ */
+TexturePoolFilter *Extension<TexturePool>::
+find_existing_filter(PyObject *tex_filter) {
+  size_t num_filters = _this->get_num_filters();
+  long filter_hash = PyObject_Hash(tex_filter);
+
+  for (size_t i = 0; i < num_filters; ++i) {
+    TexturePoolFilter *filter = _this->get_filter(i);
+
+    if (filter->is_of_type(PythonTexturePoolFilter::get_class_type())) {
+      PythonTexturePoolFilter *py_filter = (PythonTexturePoolFilter *)filter;
+
+      if (py_filter->_filter_hash == filter_hash) {
+        return filter;
+      }
+    }
+  }
+
+  // No filter found.
+  return nullptr;
+}
+
+#endif

--- a/panda/src/gobj/texturePool_ext.cxx
+++ b/panda/src/gobj/texturePool_ext.cxx
@@ -73,6 +73,14 @@ unregister_filter(PyObject *tex_filter) {
 }
 
 /**
+ * If the given Python texture pool filter is registered, returns true.
+ */
+bool Extension<TexturePool>::
+is_filter_registered(PyObject *tex_filter) {
+  return find_existing_filter(tex_filter) != nullptr;
+}
+
+/**
  * Looks for a texture pool filter that is using the
  * given Python implementation of the texture filter.
  *

--- a/panda/src/gobj/texturePool_ext.cxx
+++ b/panda/src/gobj/texturePool_ext.cxx
@@ -35,7 +35,7 @@ register_filter(PyObject *tex_filter) {
   PythonTexturePoolFilter *filter = new PythonTexturePoolFilter();
 
   if (filter->init(tex_filter)) {
-    return _this->register_filter(filter);
+    return _this->ns_register_filter(filter);
   }
 
   delete filter;
@@ -58,7 +58,7 @@ unregister_filter(PyObject *tex_filter) {
       break;
     }
 
-    unregistered = _this->unregister_filter(filter);
+    unregistered = _this->ns_unregister_filter(filter);
   }
 
   if (!unregistered) {

--- a/panda/src/gobj/texturePool_ext.cxx
+++ b/panda/src/gobj/texturePool_ext.cxx
@@ -94,7 +94,7 @@ find_existing_filter(PyObject *tex_filter) {
   for (size_t i = 0; i < num_filters; ++i) {
     TexturePoolFilter *filter = _this->get_filter(i);
 
-    if (filter->is_of_type(PythonTexturePoolFilter::get_class_type())) {
+    if (filter != nullptr && filter->is_of_type(PythonTexturePoolFilter::get_class_type())) {
       PythonTexturePoolFilter *py_filter = (PythonTexturePoolFilter *)filter;
 
       if (py_filter->_filter_hash == filter_hash) {

--- a/panda/src/gobj/texturePool_ext.h
+++ b/panda/src/gobj/texturePool_ext.h
@@ -11,8 +11,8 @@
  * @date 2020-06-24
  */
 
-#ifndef TEXTUREPOOLEXT_H
-#define TEXTUREPOOLEXT_H
+#ifndef TEXTUREPOOL_EXT_H
+#define TEXTUREPOOL_EXT_H
 
 #include "pandabase.h"
 

--- a/panda/src/gobj/texturePool_ext.h
+++ b/panda/src/gobj/texturePool_ext.h
@@ -1,0 +1,44 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file texturePool_ext.h
+ * @author Derzsi Daniel
+ * @date 2020-06-24
+ */
+
+#ifndef TEXTUREPOOLEXT_H
+#define TEXTUREPOOLEXT_H
+
+#include "pandabase.h"
+
+#ifdef HAVE_PYTHON
+
+#include "extension.h"
+#include "texturePoolFilter.h"
+#include "texturePool.h"
+#include "py_panda.h"
+
+/**
+ * This class defines the extension methods for TexturePool, which are called
+ * instead of any C++ methods with the same prototype.
+ *
+ * @since 1.11.0
+ */
+template<>
+class Extension<TexturePool> : public ExtensionBase<TexturePool> {
+public:
+  bool register_filter(PyObject *tex_filter);
+  bool unregister_filter(PyObject *tex_filter);
+
+private:
+  TexturePoolFilter *find_existing_filter(PyObject *tex_filter);
+};
+
+#endif  // HAVE_PYTHON
+
+#endif

--- a/panda/src/gobj/texturePool_ext.h
+++ b/panda/src/gobj/texturePool_ext.h
@@ -34,6 +34,7 @@ class Extension<TexturePool> : public ExtensionBase<TexturePool> {
 public:
   bool register_filter(PyObject *tex_filter);
   bool unregister_filter(PyObject *tex_filter);
+  bool is_filter_registered(PyObject *tex_filter);
 
 private:
   TexturePoolFilter *find_existing_filter(PyObject *tex_filter);

--- a/panda/src/putil/loaderOptions.cxx
+++ b/panda/src/putil/loaderOptions.cxx
@@ -75,7 +75,6 @@ output(std::ostream &out) const {
     write_flag(out, sep, "LF_no_ram_cache", LF_no_ram_cache);
   }
   write_flag(out, sep, "LF_allow_instance", LF_allow_instance);
-  write_flag(out, sep, "LF_no_filters", LF_no_filters);
   if (sep.empty()) {
     out << "0";
   }
@@ -88,6 +87,7 @@ output(std::ostream &out) const {
   write_texture_flag(out, sep, "TF_allow_1d", TF_allow_1d);
   write_texture_flag(out, sep, "TF_generate_mipmaps", TF_generate_mipmaps);
   write_texture_flag(out, sep, "TF_allow_compression", TF_allow_compression);
+  write_texture_flag(out, sep, "TF_no_filters", TF_no_filters);
   if (sep.empty()) {
     out << "0";
   }

--- a/panda/src/putil/loaderOptions.cxx
+++ b/panda/src/putil/loaderOptions.cxx
@@ -75,6 +75,7 @@ output(std::ostream &out) const {
     write_flag(out, sep, "LF_no_ram_cache", LF_no_ram_cache);
   }
   write_flag(out, sep, "LF_allow_instance", LF_allow_instance);
+  write_flag(out, sep, "LF_no_filters", LF_no_filters);
   if (sep.empty()) {
     out << "0";
   }

--- a/panda/src/putil/loaderOptions.h
+++ b/panda/src/putil/loaderOptions.h
@@ -34,7 +34,6 @@ PUBLISHED:
     LF_no_cache          = 0x0030,  // no_disk + no_ram
     LF_cache_only        = 0x0040,  // fail if not in cache
     LF_allow_instance    = 0x0080,  // returned pointer might be shared
-    LF_no_filters        = 0x0100,  // disallow using texture pool filters
   };
 
   // Flags for loading texture files.
@@ -47,6 +46,7 @@ PUBLISHED:
     TF_integer           = 0x0080,  // Load as an integer (RGB) texture
     TF_float             = 0x0100,  // Load as a floating-point (depth) texture
     TF_allow_compression = 0x0200,  // Consider compressing RAM image
+    TF_no_filters        = 0x0400,  // disallow using texture pool filters
   };
 
   LoaderOptions(int flags = LF_search | LF_report_errors);

--- a/panda/src/putil/loaderOptions.h
+++ b/panda/src/putil/loaderOptions.h
@@ -34,6 +34,7 @@ PUBLISHED:
     LF_no_cache          = 0x0030,  // no_disk + no_ram
     LF_cache_only        = 0x0040,  // fail if not in cache
     LF_allow_instance    = 0x0080,  // returned pointer might be shared
+    LF_no_filters        = 0x0100,  // disallow using texture pool filters
   };
 
   // Flags for loading texture files.

--- a/pandatool/src/egg-palettize/txaFileFilter.cxx
+++ b/pandatool/src/egg-palettize/txaFileFilter.cxx
@@ -30,8 +30,7 @@ NotifyCategoryDef(txafile, "");
 Configure(config_txaFileFilter);
 ConfigureFn(config_txaFileFilter) {
   TxaFileFilter::init_type();
-  TexturePool *pool = TexturePool::get_global_ptr();
-  pool->register_filter(new TxaFileFilter);
+  TexturePool::register_filter(new TxaFileFilter);
 }
 
 TypeHandle TxaFileFilter::_type_handle;

--- a/tests/gobj/test_texture_pool.py
+++ b/tests/gobj/test_texture_pool.py
@@ -2,55 +2,115 @@ from panda3d import core
 import pytest
 import tempfile
 
-@pytest.fixture(scope='function')
-def pool():
-    "This fixture ensures the pool is properly emptied"
-    pool = core.TexturePool
-    pool.release_all_textures()
-    yield pool
-    pool.release_all_textures()
-
-
 def write_image(filename, channels):
     img = core.PNMImage(1, 1, channels)
     img.set_xel_a(0, 0, (0.0, 0.25, 0.5, 0.75))
     assert img.write(filename)
 
 
-@pytest.fixture(scope='session')
-def image_rgb_path():
-    "Generates an RGB image."
-
-    file = tempfile.NamedTemporaryFile(suffix='-rgb.png')
+def yield_image(suffix, channels):
+    file = tempfile.NamedTemporaryFile(suffix=suffix)
     path = core.Filename.from_os_specific(file.name)
     path.make_true_case()
-    write_image(path, 3)
+    write_image(path, channels)
     yield path
     file.close()
 
 
-@pytest.fixture(scope='session')
-def image_rgba_path():
-    "Generates an RGBA image."
+def register_filter(pool, tex_filter):
+    assert pool.get_num_filters() == 0
+    assert pool.register_filter(tex_filter)
+    assert pool.get_num_filters() == 1
 
-    file = tempfile.NamedTemporaryFile(suffix='-rgba.png')
-    path = core.Filename.from_os_specific(file.name)
-    path.make_true_case()
-    write_image(path, 4)
-    yield path
-    file.close()
+
+def unregister_filter(tex_filter):
+    p = core.TexturePool.get_global_ptr()
+
+    if p.is_filter_registered(tex_filter):
+        p.unregister_filter(tex_filter)
+
+
+def yield_registered_filter(filter_type):
+    tex_filter = filter_type()
+    yield tex_filter
+    unregister_filter(tex_filter)
+
+
+@pytest.fixture(scope='function')
+def pool():
+    "This fixture ensures the pool is properly emptied"
+    pool = core.TexturePool.get_global_ptr()
+    pool.release_all_textures()
+    yield pool
+    pool.release_all_textures()
 
 
 @pytest.fixture(scope='session')
 def image_gray_path():
     "Generates a grayscale image."
+    yield from yield_image('-gray.png', channels=1)
 
-    file = tempfile.NamedTemporaryFile(suffix='-gray.png')
-    path = core.Filename.from_os_specific(file.name)
-    path.make_true_case()
-    write_image(path, 1)
-    yield path
-    file.close()
+
+@pytest.fixture(scope='session')
+def image_rgb_path():
+    "Generates an RGB image."
+    yield from yield_image('-rgb.png', channels=3)
+
+
+@pytest.fixture(scope='session')
+def image_rgba_path():
+    "Generates an RGBA image."
+    yield from yield_image('-rgba.png', channels=4)
+
+
+@pytest.fixture(scope='function')
+def pre_filter():
+    "Creates a texture pool preload filter."
+    class PreLoadTextureFilter(object):
+
+        def pre_load(self, orig_filename, orig_alpha_filename,
+                     primary_file_num_channels, alpha_file_channel,
+                     read_mipmaps, options):
+            return core.Texture('preloaded')
+
+    yield from yield_registered_filter(PreLoadTextureFilter)
+
+
+@pytest.fixture(scope='function')
+def post_filter():
+    "Creates a texture pool postload filter."
+    class PostLoadTextureFilter(object):
+
+        def post_load(self, tex):
+            tex.set_name('postloaded')
+
+    yield from yield_registered_filter(PostLoadTextureFilter)
+
+
+@pytest.fixture(scope='function')
+def mix_filter():
+    "Creates a texture pool mix filter."
+    class MixTextureFilter(object):
+
+        def pre_load(self, orig_filename, orig_alpha_filename,
+                     primary_file_num_channels, alpha_file_channel,
+                     read_mipmaps, options):
+            return core.Texture('preloaded')
+
+        def post_load(self, tex):
+            tex.set_name(tex.get_name() + '-postloaded')
+
+    yield from yield_registered_filter(MixTextureFilter)
+
+
+@pytest.fixture(scope='function')
+def invalid_filter():
+    "Creates an invalid texture filter."
+    class InvalidTextureFilter(object):
+        pass
+
+    tex_filter = InvalidTextureFilter()
+    yield tex_filter
 
 
 def test_load_texture_rgba(pool, image_rgba_path):
@@ -200,3 +260,117 @@ def test_reload_texture_without_alpha(pool, image_rgb_path, image_gray_path):
 
     tex = pool.load_texture(image_rgb_path)
     assert tex.num_components == 3
+
+
+def test_empty_texture_filters(pool):
+    assert pool.get_num_filters() == 0
+
+
+def test_register_pre_texture_filter(pool, pre_filter):
+    register_filter(pool, pre_filter)
+
+
+def test_register_post_texture_filter(pool, post_filter):
+    register_filter(pool, post_filter)
+
+
+def test_register_mix_texture_filter(pool, mix_filter):
+    register_filter(pool, mix_filter)
+
+
+def test_register_invalid_texture_filter(pool, invalid_filter):
+    assert pool.get_num_filters() == 0
+
+    with pytest.raises(TypeError):
+        pool.register_filter(invalid_filter)
+
+    assert pool.get_num_filters() == 0
+
+
+def test_register_null_texture_filter(pool):
+    assert pool.get_num_filters() == 0
+
+    with pytest.raises(TypeError):
+        pool.register_filter(None)
+
+    assert pool.get_num_filters() == 0
+
+
+def test_register_all_texture_filters(pool, pre_filter, post_filter, mix_filter):
+    assert pool.get_num_filters() == 0
+    assert pool.register_filter(pre_filter)
+    assert pool.register_filter(post_filter)
+    assert pool.register_filter(mix_filter)
+    assert pool.get_num_filters() == 3
+
+
+def test_unregister_texture_filter(pool, mix_filter):
+    register_filter(pool, mix_filter)
+    assert pool.unregister_filter(mix_filter)
+    assert pool.get_num_filters() == 0
+
+
+def test_clear_texture_filters(pool, pre_filter, post_filter):
+    assert pool.get_num_filters() == 0
+    assert pool.register_filter(pre_filter)
+    assert pool.register_filter(post_filter)
+    assert pool.get_num_filters() == 2
+
+    pool.clear_filters()
+    assert pool.get_num_filters() == 0
+
+
+def test_double_register_texture_filter(pool, mix_filter):
+    register_filter(pool, mix_filter)
+    assert not pool.register_filter(mix_filter)
+    assert pool.get_num_filters() == 1
+
+
+def test_double_unregister_texture_filter(pool, mix_filter):
+    register_filter(pool, mix_filter)
+    assert pool.unregister_filter(mix_filter)
+    assert not pool.unregister_filter(mix_filter)
+    assert pool.get_num_filters() == 0
+
+
+def test_is_texture_filter_registered(pool, pre_filter, mix_filter):
+    assert not pool.is_filter_registered(mix_filter)
+    assert pool.register_filter(mix_filter)
+    assert pool.is_filter_registered(mix_filter)
+    assert not pool.is_filter_registered(pre_filter)
+
+
+def test_get_texture_filter(pool, pre_filter):
+    with pytest.raises(AssertionError):
+        pool.get_filter(0)
+
+    assert pool.register_filter(pre_filter)
+    tex_filter = pool.get_filter(0)
+    assert isinstance(tex_filter, core.TexturePoolFilter)
+
+    with pytest.raises(AssertionError):
+        pool.get_filter(1)
+
+
+def test_texture_pre_filter(pool, pre_filter):
+    register_filter(pool, pre_filter)
+
+    texture = pool.load_texture('nonexistent')
+    assert isinstance(texture, core.Texture)
+    assert texture.get_name() == 'preloaded'
+
+
+def test_texture_post_filter(pool, post_filter, image_rgb_path):
+    register_filter(pool, post_filter)
+
+    texture = pool.load_texture(image_rgb_path, 3)
+    assert isinstance(texture, core.Texture)
+    assert texture.get_name() == 'postloaded'
+
+
+def test_texture_mix_filter(pool, mix_filter):
+    register_filter(pool, mix_filter)
+
+    texture = pool.load_texture('nonexistent')
+    assert isinstance(texture, core.Texture)
+    assert texture.get_name() == 'preloaded-postloaded'

--- a/tests/gobj/test_texture_pool.py
+++ b/tests/gobj/test_texture_pool.py
@@ -373,6 +373,6 @@ def test_texture_mix_filter(pool, mix_filter):
 def test_no_texture_filter_option(pool, pre_filter, image_rgb_path):
     register_filter(pool, pre_filter)
 
-    texture = pool.load_texture(image_rgb_path, 3, False, core.LoaderOptions.LF_no_filters)
+    texture = pool.load_texture(image_rgb_path, 3, False, core.LoaderOptions(0, core.LoaderOptions.TF_no_filters))
     assert isinstance(texture, core.Texture)
     assert texture.get_name() != 'preloaded'

--- a/tests/gobj/test_texture_pool.py
+++ b/tests/gobj/test_texture_pool.py
@@ -23,18 +23,14 @@ def register_filter(pool, tex_filter):
     assert pool.get_num_filters() == 1
 
 
-def unregister_filter(tex_filter):
+def yield_registered_filter(filter_type):
+    tex_filter = filter_type()
+    yield tex_filter
+
     p = core.TexturePool.get_global_ptr()
 
     if p.is_filter_registered(tex_filter):
         p.unregister_filter(tex_filter)
-
-
-def yield_registered_filter(filter_type):
-    tex_filter = filter_type()
-    yield tex_filter
-    unregister_filter(tex_filter)
-
 
 @pytest.fixture(scope='function')
 def pool():

--- a/tests/gobj/test_texture_pool.py
+++ b/tests/gobj/test_texture_pool.py
@@ -337,15 +337,13 @@ def test_is_texture_filter_registered(pool, pre_filter, mix_filter):
 
 
 def test_get_texture_filter(pool, pre_filter):
-    with pytest.raises(AssertionError):
-        pool.get_filter(0)
+    assert not pool.get_filter(0)
 
     assert pool.register_filter(pre_filter)
     tex_filter = pool.get_filter(0)
     assert isinstance(tex_filter, core.TexturePoolFilter)
 
-    with pytest.raises(AssertionError):
-        pool.get_filter(1)
+    assert not pool.get_filter(1)
 
 
 def test_texture_pre_filter(pool, pre_filter):

--- a/tests/gobj/test_texture_pool.py
+++ b/tests/gobj/test_texture_pool.py
@@ -368,3 +368,11 @@ def test_texture_mix_filter(pool, mix_filter):
     texture = pool.load_texture('nonexistent')
     assert isinstance(texture, core.Texture)
     assert texture.get_name() == 'preloaded-postloaded'
+
+
+def test_no_texture_filter_option(pool, pre_filter, image_rgb_path):
+    register_filter(pool, pre_filter)
+
+    texture = pool.load_texture(image_rgb_path, 3, False, core.LoaderOptions.LF_no_filters)
+    assert isinstance(texture, core.Texture)
+    assert texture.get_name() != 'preloaded'


### PR DESCRIPTION
This commit implements a special type of TexturePoolFilter: one that can be used to implement a texture pool filter directly in Python.

Rationale behind this change: I'd like to implement a texture pool filter that I'd like others to be able to use, but one that would most likely not be accepted upstream into Panda3D. As such, my goal was to create a general texture pool filter that could be programmed using Python, without having to rebuild Panda3D's C++ portion.

To use PythonTexturePoolFilter, create a Python class inheriting PythonTexturePoolFilter, and implement either the `pre_load` or `post_load` function, or both:

```py
pre_load(self, orig_filename, orig_alpha_filename,
         primary_file_num_channels, alpha_file_channel,
         read_mipmaps, options)
post_load(self, texture)
```

Returning a Texture inside `pre_load` will make Panda3D use that texture instead of looking for the on-disk variant.

To register the filter in the global texture pool:

```py
tex_filter = MyTexFilter()
tex_filter.register_filter(tex_filter)
```

To register the filter in another texture pool:
```py
tex_filter = MyTexFilter()
tex_pool = TexturePool.get_global_ptr()
tex_filter.register_filter(tex_filter, tex_pool)
```

Caveats:
* `pre_load` in TexturePool holds the `_lock` mutex. As such, loading another texture inside a custom texture pool filter and running the exact same filter on another texture causes a deadlock.
* A new LoaderOptions flag was added: `LF_no_filters`, which prevents the texture pool from attempting to use filters when enabled for the load request. This way, it does not attempt to hold `_lock` again.
* However, `_lock` is still held by `pre_load` at this time. To fix this, I've created a lock specific to filters: `_filter_lock`. This lock is only used while a texture is processing filters. (`_filter_lock` is necessary in case `_filter_registry` is modified during runtime).

I've created an example texture pool filter, one that will prioritize loading ".jpg" and ".rgb" textures over ".png" textures. If you're trying to load a PNG texture, this example texture pool filter will first check if there's a loadable JPG+RGB alpha combo texture, and if not, it will try to load the JPG variant of the same texture (for legacy reasons).

JPG+RGB > JPG > PNG

Please let me know your thoughts, and let me know if I've missed something!

[texturepoolfilter.zip](https://github.com/panda3d/panda3d/files/4777477/texturepoolfilter.zip)