### PR TITLE
direct: Clean up broken usage of "types" module with Python 3

### DIFF
--- a/direct/src/fsm/State.py
+++ b/direct/src/fsm/State.py
@@ -32,16 +32,12 @@ class State(DirectObject):
                 if type(enterFunc) == types.MethodType:
                     if enterFunc.__func__ == oldFunction:
                         # print 'found: ', enterFunc, oldFunction
-                        state.setEnterFunc(types.MethodType(newFunction,
-                                                            enterFunc.__self__,
-                                                            enterFunc.__self__.__class__))
+                        state.setEnterFunc(types.MethodType(newFunction, enterFunc.__self__))
                         count += 1
                 if type(exitFunc) == types.MethodType:
                     if exitFunc.__func__ == oldFunction:
                         # print 'found: ', exitFunc, oldFunction
-                        state.setExitFunc(types.MethodType(newFunction,
-                                                           exitFunc.__self__,
-                                                           exitFunc.__self__.__class__))
+                        state.setExitFunc(types.MethodType(newFunction, exitFunc.__self__))
                         count += 1
             return count
 
@@ -215,18 +211,3 @@ class State(DirectObject):
     def __str__(self):
         return "State: name = %s, enter = %s, exit = %s, trans = %s, children = %s" %\
                (self.__name, self.__enterFunc, self.__exitFunc, self.__transitions, self.__FSMList)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/direct/src/interval/FunctionInterval.py
+++ b/direct/src/interval/FunctionInterval.py
@@ -36,9 +36,7 @@ class FunctionInterval(Interval.Interval):
                 if type(ival.function) == types.MethodType:
                     if ival.function.__func__ == oldFunction:
                         # print 'found: ', ival.function, oldFunction
-                        ival.function = types.MethodType(newFunction,
-                                                         ival.function.__self__,
-                                                         ival.function.__self__.__class__)
+                        ival.function = types.MethodType(newFunction, ival.function.__self__)
                         count += 1
             return count
 

--- a/direct/src/showbase/ContainerLeakDetector.py
+++ b/direct/src/showbase/ContainerLeakDetector.py
@@ -5,13 +5,21 @@ from direct.showbase.Job import Job
 import types, weakref, random, sys
 import builtins
 
-deadEndTypes = (bool, types.BuiltinFunctionType,
-                types.BuiltinMethodType, complex,
-                float, int,
-                type(None), type(NotImplemented),
-                type, types.CodeType, types.FunctionType,
-                bytes, str, tuple)
+deadEndTypes = [
+    types.BuiltinFunctionType, types.BuiltinMethodType,
+    types.CodeType, types.FunctionType,
+    types.GeneratorType, types.CoroutineType,
+    types.AsyncGeneratorType,
+    bool, complex, float, int, type,
+    bytes, str, list, tuple,
+    type(None), type(NotImplemented)
+]
 
+if sys.version_info >= (3, 6):
+    if sys.version_info >= (3, 8):
+        deadEndTypes.append(types.CellType)
+
+    deadEndTypes.append(types.AsyncGeneratorType)
 
 def _createContainerLeak():
     def leakContainer(task=None):

--- a/direct/src/showbase/ContainerReport.py
+++ b/direct/src/showbase/ContainerReport.py
@@ -2,7 +2,9 @@ from direct.directnotify.DirectNotifyGlobal import directNotify
 from direct.showbase.PythonUtil import Queue, invertDictLossless
 from direct.showbase.PythonUtil import safeRepr
 from direct.showbase.Job import Job
+from direct.showbase.ContainerLeakDetector import deadEndTypes
 import types
+import io
 
 class ContainerReport(Job):
     notify = directNotify.newCategory("ContainerReport")
@@ -84,15 +86,7 @@ class ContainerReport(Job):
             except:
                 pass
 
