### PR TITLE
cocoadisplay: Use [event charactersIgnoringModifiers] when UCKeyTranslate() can not translate the input key

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1762,6 +1762,19 @@ handle_key_event(NSEvent *event) {
     return;
   }
 
+  // If UCKeyTranslate could not map the key into a valid unicode character or
+  // reserved symbol (See NSEvent.h), it returns 0x10 as translated character.
+  // This happens e.g.e with the combination Fn+F1.. keys.
+  // In that case, as fallback, we use charactersIgnoringModifiers to retrieve
+  // the character without modifiers.
+  if (c == 0x10) {
+    NSString *str = [event charactersIgnoringModifiers];
+    if (str == nil || [str length] != 1) {
+      return;
+    }
+    c = [str characterAtIndex: 0];
+  }
+
   ButtonHandle button = map_key(c);
 
   if (button == ButtonHandle::none()) {


### PR DESCRIPTION
## Issue description

This PR aim to fix the regression described in #1001, causing functions key to no longer work on MacBook where they are used in conjunction with the Fn key.

## Solution description

If UCKeyTranslate could not map the key into a valid unicode character or reserved symbol (See NSEvent.h), it returns 0x10 as translated character. This happens e.g.e with the combination Fn+F1.. keys (but for weird reasons not for the arrow keys).
In that case, as fallback, we use [event charactersIgnoringModifiers] to retrieve the character without modifiers.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
