### PR TITLE
build_apps: Use FreezeTool.__replacePaths() to cleanup tracebacks

### DIFF
--- a/direct/src/dist/FreezeTool.py
+++ b/direct/src/dist/FreezeTool.py
@@ -1721,6 +1721,8 @@ class Freezer:
 
     def generateRuntimeFromStub(self, target, stub_file, use_console, fields={},
                                 log_append=False):
+        self.__replacePaths()
+
         # We must have a __main__ module to make an exe file.
         if not self.__writingModule('__main__'):
             message = "Can't generate an executable without a __main__ module."


### PR DESCRIPTION
## Issue description
Tracebacks for distributed applications contain full, absolute paths for module names. This makes tracebacks harder to read with all of the extra noise, and it leaks information about the build machine.

## Solution description
FreezeTool already has a way to clean this up with a `__replacePaths()` method. This was being used by `writeMultifile()` and `writeCode()`. This PR adds a call to `__replacePaths()` in `generateRuntimeFromStub()` as well.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
