### PR TITLE
Allow texture compression in .bam (WIP)

### DIFF
--- a/panda/src/gobj/texture.cxx
+++ b/panda/src/gobj/texture.cxx
@@ -10059,10 +10059,6 @@ do_write_datagram_rawdata(CData *cdata, BamWriter *manager, Datagram &me) {
   me.add_uint8(cdata->_component_width);
   me.add_uint8(cdata->_ram_image_compression);
 
-  if(manager->get_file_minor_ver() >= 46) {
-    me.add_uint8(manager->get_tex_compression_format());
-  }
-
   if (cdata->_ram_images.empty() && cdata->_has_clear_color &&
       manager->get_file_minor_ver() < 45) {
     // For older .bam versions that don't support clear colors, make up a RAM

--- a/panda/src/gobj/texture.cxx
+++ b/panda/src/gobj/texture.cxx
@@ -9848,7 +9848,7 @@ write_datagram(BamWriter *manager, Datagram &me) {
 
   // If we are also including the texture's image data, then stuff it in here.
   if (has_rawdata) {
-    (cdata, manager, me);
+    do_write_datagram_rawdata(cdata, manager, me);
   }
 }
 
@@ -10060,7 +10060,7 @@ do_write_datagram_rawdata(CData *cdata, BamWriter *manager, Datagram &me) {
   me.add_uint8(cdata->_ram_image_compression);
 
   if(manager->get_file_minor_ver() >= 46) {
-    me.add_uint8(manager->get_tex_compress_level());
+    me.add_uint8(manager->get_tex_compression_format());
   }
 
   if (cdata->_ram_images.empty() && cdata->_has_clear_color &&
@@ -10086,7 +10086,7 @@ do_write_datagram_rawdata(CData *cdata, BamWriter *manager, Datagram &me) {
       me.add_uint32(cdata->_ram_images[n]._page_size);
 
       // Only write the size of the image data written to bam.
-      if(manager->get_tex_compress_level() == BamEnums::BTC_on) {
+      if(manager->get_tex_compression_format() == BamEnums::BTC_zlib) {
         string raw_image = cdata->_ram_images[n]._image.get_data();
         string compressed_image = compress_string(raw_image, 6);
         me.add_uint32(compressed_image.length());
@@ -10379,7 +10379,7 @@ do_fillin_rawdata(CData *cdata, DatagramIterator &scan, BamReader *manager) {
     PTA_uchar image_data = PTA_uchar::empty_array(read_size, get_class_type());
     scan.extract_bytes(image_data.p(), read_size);
 
-    if(manager->get_texture_compression_level() != BamEnums::BTC_off) {
+    if(manager->get_tex_compression_format() == BamEnums::BTC_zlib) {
       string decompressed = decompress_string(image_data.get_data());
       image_data.resize(decompressed.length());
       image_data.set_data(decompressed);

--- a/panda/src/gobj/texture.h
+++ b/panda/src/gobj/texture.h
@@ -749,7 +749,6 @@ protected:
   bool do_has_compression(const CData *cdata) const;
   virtual bool do_has_ram_image(const CData *cdata) const;
   virtual bool do_has_uncompressed_ram_image(const CData *cdata) const;
-
   CPTA_uchar do_get_ram_image(CData *cdata);
   CPTA_uchar do_get_uncompressed_ram_image(CData *cdata);
   void do_set_simple_ram_image(CData *cdata, CPTA_uchar image, int x_size, int y_size);

--- a/panda/src/gobj/texture.h
+++ b/panda/src/gobj/texture.h
@@ -749,6 +749,7 @@ protected:
   bool do_has_compression(const CData *cdata) const;
   virtual bool do_has_ram_image(const CData *cdata) const;
   virtual bool do_has_uncompressed_ram_image(const CData *cdata) const;
+
   CPTA_uchar do_get_ram_image(CData *cdata);
   CPTA_uchar do_get_uncompressed_ram_image(CData *cdata);
   void do_set_simple_ram_image(CData *cdata, CPTA_uchar image, int x_size, int y_size);

--- a/panda/src/putil/bam.h
+++ b/panda/src/putil/bam.h
@@ -32,7 +32,7 @@ static const unsigned short _bam_major_ver = 6;
 // Bumped to major version 6 on 2006-02-11 to factor out PandaNode::CData.
 
 static const unsigned short _bam_first_minor_ver = 14;
-static const unsigned short _bam_last_minor_ver = 45;
+static const unsigned short _bam_last_minor_ver = 46;
 static const unsigned short _bam_minor_ver = 44;
 // Bumped to minor version 14 on 2007-12-19 to change default ColorAttrib.
 // Bumped to minor version 15 on 2008-04-09 to add TextureAttrib::_implicit_sort.
@@ -66,5 +66,6 @@ static const unsigned short _bam_minor_ver = 44;
 // Bumped to minor version 43 on 2018-12-06 to expand BillboardEffect and CompassEffect.
 // Bumped to minor version 44 on 2018-12-23 to rename CollisionTube to CollisionCapsule.
 // Bumped to minor version 45 on 2020-03-18 to add Texture::_clear_color.
+// Bumped to minor version 46 on 2020-08-   to add BamWriter::TexCompressionLv.
 
 #endif

--- a/panda/src/putil/bam.h
+++ b/panda/src/putil/bam.h
@@ -66,6 +66,6 @@ static const unsigned short _bam_minor_ver = 44;
 // Bumped to minor version 43 on 2018-12-06 to expand BillboardEffect and CompassEffect.
 // Bumped to minor version 44 on 2018-12-23 to rename CollisionTube to CollisionCapsule.
 // Bumped to minor version 45 on 2020-03-18 to add Texture::_clear_color.
-// Bumped to minor version 46 on 2020-08-   to add BamWriter::TexCompressionLv.
+// Bumped to minor version 46 on 2020-08-   to add BamEnums::TexCompressionFormat.
 
 #endif

--- a/panda/src/putil/bamEnums.cxx
+++ b/panda/src/putil/bamEnums.cxx
@@ -122,3 +122,33 @@ operator >> (istream &in, BamEnums::BamTextureMode &btm) {
 
   return in;
 }
+
+ostream &
+operator << (ostream &out, BamEnums::BamTexCompressionLv btc) {
+  switch (btc) {
+  case BamEnums::BTC_off:
+    return out << "off";
+
+  case BamEnums::BTC_on:
+    return out << "on";
+  }
+
+  return out << "**invalid BamEnums::BamTexCompressionLv (" << (int)btc << ")**";
+}
+
+istream &
+operator >> (istream &in, BamEnums::BamTexCompressionLv &btc) {
+  string word;
+  in >> word;
+
+  if (cmp_nocase(word, "off") == 0) {
+    btc = BamEnums::BTC_off;
+  } else if (cmp_nocase(word, "on") == 0) {
+    btc = BamEnums::BTC_on;
+  } else {
+    util_cat->error() << "Invalid BamEnums::BamTexCompressionLv value: " << word << "\n";
+    btc = BamEnums::BTC_off;
+  }
+
+  return in;
+}

--- a/panda/src/putil/bamEnums.cxx
+++ b/panda/src/putil/bamEnums.cxx
@@ -124,29 +124,29 @@ operator >> (istream &in, BamEnums::BamTextureMode &btm) {
 }
 
 ostream &
-operator << (ostream &out, BamEnums::BamTexCompressionLv btc) {
+operator << (ostream &out, BamEnums::BamTexCompressionFormat btc) {
   switch (btc) {
   case BamEnums::BTC_off:
     return out << "off";
 
-  case BamEnums::BTC_on:
-    return out << "on";
+  case BamEnums::BTC_zlib:
+    return out << "zlib";
   }
 
-  return out << "**invalid BamEnums::BamTexCompressionLv (" << (int)btc << ")**";
+  return out << "**invalid BamEnums::BamTexCompressionFormat (" << (int)btc << ")**";
 }
 
 istream &
-operator >> (istream &in, BamEnums::BamTexCompressionLv &btc) {
+operator >> (istream &in, BamEnums::BamTexCompressionFormat &btc) {
   string word;
   in >> word;
 
   if (cmp_nocase(word, "off") == 0) {
     btc = BamEnums::BTC_off;
-  } else if (cmp_nocase(word, "on") == 0) {
-    btc = BamEnums::BTC_on;
+  } else if (cmp_nocase(word, "zlib") == 0) {
+    btc = BamEnums::BTC_zlib;
   } else {
-    util_cat->error() << "Invalid BamEnums::BamTexCompressionLv value: " << word << "\n";
+    util_cat->error() << "Invalid BamEnums::BamTexCompressionFormat value: " << word << "\n";
     btc = BamEnums::BTC_off;
   }
 

--- a/panda/src/putil/bamEnums.h
+++ b/panda/src/putil/bamEnums.h
@@ -71,9 +71,9 @@ PUBLISHED:
   };
 
   // Level of compression for textures in the .bam
-  enum BamTexCompressionLv{
+  enum BamTexCompressionFormat{
     BTC_off,
-    BTC_on,
+    BTC_zlib,
   };
 };
 
@@ -85,6 +85,6 @@ EXPCL_PANDA_PUTIL std::ostream &operator << (std::ostream &out, BamEnums::BamObj
 EXPCL_PANDA_PUTIL std::ostream &operator << (std::ostream &out, BamEnums::BamTextureMode btm);
 EXPCL_PANDA_PUTIL std::istream &operator >> (std::istream &in, BamEnums::BamTextureMode &btm);
 
-EXPCL_PANDA_PUTIL std::ostream &operator << (std::ostream &out, BamEnums::BamTexCompressionLv btc);
-EXPCL_PANDA_PUTIL std::istream &operator >> (std::istream &in, BamEnums::BamTexCompressionLv &btc);
+EXPCL_PANDA_PUTIL std::ostream &operator << (std::ostream &out, BamEnums::BamTexCompressionFormat btc);
+EXPCL_PANDA_PUTIL std::istream &operator >> (std::istream &in, BamEnums::BamTexCompressionFormat &btc);
 #endif

--- a/panda/src/putil/bamEnums.h
+++ b/panda/src/putil/bamEnums.h
@@ -69,6 +69,12 @@ PUBLISHED:
     BTM_basename,
     BTM_rawdata
   };
+
+  // Level of compression for textures in the .bam
+  enum BamTexCompressionLv{
+    BTC_off,
+    BTC_on,
+  };
 };
 
 EXPCL_PANDA_PUTIL std::ostream &operator << (std::ostream &out, BamEnums::BamEndian be);
@@ -79,4 +85,6 @@ EXPCL_PANDA_PUTIL std::ostream &operator << (std::ostream &out, BamEnums::BamObj
 EXPCL_PANDA_PUTIL std::ostream &operator << (std::ostream &out, BamEnums::BamTextureMode btm);
 EXPCL_PANDA_PUTIL std::istream &operator >> (std::istream &in, BamEnums::BamTextureMode &btm);
 
+EXPCL_PANDA_PUTIL std::ostream &operator << (std::ostream &out, BamEnums::BamTexCompressionLv btc);
+EXPCL_PANDA_PUTIL std::istream &operator >> (std::istream &in, BamEnums::BamTexCompressionLv &btc);
 #endif

--- a/panda/src/putil/bamReader.I
+++ b/panda/src/putil/bamReader.I
@@ -98,9 +98,9 @@ get_file_endian() const {
 /**
  * Returns the level of compression for textures in the .bam.
  */
-INLINE BamReader::BamTexCompressionLv BamReader::
-get_texture_compression_level() const {
-  return _tex_compression_level;
+INLINE BamEnums::BamTexCompressionFormat BamReader::
+get_tex_compression_format() const {
+  return _tex_compression_format;
 }
 
 /**

--- a/panda/src/putil/bamReader.I
+++ b/panda/src/putil/bamReader.I
@@ -96,6 +96,14 @@ get_file_endian() const {
 }
 
 /**
+ * Returns the level of compression for textures in the .bam.
+ */
+INLINE BamReader::BamTexCompressionLv BamReader::
+get_texture_compression_level() const {
+  return _tex_compression_level;
+}
+
+/**
  * Returns true if the file stores all "standard" floats as 64-bit doubles, or
  * false if they are 32-bit floats.  This is determined by the compilation
  * flags of the version of Panda that generated this file.

--- a/panda/src/putil/bamReader.cxx
+++ b/panda/src/putil/bamReader.cxx
@@ -133,6 +133,10 @@ init() {
     _file_stdfloat_double = scan.get_bool();
   }
 
+  if(_file_minor >= 46) {
+    _tex_compression_level = (BamTexCompressionLv)scan.get_uint8();
+  }
+
   if (scan.get_current_index() > header.get_length()) {
     bam_cat.error()
       << "Bam header is too short.\n";

--- a/panda/src/putil/bamReader.cxx
+++ b/panda/src/putil/bamReader.cxx
@@ -134,7 +134,15 @@ init() {
   }
 
   if(_file_minor >= 46) {
-    _tex_compression_level = (BamTexCompressionLv)scan.get_uint8();
+    _tex_compression_format = (BamTexCompressionFormat)scan.get_uint8();
+  }
+
+  if(_tex_compression_format == BTC_zlib) {
+#ifndef HAVE_ZLIB
+    bam_cat.error()
+      << "This program can not decompress using zlib"
+      << std::endl;
+#endif
   }
 
   if (scan.get_current_index() > header.get_length()) {

--- a/panda/src/putil/bamReader.h
+++ b/panda/src/putil/bamReader.h
@@ -144,7 +144,7 @@ PUBLISHED:
   INLINE int get_file_minor_ver() const;
   INLINE BamEndian get_file_endian() const;
   INLINE bool get_file_stdfloat_double() const;
-  INLINE BamTexCompressionLv get_texture_compression_level() const;
+  INLINE BamTexCompressionFormat get_tex_compression_format() const;
 
   INLINE int get_current_major_ver() const;
   INLINE int get_current_minor_ver() const;
@@ -336,7 +336,7 @@ private:
   int _file_major, _file_minor;
   BamEndian _file_endian;
   bool _file_stdfloat_double;
-  BamTexCompressionLv _tex_compression_level;
+  BamTexCompressionFormat _tex_compression_format;
   static const int _cur_major;
   static const int _cur_minor;
 };

--- a/panda/src/putil/bamReader.h
+++ b/panda/src/putil/bamReader.h
@@ -144,6 +144,7 @@ PUBLISHED:
   INLINE int get_file_minor_ver() const;
   INLINE BamEndian get_file_endian() const;
   INLINE bool get_file_stdfloat_double() const;
+  INLINE BamTexCompressionLv get_texture_compression_level() const;
 
   INLINE int get_current_major_ver() const;
   INLINE int get_current_minor_ver() const;
@@ -335,6 +336,7 @@ private:
   int _file_major, _file_minor;
   BamEndian _file_endian;
   bool _file_stdfloat_double;
+  BamTexCompressionLv _tex_compression_level;
   static const int _cur_major;
   static const int _cur_minor;
 };

--- a/panda/src/putil/bamWriter.I
+++ b/panda/src/putil/bamWriter.I
@@ -120,3 +120,26 @@ INLINE void BamWriter::
 set_root_node(TypedWritable *root_node) {
   _root_node = root_node;
 }
+
+/**
+ * Returns the level of compression for textures written to the .bam.
+ */
+INLINE BamEnums::BamTexCompressionLv BamWriter::
+get_tex_compress_level() const {
+  return _tex_compression_level;
+}
+
+/**
+ * Sets the level of compression for textures, potentially overriding
+ * the config variable "compress_texture_to_bam". If no ZLIB is found
+ * at compile time, then _tex_compression_level will always be BTC_off.
+ */
+INLINE void BamWriter::
+set_tex_compress_level(BamEnums::BamTexCompressionLv level) {
+#ifndef HAVE_ZLIB
+  _tex_compression_level = BamEnums::BTC_off;
+  return;
+#endif
+
+  _tex_compression_level = level;
+}

--- a/panda/src/putil/bamWriter.I
+++ b/panda/src/putil/bamWriter.I
@@ -124,9 +124,9 @@ set_root_node(TypedWritable *root_node) {
 /**
  * Returns the level of compression for textures written to the .bam.
  */
-INLINE BamEnums::BamTexCompressionLv BamWriter::
-get_tex_compress_level() const {
-  return _tex_compression_level;
+INLINE BamEnums::BamTexCompressionFormat BamWriter::
+get_tex_compression_format() const {
+  return _tex_compression_format;
 }
 
 /**
@@ -135,8 +135,8 @@ get_tex_compress_level() const {
  * at compile time, then _tex_compression_level will always be BTC_off.
  */
 INLINE void BamWriter::
-set_tex_compress_level(BamEnums::BamTexCompressionLv level) {
+set_tex_compression_format(BamEnums::BamTexCompressionFormat format) {
 #ifdef HAVE_ZLIB
-  if(_file_minor >= 46) _tex_compression_level = level;
+  if(_file_minor >= 46) _tex_compression_format = format;
 #endif
 }

--- a/panda/src/putil/bamWriter.I
+++ b/panda/src/putil/bamWriter.I
@@ -136,10 +136,7 @@ get_tex_compress_level() const {
  */
 INLINE void BamWriter::
 set_tex_compress_level(BamEnums::BamTexCompressionLv level) {
-#ifndef HAVE_ZLIB
-  _tex_compression_level = BamEnums::BTC_off;
-  return;
+#ifdef HAVE_ZLIB
+  if(_file_minor >= 46) _tex_compression_level = level;
 #endif
-
-  _tex_compression_level = level;
 }

--- a/panda/src/putil/bamWriter.cxx
+++ b/panda/src/putil/bamWriter.cxx
@@ -100,6 +100,10 @@ BamWriter(DatagramSink *target) :
   _file_endian = bam_endian;
   _file_stdfloat_double = bam_stdfloat_double;
   _file_texture_mode = bam_texture_mode;
+
+  if(_file_minor >= 46) {
+    _tex_compression_level = bam_tex_compression_level;
+  } else _tex_compression_level = BamEnums::BTC_off;
 }
 
 /**
@@ -174,6 +178,9 @@ init() {
   } else {
     _file_stdfloat_double = false;
   }
+
+  // Write out whether texture rawdata will be compressed in .bam
+  header.add_uint8(_tex_compression_level);
 
   if (!_target->put_datagram(header)) {
     util_cat.error()

--- a/panda/src/putil/bamWriter.cxx
+++ b/panda/src/putil/bamWriter.cxx
@@ -102,8 +102,8 @@ BamWriter(DatagramSink *target) :
   _file_texture_mode = bam_texture_mode;
 
   if(_file_minor >= 46) {
-    _tex_compression_level = bam_tex_compression_level;
-  } else _tex_compression_level = BamEnums::BTC_off;
+    _tex_compression_format = bam_tex_compression_format;
+  } else _tex_compression_format = BamEnums::BTC_off;
 }
 
 /**
@@ -180,7 +180,7 @@ init() {
   }
 
   // Write out whether texture rawdata will be compressed in .bam
-  header.add_uint8(_tex_compression_level);
+  header.add_uint8(_tex_compression_format);
 
   if (!_target->put_datagram(header)) {
     util_cat.error()

--- a/panda/src/putil/bamWriter.h
+++ b/panda/src/putil/bamWriter.h
@@ -87,6 +87,9 @@ PUBLISHED:
   INLINE TypedWritable *get_root_node() const;
   INLINE void set_root_node(TypedWritable *root_node);
 
+  INLINE BamEnums::BamTexCompressionLv get_tex_compress_level() const;
+  INLINE void set_tex_compress_level(BamEnums::BamTexCompressionLv level);
+
 PUBLISHED:
   MAKE_PROPERTY(target, get_target, set_target);
   MAKE_PROPERTY(filename, get_filename);
@@ -94,6 +97,7 @@ PUBLISHED:
   MAKE_PROPERTY(file_stdfloat_double, get_file_stdfloat_double);
   MAKE_PROPERTY(file_texture_mode, get_file_texture_mode);
   MAKE_PROPERTY(root_node, get_root_node, set_root_node);
+  MAKE_PROPERTY(tex_compression_level, get_tex_compress_level, set_tex_compress_level);
 
 public:
   // Functions to support classes that write themselves to the Bam.
@@ -187,6 +191,8 @@ private:
   // The destination to write all the output to.
   DatagramSink *_target;
   bool _needs_init;
+
+  BamTexCompressionLv _tex_compression_level;
 
   friend class TypedWritable;
 };

--- a/panda/src/putil/bamWriter.h
+++ b/panda/src/putil/bamWriter.h
@@ -87,8 +87,8 @@ PUBLISHED:
   INLINE TypedWritable *get_root_node() const;
   INLINE void set_root_node(TypedWritable *root_node);
 
-  INLINE BamEnums::BamTexCompressionLv get_tex_compress_level() const;
-  INLINE void set_tex_compress_level(BamEnums::BamTexCompressionLv level);
+  INLINE BamEnums::BamTexCompressionFormat get_tex_compression_format() const;
+  INLINE void set_tex_compression_format(BamEnums::BamTexCompressionFormat level);
 
 PUBLISHED:
   MAKE_PROPERTY(target, get_target, set_target);
@@ -97,7 +97,7 @@ PUBLISHED:
   MAKE_PROPERTY(file_stdfloat_double, get_file_stdfloat_double);
   MAKE_PROPERTY(file_texture_mode, get_file_texture_mode);
   MAKE_PROPERTY(root_node, get_root_node, set_root_node);
-  MAKE_PROPERTY(tex_compression_level, get_tex_compress_level, set_tex_compress_level);
+  MAKE_PROPERTY(tex_compression_format, get_tex_compression_format, set_tex_compression_format);
 
 public:
   // Functions to support classes that write themselves to the Bam.
@@ -192,7 +192,7 @@ private:
   DatagramSink *_target;
   bool _needs_init;
 
-  BamTexCompressionLv _tex_compression_level;
+  BamTexCompressionFormat _tex_compression_format;
 
   friend class TypedWritable;
 };

--- a/panda/src/putil/config_putil.cxx
+++ b/panda/src/putil/config_putil.cxx
@@ -89,17 +89,16 @@ ConfigVariableEnum<BamEnums::BamTextureMode> bam_texture_mode
  PRC_DESC("Set this to specify how textures should be written into Bam files."
           "See the panda source or documentation for available options."));
 
-ConfigVariableEnum<BamEnums::BamTexCompressionLv> bam_tex_compression_level
-("bam-tex-compression-level",
+ConfigVariableEnum<BamEnums::BamTexCompressionFormat> bam_tex_compression_format
+("bam-tex-compression-format",
  #ifndef HAVE_ZLIB
    BamEnums::BTC_off,
  #else
-   BamEnums::BTC_on,
+   BamEnums::BTC_zlib,
  #endif
- PRC_DESC("Set this to BTC_on to compress textures on the fly as they are "
-          "being written into bam files. Specifically, this changes the "
-          "meaning of set_compression(BamEnums::BC_default) to BTC_on."
-          "This variable will be BTC_off in case ZLib is not found."));
+ PRC_DESC("Set this to BTC_zlib to compress textures on the fly as they are "
+          "being written into bam files. This variable will be BTC_off "
+          "in case ZLib is not found."));
 
 ConfigureFn(config_putil) {
   init_libputil();

--- a/panda/src/putil/config_putil.cxx
+++ b/panda/src/putil/config_putil.cxx
@@ -89,6 +89,18 @@ ConfigVariableEnum<BamEnums::BamTextureMode> bam_texture_mode
  PRC_DESC("Set this to specify how textures should be written into Bam files."
           "See the panda source or documentation for available options."));
 
+ConfigVariableEnum<BamEnums::BamTexCompressionLv> bam_tex_compression_level
+("bam-tex-compression-level",
+ #ifndef HAVE_ZLIB
+   BamEnums::BTC_off,
+ #else
+   BamEnums::BTC_on,
+ #endif
+ PRC_DESC("Set this to BTC_on to compress textures on the fly as they are "
+          "being written into bam files. Specifically, this changes the "
+          "meaning of set_compression(BamEnums::BC_default) to BTC_on."
+          "This variable will be BTC_off in case ZLib is not found."));
+
 ConfigureFn(config_putil) {
   init_libputil();
 }

--- a/panda/src/putil/config_putil.h
+++ b/panda/src/putil/config_putil.h
@@ -39,7 +39,7 @@ extern EXPCL_PANDA_PUTIL ConfigVariableInt bam_version;
 extern EXPCL_PANDA_PUTIL ConfigVariableEnum<BamEnums::BamEndian> bam_endian;
 extern EXPCL_PANDA_PUTIL ConfigVariableBool bam_stdfloat_double;
 extern EXPCL_PANDA_PUTIL ConfigVariableEnum<BamEnums::BamTextureMode> bam_texture_mode;
-extern EXPCL_PANDA_PUTIL ConfigVariableEnum<BamEnums::BamTexCompressionLv> bam_tex_compression_level;
+extern EXPCL_PANDA_PUTIL ConfigVariableEnum<BamEnums::BamTexCompressionFormat> bam_tex_compression_format;
 
 BEGIN_PUBLISH
 EXPCL_PANDA_PUTIL ConfigVariableSearchPath &get_model_path();

--- a/panda/src/putil/config_putil.h
+++ b/panda/src/putil/config_putil.h
@@ -39,6 +39,7 @@ extern EXPCL_PANDA_PUTIL ConfigVariableInt bam_version;
 extern EXPCL_PANDA_PUTIL ConfigVariableEnum<BamEnums::BamEndian> bam_endian;
 extern EXPCL_PANDA_PUTIL ConfigVariableBool bam_stdfloat_double;
 extern EXPCL_PANDA_PUTIL ConfigVariableEnum<BamEnums::BamTextureMode> bam_texture_mode;
+extern EXPCL_PANDA_PUTIL ConfigVariableEnum<BamEnums::BamTexCompressionLv> bam_tex_compression_level;
 
 BEGIN_PUBLISH
 EXPCL_PANDA_PUTIL ConfigVariableSearchPath &get_model_path();


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
This PR is aimed to resolve issue #745 .

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
This is still a work in progress and a bug probably exists, as turning `bam-tex-compression-level` to `on` doesn't seems to make the .bam file smaller.
Also, as suggested by @Moguri , I checked out the comparison between zlib and other algorithms. Since the decompression speed is of concern, I think lz4 is better suited for the issue.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
