### PR TITLE
putil: Turn UniqueIdAllocator's free into an atomic operation

### DIFF
--- a/panda/src/putil/uniqueIdAllocator.cxx
+++ b/panda/src/putil/uniqueIdAllocator.cxx
@@ -195,7 +195,9 @@ is_allocated(uint32_t id) {
  * Free an allocated index (index must be between _min and _max that were
  * passed to the constructor).
  *
- * Returns true if the index has been freed successfully.
+ * Since 1.11.0, returns true if the index has been freed successfully
+ * or false if the index has not been allocated yet, instead of
+ * triggering an assertion.
  */
 bool UniqueIdAllocator::
 free(uint32_t id) {

--- a/panda/src/putil/uniqueIdAllocator.cxx
+++ b/panda/src/putil/uniqueIdAllocator.cxx
@@ -194,20 +194,32 @@ is_allocated(uint32_t id) {
 /**
  * Free an allocated index (index must be between _min and _max that were
  * passed to the constructor).
+ *
+ * Returns true if the index has been freed successfully.
  */
-void UniqueIdAllocator::
+bool UniqueIdAllocator::
 free(uint32_t id) {
   LightMutexHolder holder(_lock);
 
   uniqueIdAllocator_debug("free("<<id<<")");
 
-  nassertv(id >= _min && id <= _max); // Attempt to free out-of-range id.
+  if (id < _min || id > _max) {
+    // Attempt to free out-of-range id.
+    return false;
+  }
+
   uint32_t index = id - _min; // Convert to _table index.
-  nassertv(_table[index] == IndexAllocated); // Attempt to free non-allocated id.
+
+  if (_table[index] != IndexAllocated) {
+    // Attempt to free non-allocated id.
+    return false;
+  }
+
   if (_next_free != IndexEnd) {
-    nassertv(_table[_last_free] == IndexEnd);
+    nassertr(_table[_last_free] == IndexEnd, false);
     _table[_last_free] = index;
   }
+
   _table[index] = IndexEnd; // Mark this element as the end of the list.
   _last_free = index;
 
@@ -217,6 +229,7 @@ free(uint32_t id) {
   }
 
   ++_free;
+  return true;
 }
 
 

--- a/panda/src/putil/uniqueIdAllocator.h
+++ b/panda/src/putil/uniqueIdAllocator.h
@@ -46,7 +46,7 @@ PUBLISHED:
 
   bool is_allocated(uint32_t index);
 
-  void free(uint32_t index);
+  bool free(uint32_t index);
   PN_stdfloat fraction_used() const;
 
   void output(std::ostream &out) const;

--- a/tests/putil/test_uniqueidallocator.py
+++ b/tests/putil/test_uniqueidallocator.py
@@ -75,7 +75,7 @@ def test_free():
 
     assert allocator.allocate() == 0
     assert allocator.is_allocated(0)
-    allocator.free(0)
+    assert allocator.free(0)
     assert not allocator.is_allocated(0)
 
 
@@ -87,13 +87,30 @@ def test_free_reallocation():
         assert allocator.is_allocated(i)
 
     for i in range(1, 5 + 1):
-        allocator.free(i)
+        assert allocator.free(i)
 
     for i in range(1, 5 + 1):
         assert not allocator.is_allocated(i)
         assert allocator.allocate() == i
 
     assert allocator.allocate() == IndexEnd
+
+
+def test_free_unallocated():
+    allocator = UniqueIdAllocator(0, 2)
+
+    assert allocator.allocate() == 0
+    assert allocator.free(0)
+
+    for i in range(0, 2 + 1):
+        assert not allocator.free(i)
+
+
+def test_free_bounds():
+    allocator = UniqueIdAllocator(1, 3)
+
+    assert not allocator.free(0) # Out of range, left side
+    assert not allocator.free(4) # Out of range, right side
 
 
 def test_free_reallocation_mid():
@@ -103,8 +120,8 @@ def test_free_reallocation_mid():
         assert allocator.allocate() == i
         assert allocator.is_allocated(i)
 
-    allocator.free(2)
-    allocator.free(3)
+    assert allocator.free(2)
+    assert allocator.free(3)
 
     assert allocator.allocate() == 2
     assert allocator.allocate() == 3
@@ -115,7 +132,7 @@ def test_free_initial_reserve_id():
     allocator = UniqueIdAllocator(1, 3)
 
     allocator.initial_reserve_id(1)
-    allocator.free(1)
+    assert allocator.free(1)
     assert allocator.allocate() == 2
     assert allocator.allocate() == 3
     assert allocator.allocate() == 1


### PR DESCRIPTION
## Issue description
Currently, using the "free" method on an UniqueIdAllocator is relatively dangerous.

If you free an ID that has not been allocated yet, you will trigger an `_table[index] == IndexAllocated`  assert on debug builds. (I presume it causes a crash on release builds.)

A previous commit, fb0807d7696142d403bb6b18e14acabbdf2b9308, attempted to solve this issue by adding an `is_allocated` function, which could be called before freeing an ID.

However, we haven't considered the fact that UniqueIdAllocators might be used by more than one thread at once!

What happens if you check if an ID is allocated, then attempt to free it while another thread frees it in the background?

Even though you've checked for the allocation state already, since some other thread has already freed that ID, you'll run into the same assert, even with the `is_allocated` safeguard.

## Solution description
I propose that we turn `void UniqueIdAllocator::free(uint32_t id)`'s function signature into `bool UniqueIdAllocator::free(uint32_t id)` instead.

When a unique ID free attempt is made, the method will now return `false` if the ID could not be freed (either it's out of bounds or already freed) or `true` if the ID was freed successfully.

This way, `free` turns into an atomic operation that encapsulates the `is_allocated` safeguard without any risk of other threads interfering.

This turns code like:

```python
allocator = UniqueIdAllocator()

if allocator.is_allocated(500):
    allocator.free(500)
    print('Freed ID')
```

into code like this:

```python
allocator = UniqueIdAllocator()

if allocator.free(500):
    print('Freed ID')
```

which looks so much safer and cleaner.

We should still keep the `is_allocated` method. It certainly has other uses besides being a safeguard - it could be used for statistics in an admin panel, for example.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.