-            if type(parentObj) in (types.StringType, types.UnicodeType):
-                continue
-
-            if type(parentObj) in (types.ModuleType, types.InstanceType):
-                child = parentObj.__dict__
-                if self._examine(child):
-                    assert (self._queue.back() is child)
-                    self._instanceDictIds.add(id(child))
-                    self._id2pathStr[id(child)] = str(self._id2pathStr[id(parentObj)])
+            if type(parentObj) in (str, bytes):
                 continue
 
             if type(parentObj) is dict:
@@ -124,7 +118,16 @@ class ContainerReport(Job):
                 del attr
                 continue
 
-            if type(parentObj) is not types.FileType:
+            if hasattr(parentObj, '__dict__'):
+                # Instance of a class
+                child = parentObj.__dict__
+                if self._examine(child):
+                    assert (self._queue.back() is child)
+                    self._instanceDictIds.add(id(child))
+                    self._id2pathStr[id(child)] = str(self._id2pathStr[id(parentObj)])
+                continue
+
+            if not isinstance(parentObj, io.TextIOWrapper):
                 try:
                     itr = iter(parentObj)
                 except:
@@ -159,7 +162,10 @@ class ContainerReport(Job):
                 childName = None
                 child = None
                 for childName in childNames:
-                    child = getattr(parentObj, childName)
+                    try:
+                        child = getattr(parentObj, childName)
+                    except:
+                        continue
                     if id(child) not in self._visitedIds:
                         self._visitedIds.add(id(child))
                         if self._examine(child):
@@ -196,11 +202,7 @@ class ContainerReport(Job):
             self._type2id2len[type(obj)][objId] = length
     def _examine(self, obj):
         # return False if it's an object that can't contain or lead to other objects
-        if type(obj) in (types.BooleanType, types.BuiltinFunctionType,
-                         types.BuiltinMethodType, types.ComplexType,
-                         types.FloatType, types.IntType, types.LongType,
-                         types.NoneType, types.NotImplementedType,
-                         types.TypeType, types.CodeType, types.FunctionType):
+        if type(obj) in deadEndTypes:
             return False
         # if it's an internal object, ignore it
         if id(obj) in ContainerReport.PrivateIds:
@@ -243,7 +245,7 @@ class ContainerReport(Job):
             for i in self._outputType(type, **kArgs):
                 yield None
         otherTypes = list(set(self._type2id2len.keys()).difference(set(initialTypes)))
-        otherTypes.sort()
+        otherTypes.sort(key=lambda obj: obj.__name__)
         for type in otherTypes:
             for i in self._outputType(type, **kArgs):
                 yield None

--- a/direct/src/showbase/Finder.py
+++ b/direct/src/showbase/Finder.py
@@ -22,8 +22,7 @@ def findClass(className):
             # the matching class and a good module namespace to redefine
             # our class in.
             if (classObj and
-                ((type(classObj) == types.ClassType) or
-                 (type(classObj) == types.TypeType)) and
+                (type(classObj) == type) and
                 (classObj.__module__ == moduleName)):
                 return [classObj, module.__dict__]
     return None

--- a/direct/src/showbase/GarbageReport.py
+++ b/direct/src/showbase/GarbageReport.py
@@ -7,7 +7,6 @@ from direct.showbase.PythonUtil import fastRepr
 from direct.showbase.PythonUtil import AlphabetCounter
 from direct.showbase.Job import Job
 import gc
-import types
 
 GarbageCycleCountAnnounceEvent = 'announceGarbageCycleDesc2num'
 
@@ -212,7 +211,7 @@ class GarbageReport(Job):
                     startIndex = 0
                     # + 1 to include a reference back to the first object
                     endIndex = numObjs + 1
-                    if type(objs[-1]) is types.InstanceType and type(objs[0]) is dict:
+                    if hasattr(objs[-1], '__dict__') and type(objs[0]) is dict:
                         startIndex -= 1
                         endIndex -= 1
 
