### PR TITLE
tests: Account for clock inaccuracies in all ClockObject tests

### DIFF
--- a/tests/putil/test_clockobject.py
+++ b/tests/putil/test_clockobject.py
@@ -5,13 +5,13 @@ import sys
 
 # We must account for clock inaccuracy
 if sys.platform == 'win32' or sys.platform == 'cygwin':
-    # Assume 17 milliseconds inaccuracy on Windows (worst case)
-    # 16 milliseconds plus 1 millisecond for execution time
-    CLOCK_INACCURACY = 0.017
+    # Assume 19 milliseconds inaccuracy on Windows (worst case)
+    # 16 milliseconds plus 3 milliseconds for execution time
+    CLOCK_INACCURACY = 0.019
 else:
-    # On other platforms, assume 1 milliseconds, allowing for execution time
-    # (1000 times higher than their actual 1 microsecond accuracy)
-    CLOCK_INACCURACY = 0.001
+    # On other platforms, assume 5 milliseconds, allowing for execution time
+    # (5000 times higher than their actual 1 microsecond accuracy)
+    CLOCK_INACCURACY = 0.005
 
 
 def test_clock_get_frame_time(clockobj):

--- a/tests/putil/test_clockobject.py
+++ b/tests/putil/test_clockobject.py
@@ -1,4 +1,17 @@
+import math
 import time
+import sys
+
+
+# We must account for clock inaccuracy
+if sys.platform == 'win32' or sys.platform == 'cygwin':
+    # Assume 17 milliseconds inaccuracy on Windows (worst case)
+    # 16 milliseconds plus 1 millisecond for execution time
+    CLOCK_INACCURACY = 0.017
+else:
+    # On other platforms, assume 1 milliseconds, allowing for execution time
+    # (1000 times higher than their actual 1 microsecond accuracy)
+    CLOCK_INACCURACY = 0.001
 
 
 def test_clock_get_frame_time(clockobj):
@@ -16,13 +29,13 @@ def test_clock_jump_frame_time(clockobj):
 def test_clock_get_real_time(clockobj):
     current_time = clockobj.get_real_time()
     time.sleep(0.4)
-    assert clockobj.get_real_time() - current_time >= 0.39
+    assert math.isclose(clockobj.get_real_time() - current_time, 0.4, abs_tol=CLOCK_INACCURACY)
 
 
 def test_clock_get_long_time(clockobj):
     current_time = clockobj.get_long_time()
     time.sleep(0.4)
-    assert clockobj.get_long_time() - current_time >= 0.39
+    assert math.isclose(clockobj.get_long_time() - current_time, 0.4, abs_tol=CLOCK_INACCURACY)
 
 
 def test_clock_get_dt(clockobj):
@@ -37,4 +50,4 @@ def test_clock_reset(clockobj):
     clockobj.reset()
     assert clockobj.get_dt() == 0
     assert clockobj.get_frame_time() == 0
-    assert clockobj.get_real_time() < 0.01
+    assert clockobj.get_real_time() <= CLOCK_INACCURACY

--- a/tests/putil/test_clockobject.py
+++ b/tests/putil/test_clockobject.py
@@ -1,7 +1,8 @@
-import math
 import time
 import sys
 
+# Epsilon for taking floating point calculation inaccuracies in mind
+EPSILON = 1e-06
 
 # We must account for clock inaccuracy
 if sys.platform == 'win32' or sys.platform == 'cygwin':
@@ -29,13 +30,13 @@ def test_clock_jump_frame_time(clockobj):
 def test_clock_get_real_time(clockobj):
     current_time = clockobj.get_real_time()
     time.sleep(0.4)
-    assert math.isclose(clockobj.get_real_time() - current_time, 0.4, abs_tol=CLOCK_INACCURACY)
+    assert clockobj.get_real_time() - current_time + EPSILON >= 0.4 - CLOCK_INACCURACY
 
 
 def test_clock_get_long_time(clockobj):
     current_time = clockobj.get_long_time()
     time.sleep(0.4)
-    assert math.isclose(clockobj.get_long_time() - current_time, 0.4, abs_tol=CLOCK_INACCURACY)
+    assert clockobj.get_long_time() - current_time + EPSILON >= 0.4 - CLOCK_INACCURACY
 
 
 def test_clock_get_dt(clockobj):
@@ -50,4 +51,4 @@ def test_clock_reset(clockobj):
     clockobj.reset()
     assert clockobj.get_dt() == 0
     assert clockobj.get_frame_time() == 0
-    assert clockobj.get_real_time() <= CLOCK_INACCURACY
+    assert clockobj.get_real_time() - EPSILON <= CLOCK_INACCURACY


### PR DESCRIPTION
## Issue description
This pull request intends to solve issue #997.

Sometimes, `test_clock_get_long_time` errors when running the test suite on Windows, more often on the GitHub CI.

This is a Windows-specific issue. given that GetTickCount is unreliable and only offers 10 milliseconds of accuracy (see https://github.com/panda3d/panda3d/blob/master/panda/src/express/trueClock.cxx#L74 and https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-gettickcount).

Therefore, we must account for clock inaccuracies when conducting ClockObject tests.

## Solution description
This PR solves the problem by introducing clock inaccuracies into the test.

On Windows, the clock inaccuracy is perceived as 16 milliseconds, as per the Microsoft documentation. This is a worst case scenario, as the best case scenario would be a 10 millisecond inaccuracy.

On Unix systems, the actual clock inaccuracy is 10^-6 seconds (1 microsecond), but to prevent any potential timing issues I have set it as 1 millisecond for the time being.

`math.isclose` has been available since Python 3.5, so its usage should not be a problem. It also accounts for floating point inaccuracies, with an epsilon of 1e-09.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
