### PR TITLE
mayaegg: Fix animations not being created during egg traversal

### DIFF
--- a/pandatool/src/maya/maya_funcs.cxx
+++ b/pandatool/src/maya/maya_funcs.cxx
@@ -519,8 +519,8 @@ describe_compound_attribute(MObject &node) {
   for (size_t i = 0; i < comp_attr.numChildren(); i++) {
     MObject child = comp_attr.child(i, &status);
     if (child.apiType() == MFn::kAttribute3Float){
-      LRGBColor color;
       /*
+      LRGBColor color;
       if (get_vec3_attribute(child, "color", color)) {
         maya_cat.info() << "color: " << color << endl;
       }

--- a/pandatool/src/mayaegg/mayaEggLoader.cxx
+++ b/pandatool/src/mayaegg/mayaEggLoader.cxx
@@ -1572,7 +1572,8 @@ void MayaEggLoader::TraverseEggNode(EggNode *node, EggGroup *context, string del
         mayaloader_cat.debug() << delim+delstring << "found an EggTable: " << node->get_name() << endl;
       }
     } else if (node->is_of_type(EggXfmSAnim::get_class_type())) {
-      //MayaAnim *anim = GetAnim(DCAST(EggXfmSAnim, node));
+      // Create a MayaAnim equivalent of the EggXfmSAnim
+      GetAnim(DCAST(EggXfmSAnim, node));
       //anim->PrintData();
       if (mayaloader_cat.is_debug()) {
         mayaloader_cat.debug() << delim+delstring << "found an EggXfmSAnim: " << node->get_name() << endl;


### PR DESCRIPTION
## Issue description
The maya2egg utilities do not convert any animations from the EGG format back to the Maya format when used.

This even happens when the "-a" flag is provided to enable animation translations.

## Solution description
This is a regression that was introduced by the commit 754344906c657c703de43f2032b254ad2637f72b.

Simply put, a debug print function was removed, but to prevent a compiler warning because of an unused variable, the "GetAnim" method was also removed.

But this is the method that creates the animation entry in the table in the first place!

I've reintroduced this piece of code, and now animations are now converted back to the Maya format correctly.

I've also silenced another compiler warning.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
