### PR TITLE
joystick: Fix erroneous dpad_*-up events when emulating a dpad on Linux

### DIFF
--- a/panda/src/device/evdevInputDevice.cxx
+++ b/panda/src/device/evdevInputDevice.cxx
@@ -595,6 +595,8 @@ init_device() {
               _buttons.push_back(ButtonState(GamepadButton::hat_left()));
               _buttons.push_back(ButtonState(GamepadButton::hat_right()));
             }
+            _buttons[_dpad_left_button]._state = S_up;
+            _buttons[_dpad_left_button+1]._state = S_up;
           }
           break;
         case ABS_HAT0Y:
@@ -608,6 +610,8 @@ init_device() {
               _buttons.push_back(ButtonState(GamepadButton::hat_up()));
               _buttons.push_back(ButtonState(GamepadButton::hat_down()));
             }
+            _buttons[_dpad_up_button]._state = S_up;
+            _buttons[_dpad_up_button+1]._state = S_up;
           }
           break;
         case ABS_HAT2X:

--- a/panda/src/device/linuxJoystickDevice.cxx
+++ b/panda/src/device/linuxJoystickDevice.cxx
@@ -234,6 +234,8 @@ open_device() {
             add_button(GamepadButton::hat_left());
             add_button(GamepadButton::hat_right());
           }
+          _buttons[_dpad_left_button]._state = S_up;
+          _buttons[_dpad_left_button+1]._state = S_up;
           axis = Axis::none;
         }
         break;
@@ -250,6 +252,8 @@ open_device() {
             add_button(GamepadButton::hat_up());
             add_button(GamepadButton::hat_down());
           }
+          _buttons[_dpad_up_button]._state = S_up;
+          _buttons[_dpad_up_button+1]._state = S_up;
           axis = Axis::none;
         }
         break;


### PR DESCRIPTION
## Issue Description
When emulating a dpad using the hat axes, an change in an axis will trigger updates for both associated dpad "buttons" (i.e., left/right or up/down). The depressed button is updated as "down" and the other button is updated to "up." However, since these buttons start in an unknown state and a state change triggers an event to fire, the first time an emulated dpad button is updated to "down" the opposite button will throw an "up" event.

## Solution Description
Start emulated dpad buttons in an S_up state instead of S_unknown. This way, the first S_up event will go from S_up to S_up instead of S_unknown to S_up and not trigger an event to fire.

This PR applies this fix for the Linux Joystick API and for the Linux evdev API, but only the evdev changes were tested. I do not know if other platforms have similar issues.