### PR TITLE
makepanda: MSVC fix generating non-SSE2 code for x86

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -1111,8 +1111,12 @@ def CompileCxx(obj,src,opts):
             cmd += "/DWINVER=0x600 "
 
             cmd += "/Fo" + obj + " /nologo /c"
-            if GetTargetArch() != 'x64' and (not PkgSkip("SSE2") or 'SSE2' in opts):
-                cmd += " /arch:SSE2"
+            if GetTargetArch() == 'x86':
+                # x86 (32 bit) MSVC 2015+ defaults to /arch:SSE2
+                if not PkgSkip("SSE2") or 'SSE2' in opts:   # x86 with SSE2 case
+                    cmd += " /arch:SSE2"    # let's still be explicit and pass in /arch:SSE2
+                else:                                       # x86 without SSE2
+                    cmd += " /arch:IA32"
             for x in ipath: cmd += " /I" + x
             for (opt,dir) in INCDIRECTORIES:
                 if (opt=="ALWAYS") or (opt in opts): cmd += " /I" + BracketNameWithQuotes(dir)

--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -1113,7 +1113,7 @@ def CompileCxx(obj,src,opts):
             cmd += "/Fo" + obj + " /nologo /c"
             if GetTargetArch() == 'x86':
                 # x86 (32 bit) MSVC 2015+ defaults to /arch:SSE2
-                if not PkgSkip("SSE2") or 'SSE2' in opts:   # x86 with SSE2 case
+                if not PkgSkip("SSE2") or 'SSE2' in opts:   # x86 with SSE2
                     cmd += " /arch:SSE2"    # let's still be explicit and pass in /arch:SSE2
                 else:                                       # x86 without SSE2
                     cmd += " /arch:IA32"


### PR DESCRIPTION
## Issue description
Fix for #1017

## Solution description
We are now passing in /arch:IA32 for x86 when no SSE2 is requested.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.

Fixes #1017