### PR TITLE
PythonUtil: Fix usage of reduce() for Python 3

### DIFF
--- a/direct/src/showbase/PythonUtil.py
+++ b/direct/src/showbase/PythonUtil.py
@@ -39,6 +39,7 @@ import random
 import time
 import builtins
 import importlib
+import functools
 
 __report_indent = 3
 
@@ -2062,7 +2063,7 @@ def report(types = [], prefix = '', xform = None, notifyFunc = None, dConfigPara
             if not rArgs:
                 rArgs = '()'
             else:
-                rArgs = '(' + reduce(str.__add__,rArgs)[:-2] + ')'
+                rArgs = '(' + functools.reduce(str.__add__,rArgs)[:-2] + ')'
 
 
             outStr = '%s%s' % (f.__name__, rArgs)
@@ -2345,7 +2346,7 @@ class MiniLog:
         if not rArgs:
             rArgs = '()'
         else:
-            rArgs = '(' + reduce(str.__add__,rArgs)[:-2] + ')'
+            rArgs = '(' + functools.reduce(str.__add__,rArgs)[:-2] + ')'
 
         line = '%s%s' % (funcName, rArgs)
         self.appendFunctionCall(line)


### PR DESCRIPTION
## Issue description

Nothing too complicated here; just fixing two uses of reduce() which has been moved to functools in Python 3.

## Solution description

Simply using the reduce() now part of the Python functools module.