### PR TITLE
direct: Fix TexMemWatcher crash when graphics memory reaches 1 GB

### DIFF
--- a/direct/src/showutil/TexMemWatcher.py
+++ b/direct/src/showutil/TexMemWatcher.py
@@ -883,7 +883,7 @@ class TexMemWatcher(DirectObject):
             matches.append((match, tp))
 
         if matches:
-            return max(matches)[1]
+            return max(matches, key=lambda match: match[0])[1]
         return None
 
     def findHolePieces(self, area):
@@ -937,7 +937,7 @@ class TexMemWatcher(DirectObject):
     def findLargestHole(self):
         holes = self.findAvailableHoles(0)
         if holes:
-            return max(holes)[1]
+            return max(holes, key=lambda hole: hole[0])[1]
         return None
 
     def findAvailableHoles(self, area, w = None, h = None):

--- a/panda/src/display/graphicsOutput.cxx
+++ b/panda/src/display/graphicsOutput.cxx
@@ -1468,8 +1468,8 @@ create_texture_card_vdata(int x, int y) {
   PN_stdfloat yhi = 1.0;
 
   if (Texture::get_textures_power_2() != ATS_none) {
-    int xru = Texture::up_to_power_2(x);
-    int yru = Texture::up_to_power_2(y);
+    size_t xru = Texture::up_to_power_2(x);
+    size_t yru = Texture::up_to_power_2(y);
     xhi = (x * 1.0f) / xru;
     yhi = (y * 1.0f) / yru;
   }

--- a/panda/src/display/parasiteBuffer.cxx
+++ b/panda/src/display/parasiteBuffer.cxx
@@ -91,8 +91,8 @@ void ParasiteBuffer::
 set_size_and_recalc(int x, int y) {
   if (!(_creation_flags & GraphicsPipe::BF_size_track_host)) {
     if (_creation_flags & GraphicsPipe::BF_size_power_2) {
-      x = Texture::down_to_power_2(x);
-      y = Texture::down_to_power_2(y);
+      x = (int)Texture::down_to_power_2(x);
+      y = (int)Texture::down_to_power_2(y);
     }
     if (_creation_flags & GraphicsPipe::BF_size_square) {
       x = y = std::min(x, y);

--- a/panda/src/dxgsg9/wdxGraphicsBuffer9.cxx
+++ b/panda/src/dxgsg9/wdxGraphicsBuffer9.cxx
@@ -275,8 +275,8 @@ rebuild_bitplanes() {
   int bitplane_x = get_x_size();
   int bitplane_y = get_y_size();
   if (Texture::get_textures_power_2() != ATS_none) {
-    bitplane_x = Texture::up_to_power_2(bitplane_x);
-    bitplane_y = Texture::up_to_power_2(bitplane_y);
+    bitplane_x = (int)Texture::up_to_power_2(bitplane_x);
+    bitplane_y = (int)Texture::up_to_power_2(bitplane_y);
   }
 
   // Find the color and depth textures.  Either may be present, or neither.

--- a/panda/src/glstuff/glGraphicsBuffer_src.cxx
+++ b/panda/src/glstuff/glGraphicsBuffer_src.cxx
@@ -385,8 +385,8 @@ rebuild_bitplanes() {
   int bitplane_x = get_x_size();
   int bitplane_y = get_y_size();
   if (Texture::get_textures_power_2() != ATS_none) {
-    bitplane_x = Texture::up_to_power_2(bitplane_x);
-    bitplane_y = Texture::up_to_power_2(bitplane_y);
+    bitplane_x = (int)Texture::up_to_power_2(bitplane_x);
+    bitplane_y = (int)Texture::up_to_power_2(bitplane_y);
   }
   bool rb_resize = false;
   if ((bitplane_x != _rb_size_x)||

--- a/panda/src/gobj/geomVertexArrayData.cxx
+++ b/panda/src/gobj/geomVertexArrayData.cxx
@@ -631,7 +631,7 @@ set_num_rows(int n) {
     if (new_size > orig_reserved_size) {
       // Add more rows.  Go up to the next power of two bytes, mainly to
       // reduce the number of allocs needed.
-      size_t new_reserved_size = (size_t)Texture::up_to_power_2((int)new_size);
+      size_t new_reserved_size = Texture::up_to_power_2(new_size);
       nassertr(new_reserved_size >= new_size, false);
 
       _cdata->_buffer.clean_realloc(new_reserved_size);
@@ -818,7 +818,7 @@ copy_subdata_from(size_t to_start, size_t to_size,
     size_t needed_size = to_buffer_orig_size + from_size - to_size;
     size_t to_buffer_orig_reserved_size = to_buffer.get_reserved_size();
     if (needed_size > to_buffer_orig_reserved_size) {
-      size_t new_reserved_size = (size_t)Texture::up_to_power_2((int)needed_size);
+      size_t new_reserved_size = Texture::up_to_power_2(needed_size);
       to_buffer.clean_realloc(new_reserved_size);
     }
     to_buffer.set_size(needed_size);
@@ -891,7 +891,7 @@ set_subdata(size_t start, size_t size, const vector_uchar &data) {
     size_t needed_size = to_buffer_orig_size + from_size - size;
     size_t to_buffer_orig_reserved_size = to_buffer.get_reserved_size();
     if (needed_size > to_buffer_orig_reserved_size) {
-      size_t new_reserved_size = (size_t)Texture::up_to_power_2((int)needed_size);
+      size_t new_reserved_size = Texture::up_to_power_2(needed_size);
       to_buffer.clean_realloc(new_reserved_size);
     }
     to_buffer.set_size(needed_size);

--- a/panda/src/gobj/texture.cxx
+++ b/panda/src/gobj/texture.cxx
@@ -1334,8 +1334,8 @@ generate_simple_ram_image() {
 
   // Limit it to no larger than the source image, and also make it a power of
   // two.
-  x_size = down_to_power_2(min(x_size, cdata->_x_size));
-  y_size = down_to_power_2(min(y_size, cdata->_y_size));
+  x_size = (int)down_to_power_2(min(x_size, cdata->_x_size));
+  y_size = (int)down_to_power_2(min(y_size, cdata->_y_size));
 
   // Generate a reduced image of that size.
   PNMImage scaled(x_size, y_size, pnmimage.get_num_channels());
@@ -1907,13 +1907,13 @@ void Texture::
 set_size_padded(int x, int y, int z) {
   CDWriter cdata(_cycler, true);
   if (do_get_auto_texture_scale(cdata) != ATS_none) {
-    do_set_x_size(cdata, up_to_power_2(x));
-    do_set_y_size(cdata, up_to_power_2(y));
+    do_set_x_size(cdata, (int)up_to_power_2(x));
+    do_set_y_size(cdata, (int)up_to_power_2(y));
 
     if (cdata->_texture_type == TT_3d_texture) {
       // Only pad 3D textures.  It does not make sense to do so for cube maps
       // or 2D texture arrays.
-      do_set_z_size(cdata, up_to_power_2(z));
+      do_set_z_size(cdata, (int)up_to_power_2(z));
     } else {
       do_set_z_size(cdata, z);
     }
@@ -1979,24 +1979,24 @@ prepare_now(int view,
 /**
  * Returns the smallest power of 2 greater than or equal to value.
  */
-int Texture::
-up_to_power_2(int value) {
+size_t Texture::
+up_to_power_2(size_t value) {
   if (value <= 1) {
     return 1;
   }
-  int bit = get_next_higher_bit(((unsigned int)value) - 1);
+  size_t bit = get_next_higher_bit(((uint64_t)value) - 1);
   return (1 << bit);
 }
 
 /**
  * Returns the largest power of 2 less than or equal to value.
  */
-int Texture::
-down_to_power_2(int value) {
+size_t Texture::
+down_to_power_2(size_t value) {
   if (value <= 1) {
     return 1;
   }
-  int bit = get_next_higher_bit(((unsigned int)value) >> 1);
+  size_t bit = get_next_higher_bit(((uint64_t)value) >> 1);
   return (1 << bit);
 }
 
@@ -2674,14 +2674,14 @@ adjust_size(int &x_size, int &y_size, const string &name,
 
   switch (ats) {
   case ATS_down:
-    new_x_size = down_to_power_2(new_x_size);
-    new_y_size = down_to_power_2(new_y_size);
+    new_x_size = (int)down_to_power_2(new_x_size);
+    new_y_size = (int)down_to_power_2(new_y_size);
     break;
 
   case ATS_up:
   case ATS_pad:
-    new_x_size = up_to_power_2(new_x_size);
-    new_y_size = up_to_power_2(new_y_size);
+    new_x_size = (int)up_to_power_2(new_x_size);
+    new_y_size = (int)up_to_power_2(new_y_size);
     break;
 
   case ATS_none:

--- a/panda/src/gobj/texture.h
+++ b/panda/src/gobj/texture.h
@@ -589,8 +589,8 @@ PUBLISHED:
                               PreparedGraphicsObjects *prepared_objects,
                               GraphicsStateGuardianBase *gsg);
 
-  static int up_to_power_2(int value);
-  static int down_to_power_2(int value);
+  static size_t up_to_power_2(size_t value);
+  static size_t down_to_power_2(size_t value);
 
   void consider_rescale(PNMImage &pnmimage);
   static void consider_rescale(PNMImage &pnmimage, const std::string &name, AutoTextureScale auto_texture_scale = ATS_unspecified);

--- a/panda/src/wgldisplay/wglGraphicsBuffer.cxx
+++ b/panda/src/wgldisplay/wglGraphicsBuffer.cxx
@@ -429,8 +429,8 @@ rebuild_bitplanes() {
   int desired_x = get_x_size();
   int desired_y = get_y_size();
   if ((bindtexture != 0)&&(Texture::get_textures_power_2() != ATS_none)) {
-    desired_x = Texture::up_to_power_2(desired_x);
-    desired_y = Texture::up_to_power_2(desired_y);
+    desired_x = (int)Texture::up_to_power_2(desired_x);
+    desired_y = (int)Texture::up_to_power_2(desired_y);
   }
   bool desired_mipmap = false;
   Texture::TextureType desired_type = Texture::TT_2d_texture;


### PR DESCRIPTION
TexMemWatcher crashes frequently when the graphics memory approaches or reaches 1 GB.

The first crash happens when two texture match dimensions are the same. Python tries to compare the texture placements, but this is impossible as they are not comparable, therefore the following traceback occurs:
```
  File "C:\Panda3D-1.11.0\direct\showutil\TexMemWatcher.py", line 787, in placeTexture
    tp = self.findHole(tr.area, tr.w, tr.h)
  File "C:\Panda3D-1.11.0\direct\showutil\TexMemWatcher.py", line 886, in findHole
    return max(matches)[1]
TypeError: '>' not supported between instances of 'TexPlacement' and 'TexPlacement'
```

The second crash happens because of Texture's `up_to_power_2`. Unfortunately, `up_to_power_2` returns a negative number as soon as it reaches 1073741824, because the next power of two, 2147483648, does not fit into an integer.
```
  File "C:\Panda3D-1.11.0\direct\showutil\TexMemWatcher.py", line 335, in __doSetLimit
    self.win.getGsg().getPreparedObjects().setGraphicsMemoryLimit(self.limit)
OverflowError: can't convert negative value to size_t
```

I've changed `up_to_power_2` and `down_to_power_2` to operate on `size_t` instead. All usages of these have been downcasted to int where necessary for DirectX APIs or texture sizes, which are of the `int` type.

This means that `up_to_power_2` and `down_to_power_2` now support all numbers from 0 to 9223372036854775807 (2**63 - 1) (as bit-counting methods only exist up to uint64_t).

The TexMemWatcher now works properly when 1 GB of texture memory is reached.