@@ -221,7 +220,8 @@ class GarbageReport(Job):
                             numToSkip -= 1
                             continue
                         obj = objs[index]
-                        if type(obj) is types.InstanceType:
+                        if hasattr(obj, '__dict__'):
+                            # Instance of a class
                             if not objAlreadyRepresented:
                                 cycleBySyntax += '%s' % obj.__class__.__name__
                             cycleBySyntax += '.'

--- a/direct/src/showbase/Messenger.py
+++ b/direct/src/showbase/Messenger.py
@@ -464,8 +464,7 @@ class Messenger:
                 #       'oldMethod: ' + repr(oldMethod) + '\n' +
                 #       'newFunction: ' + repr(newFunction) + '\n')
                 if (function == oldMethod):
-                    newMethod = types.MethodType(
-                        newFunction, method.__self__, method.__self__.__class__)
+                    newMethod = types.MethodType(newFunction, method.__self__)
                     params[0] = newMethod
                     # Found it retrun true
                     retFlag += 1

--- a/direct/src/showbase/PythonUtil.py
+++ b/direct/src/showbase/PythonUtil.py
@@ -1561,7 +1561,7 @@ def appendStr(obj, st):
             return s
         oldStr = Functor(stringer, str(obj))
         stringer = None
-    obj.__str__ = types.MethodType(Functor(appendedStr, oldStr, st), obj, obj.__class__)
+    obj.__str__ = types.MethodType(Functor(appendedStr, oldStr, st), obj)
     appendedStr = None
     return obj
 

--- a/direct/src/task/Task.py
+++ b/direct/src/task/Task.py
@@ -593,9 +593,7 @@ class TaskManager:
         else:
             function = method
         if (function == oldMethod):
-            newMethod = types.MethodType(newFunction,
-                                         method.__self__,
-                                         method.__self__.__class__)
+            newMethod = types.MethodType(newFunction, method.__self__)
             task.setFunction(newMethod)
             # Found a match
             return 1


### PR DESCRIPTION
## Issue description
During the migration to Python 3, some functionality in old direct scripts has been broken.

Some of these breakages pertain to old scripts that are no longer being used (by anyone, I believe), mostly `DirectMySQLdbConnection` and `Finder`.

For starters, a lot of the types that have been defined in Python 2 through the `types` module are now removed.

Some new types have also been added that, if not ignored, throw off the results of the `GarbageReport` class (types.CellType in particular after Python 3.8).

`types.MethodType`'s constructor now only accepts two arguments, rather than three. The functionality related to the third argument has been completely removed in Python 3.

## Solution description
This PR fixes some of the issues that were brought upon by the migration to Python 3.

All incorrect usage of the `types` module have been corrected to reflect the current state of the language.

My only concern is that `DirectMySQLdbConnection`'s behavior regarding strings has technically changed. When encountering a `string` object, Panda3D will now try to decode the string object into the encoding used by the database. This is also the new default strategy of the `mysqlclient` Python library. It should not break any existing code (since this class has never worked in Python 3), but there is always the possibility of the end user completing their own Python 2->3 migration incorrectly.

I would like to propose the removal of the `DirectMySQLdbConnection` class, however. It depends on `MySQLdb` (provided by `mysqlclient`) and is an old, copy pasted version of the `Connection` class (with VR Studio-specific changes to solve an old mysqlclient bug).

We have three options:
1. Keep `DirectMySQLdbConnection` as-is for now (not a good idea, IMO)
2. Remove `DirectMySQLdbConnection` and have users just use `mysqlclient`
3. Keep `DirectMySQLdbConnection`, but replace it with the following import: `from MySQLdb.connections import Connection as 
DirectMySQLdbConnection`

As somebody who has been using `direct` for a long time, I seriously do not believe anyone is relying on `DirectMySQLdbConnection` at this point. It's been broken for a while and nobody has complained so far, either. I'd recommend we remove the class in the 1.11.0 release, together with `DirectMySQLdb`.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
