### PR TITLE
Fix invalid constant used to detect infinity and NaN when code is compiled with finite-math-only

### DIFF
--- a/dtool/src/dtoolbase/cmath.I
+++ b/dtool/src/dtoolbase/cmath.I
@@ -351,7 +351,7 @@ cnan(double v) {
 #if __FINITE_MATH_ONLY__
   // GCC's isnan breaks when using -ffast-math.
   union { double d; uint64_t x; } u = { v };
-  return ((u.x << 1) > 0xff70000000000000ull);
+  return ((u.x << 1) > 0xffe0000000000000ull);
 #elif !defined(_WIN32)
   return std::isnan(v);
 #else
@@ -383,7 +383,7 @@ cinf(double v) {
 #if __FINITE_MATH_ONLY__
   // GCC's isinf breaks when using -ffast-math.
   union { double d; uint64_t x; } u = { v };
-  return ((u.x << 1) == 0xff70000000000000ull);
+  return ((u.x << 1) == 0xffe0000000000000ull);
 #elif !defined(_WIN32)
   return std::isinf(v);
 #else


### PR DESCRIPTION
## Issue description

This PR fixes #987. The  constant used to detect infinite (and also NaN) for double precision value when using code compiled with finite-math-only (implied by optimize=4) is wrong.

Current code is using 0x7ff0000000000000ull as the representation of infinity after a unit left shift. However, the actual representation of infinity is 0x7FF0000000000000, so after a unit left shift it is 0xffe0000000000000ull

Note that the same problem is present in cnan(), a NaN is 0x7FFxxxxxxxxxxxxxx

## Solution description

Change the constant in cinf(double v) and cnan(double v) in cmath.I

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.

It seems that there are no unit tests covering dtoolbase (unless I'm mistaken), this could have been detected there...