### PR TITLE
pgraph: add the ability to store a pointer to user data on nodes

### DIFF
--- a/panda/src/pgraph/nodePath.I
+++ b/panda/src/pgraph/nodePath.I
@@ -2076,6 +2076,42 @@ list_tags() const {
 }
 
 /**
+ * Stores on the node a pointer to some data that is meaningful to the user.
+ */
+INLINE void NodePath::
+set_user_data(TypedReferenceCount *data) {
+  nassertv_always(!is_empty());
+  node()->set_user_data(data);
+}
+
+/**
+ * Clears the user data pointer stored on the node.
+ */
+INLINE void NodePath::
+clear_user_data() {
+  nassertv_always(!is_empty());
+  node()->clear_user_data();
+}
+
+/**
+ * Returns true if the node has a user data pointer, false if it does not.
+ */
+INLINE bool NodePath::
+has_user_data() const {
+  nassertr_always(!is_empty(), false);
+  return node()->has_user_data();
+}
+
+/**
+ * Returns the user data pointer that was stored on the node.
+ */
+INLINE TypedReferenceCount *NodePath::
+get_user_data() const {
+  nassertr_always(!is_empty(), nullptr);
+  return node()->get_user_data();
+}
+
+/**
  * Changes the name of the referenced node.
  */
 INLINE void NodePath::

--- a/panda/src/pgraph/nodePath.h
+++ b/panda/src/pgraph/nodePath.h
@@ -940,6 +940,12 @@ PUBLISHED:
 
   INLINE void list_tags() const;
 
+  INLINE void set_user_data(TypedReferenceCount *data);
+  INLINE void clear_user_data();
+  INLINE bool has_user_data() const;
+  INLINE TypedReferenceCount *get_user_data() const;
+  MAKE_PROPERTY(user_data, get_user_data, set_user_data);
+
   INLINE void set_name(const std::string &name);
   INLINE std::string get_name() const;
   MAKE_PROPERTY(name, get_name, set_name);

--- a/panda/src/pgraph/pandaNode.I
+++ b/panda/src/pgraph/pandaNode.I
@@ -407,6 +407,31 @@ has_tags() const {
 }
 
 /**
+ * Clears the user data pointer stored on the node.
+ */
+INLINE void PandaNode::
+clear_user_data() {
+  set_user_data(nullptr);
+}
+
+/**
+ * Returns true if the node has a user data pointer, false if it does not.
+ */
+INLINE bool PandaNode::
+has_user_data() const {
+  return get_user_data() != nullptr;
+}
+
+/**
+ * Returns the user data pointer that was stored on the node.
+ */
+INLINE TypedReferenceCount *PandaNode::
+get_user_data() const {
+  CDReader cdata(_cycler);
+  return cdata->_user_data;
+}
+
+/**
  * Lists all the nodes at and below the current path hierarchically.
  */
 INLINE void PandaNode::

--- a/panda/src/pgraph/pandaNode.cxx
+++ b/panda/src/pgraph/pandaNode.cxx
@@ -159,6 +159,7 @@ PandaNode(const PandaNode &copy) :
 
     cdata->_effects = copy_cdata->_effects;
     cdata->_tag_data = copy_cdata->_tag_data;
+    cdata->_user_data = copy_cdata->_user_data;
     cdata->_draw_control_mask = copy_cdata->_draw_control_mask;
     cdata->_draw_show_mask = copy_cdata->_draw_show_mask;
     cdata->_into_collide_mask = copy_cdata->_into_collide_mask;
@@ -1390,6 +1391,7 @@ copy_all_properties(PandaNode *other) {
     cdataw->_prev_transform = cdatar->_prev_transform;
     cdataw->_state = cdatar->_state;
     cdataw->_effects = cdatar->_effects;
+    cdataw->_user_data = cdatar->_user_data;
     cdataw->_draw_control_mask = cdatar->_draw_control_mask;
     cdataw->_draw_show_mask = cdatar->_draw_show_mask;
 
@@ -3568,6 +3570,19 @@ set_scene_root_func(SceneRootFunc *func) {
 }
 
 /**
+ * Stores on the node a pointer to some data that is meaningful to the user.
+ */
+void PandaNode::
+set_user_data(TypedReferenceCount *data) {
+  Thread *current_thread = Thread::get_current_thread();
+  OPEN_ITERATE_CURRENT_AND_UPSTREAM(_cycler, current_thread) {
+    CDStageWriter cdata(_cycler, pipeline_stage, current_thread);
+    cdata->_user_data = data;
+  }
+  CLOSE_ITERATE_CURRENT_AND_UPSTREAM(_cycler);
+}
+
+/**
  * Tells the BamReader how to create objects of type PandaNode.
  */
 void PandaNode::
@@ -3667,6 +3682,7 @@ CData() :
   _prev_transform(TransformState::make_identity()),
 
   _effects(RenderEffects::make_empty()),
+  _user_data(nullptr),
   _draw_control_mask(DrawMask::all_off()),
   _draw_show_mask(DrawMask::all_on()),
   _into_collide_mask(CollideMask::all_off()),
@@ -3698,6 +3714,7 @@ CData(const PandaNode::CData &copy) :
 
   _effects(copy._effects),
   _tag_data(copy._tag_data),
+  _user_data(copy._user_data),
   _draw_control_mask(copy._draw_control_mask),
   _draw_show_mask(copy._draw_show_mask),
   _into_collide_mask(copy._into_collide_mask),

--- a/panda/src/pgraph/pandaNode.h
+++ b/panda/src/pgraph/pandaNode.h
@@ -198,6 +198,11 @@ PUBLISHED:
   void clear_tag(const std::string &key,
                  Thread *current_thread = Thread::get_current_thread());
 
+  void set_user_data(TypedReferenceCount *data);
+  INLINE void clear_user_data();
+  INLINE bool has_user_data() const;
+  INLINE TypedReferenceCount *get_user_data() const;
+
 public:
   void get_tag_keys(vector_string &keys) const;
   INLINE size_t get_num_tags() const;
@@ -569,6 +574,8 @@ private:
     CPT(RenderEffects) _effects;
 
     TagData _tag_data;
+
+    PT(TypedReferenceCount) _user_data;
 
     // These two together determine the per-camera visibility of this node.
     // See adjust_draw_mask() for details.

--- a/tests/pgraph/test_nodepath.py
+++ b/tests/pgraph/test_nodepath.py
@@ -240,3 +240,19 @@ def test_nodepath_replace_texture():
     path1.replace_texture(tex1, tex2)
     assert not path1.has_texture()
     assert path2.get_texture() == tex2
+
+def test_nodepath_user_data():
+    from panda3d.core import NodePath, BoundingBox
+
+    # Randomly chose this for testing.
+    data = BoundingBox()
+
+    path = NodePath("node")
+    assert not path.has_user_data()
+
+    path.set_user_data(data)
+    assert path.has_user_data()
+    assert path.get_user_data() == data
+
+    path.clear_user_data()
+    assert not path.has_user_data()


### PR DESCRIPTION
## Issue description
This PR adds the ability to store a pointer to custom user data on a node. I needed a way to associate custom data with nodes and be able to access it quickly without having to do a map lookup, string comparison, etc.

## Solution description
The approach taken is to simply store a pointer to a TypedReferenceCount on the node, and allow the user to set the pointer to whatever they like and access it later. I chose TypedReferenceCount so the node can keep a reference to the user data and the user can validate the type.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
