### PR TITLE
OnScreenDebug: Parent to a2dTopLeft as opposed to aspect2d

### DIFF
--- a/direct/src/showbase/OnScreenDebug.py
+++ b/direct/src/showbase/OnScreenDebug.py
@@ -37,10 +37,10 @@ class OnScreenDebug:
         if not font.isValid():
             print("failed to load OnScreenDebug font %s" % fontPath)
             font = TextNode.getDefaultFont()
-        self.onScreenText = OnscreenText.OnscreenText(parent = base.a2dTopLeft,
-                pos = (0.0, -0.1), fg=fgColor, bg=bgColor,
-                scale = (fontScale, fontScale, 0.0), align = TextNode.ALeft,
-                mayChange = 1, font = font)
+        self.onScreenText = OnscreenText.OnscreenText(
+                parent = base.a2dTopLeft, pos = (0.0, -0.1),
+                fg=fgColor, bg=bgColor, scale = (fontScale, fontScale, 0.0),
+                align = TextNode.ALeft, mayChange = 1, font = font)
         # Make sure readout is never lit or drawn in wireframe
         DirectUtil.useDirectRenderStyle(self.onScreenText)
 

--- a/direct/src/showbase/OnScreenDebug.py
+++ b/direct/src/showbase/OnScreenDebug.py
@@ -37,8 +37,8 @@ class OnScreenDebug:
         if not font.isValid():
             print("failed to load OnScreenDebug font %s" % fontPath)
             font = TextNode.getDefaultFont()
-        self.onScreenText = OnscreenText.OnscreenText(
-                pos = (-1.0, 0.9), fg=fgColor, bg=bgColor,
+        self.onScreenText = OnscreenText.OnscreenText(parent = base.a2dTopLeft,
+                pos = (0.0, -0.1), fg=fgColor, bg=bgColor,
                 scale = (fontScale, fontScale, 0.0), align = TextNode.ALeft,
                 mayChange = 1, font = font)
         # Make sure readout is never lit or drawn in wireframe


### PR DESCRIPTION
The OSD hasn't been touched in well over a decade, so it could definitely be adjusted to better suit the current state of the engine.

Currently, the OSD is just parented to aspect2d with a position of -1.0, 0.9, whereas parenting it directly to a2dTopLeft would make much more sense and would look better on all screens.