### PR TITLE
cocoadisplay: Fix handling of shift modifier

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1720,20 +1720,19 @@ handle_key_event(NSEvent *event) {
     return;
   }
 
+  TISInputSourceRef input_source = TISCopyCurrentKeyboardLayoutInputSource();
+  CFDataRef layout_data = (CFDataRef)TISGetInputSourceProperty(input_source, kTISPropertyUnicodeKeyLayoutData);
+  const UCKeyboardLayout *layout = (const UCKeyboardLayout *)CFDataGetBytePtr(layout_data);
+
   if ([event type] == NSKeyDown) {
     // Translate it to a unicode character for keystrokes.  I would use
     // interpretKeyEvents and insertText, but that doesn't handle dead keys.
-    TISInputSourceRef input_source = TISCopyCurrentKeyboardLayoutInputSource();
-    CFDataRef layout_data = (CFDataRef)TISGetInputSourceProperty(input_source, kTISPropertyUnicodeKeyLayoutData);
-    const UCKeyboardLayout *layout = (const UCKeyboardLayout *)CFDataGetBytePtr(layout_data);
-
     UInt32 modifier_state = (modifierFlags >> 16) & 0xFF;
     UniChar ustr[8];
     UniCharCount length;
 
     UCKeyTranslate(layout, [event keyCode], kUCKeyActionDown, modifier_state,
                    LMGetKbdType(), 0, &_dead_key_state, sizeof(ustr), &length, ustr);
-    CFRelease(input_source);
 
     for (int i = 0; i < length; ++i) {
       UniChar c = ustr[i];
@@ -1749,17 +1748,25 @@ handle_key_event(NSEvent *event) {
     }
   }
 
-  NSString *str = [event charactersIgnoringModifiers];
-  if (str == nil || [str length] == 0) {
+  // [NSEvent charactersIgnoringModifiers] doesn't ignore the shift key, so we
+  // need to do what that method is doing manually.
+  _dead_key_state = 0;
+  UniChar c;
+  UniCharCount length;
+  OSStatus result = UCKeyTranslate(layout, [event keyCode], kUCKeyActionDisplay,
+    0, LMGetKbdType(), kUCKeyTranslateNoDeadKeysMask, &_dead_key_state,
+    sizeof(c), &length, &c);
+  CFRelease(input_source);
+
+  if (length != 1) {
     return;
   }
-  nassertv_always([str length] == 1);
-  unichar c = [str characterAtIndex: 0];
 
   ButtonHandle button = map_key(c);
 
   if (button == ButtonHandle::none()) {
     // That done, continue trying to find out the button handle.
+    NSString *str = [[NSString alloc] initWithCharacters:&c length:length];
     if ([str canBeConvertedToEncoding: NSASCIIStringEncoding]) {
       // Nhm, ascii character perhaps?
       str = [str lowercaseString];


### PR DESCRIPTION
This replaces the use of [NSEvent charactersIgnoringModifiers] with a Carbon function. In macOS 10.15+ there is a way in Foundation of achieving the same thing, so we'll be able to switch to that once Carbon is fully removed from macOS.

Fixes #959 