### PR TITLE
Add initial issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,36 @@
+
+---
+name: Bug report
+about: Report a defect
+title: ''
+labels: 
+assignees: ''
+
+---
+
+## Environment
+ * OS:
+ * Panda3D version:
+ * Python version (if using Python):
+ * Compiler (if using C++):
+
+## Summary
+A clear and concise description of what the bug is.
+Please include what you expected to happen, and what actually happened.
+
+## Steps To Reproduce
+A description of how to reproduce the bug, preferably with a code snippet that clearly demonstrates the bug.
+
+```python
+from direct.showbase.ShowBase import ShowBase
+
+
+class MyApp(ShowBase):
+
+    def __init__(self):
+        ShowBase.__init__(self)
+
+
+app = MyApp()
+app.run()
+```

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,20 @@
+
+
+---
+name: Discussion
+about: Open a discussion to gather community feedback
+title: ''
+labels: discussion
+assignees: ''
+
+---
+
+## Topic Of Discussion
+A description of the items to discuss in this issue
+
+## End Of Discussion
+Describe when this issue can be closed.
+Some examples include:
+* a certain amount of time has passed
+* a particular release happens
+* a decision is reached.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,18 @@
+
+---
+name: Enhancement request
+about: Request new functionality or improvement to existing functionality
+title: ''
+labels: 
+assignees: ''
+
+---
+
+## Proposed Enhancement
+A clear and concise description of what you want to happen, and why you want it.
+
+## Considered Alternatives
+A clear and concise description of any alternative solutions or features you have considered.
+
+## Additional Context
+Add any other context such as screenshots, code snippets, or other examples about the enhancement request here.


### PR DESCRIPTION
## Issue description
This repository currently lacks issue templates as recommended by the [Community Profile](https://github.com/panda3d/panda3d/community).

## Solution description
I put together three simple issue templates for bugs, enhancement requests, and discussion issues. The discussion template will automatically apply the "discussion" label. No other labels are applied automatically. If these templates are not sufficient for a user, they can still select the option to use a blank template.