### PR TITLE
build_apps: Disable the pip version check when downloading wheels

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -425,12 +425,13 @@ class build_apps(setuptools.Command):
                     os.remove(os.path.join(whldir, whl))
 
         pip_args = [
+            '--disable-pip-version-check',
             'download',
             '-d', whldir,
             '-r', self.requirements_path,
             '--only-binary', ':all:',
             '--platform', platform,
-            '--abi', abi_tag
+            '--abi', abi_tag,
         ]
 
         if self.use_optimized_wheels:


### PR DESCRIPTION
## Issue description
When downloading wheels as part of `build_apps`, pip will issue warnings about a newer version of pip being available. If the user is not using the latest version of pip, they will likely be
spammed by pip enough as is. There is not much need to remind them about this for each built platform.

## Solution description
Pass `--disable-pip-version-check` to pip when downloading wheels.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
