### PR TITLE
x11display: Remove incorrect INLINE marker on these methods

### DIFF
--- a/panda/src/x11display/x11GraphicsPipe.cxx
+++ b/panda/src/x11display/x11GraphicsPipe.cxx
@@ -384,7 +384,7 @@ x11GraphicsPipe::
 /**
  * Enables raw mouse mode for this display.  Returns false if unsupported.
  */
-INLINE bool x11GraphicsPipe::
+bool x11GraphicsPipe::
 enable_raw_mouse() {
   if (_num_raw_mouse_windows > 0) {
     // Already enabled by another window.

--- a/panda/src/x11display/x11GraphicsPipe.h
+++ b/panda/src/x11display/x11GraphicsPipe.h
@@ -147,8 +147,8 @@ public:
   INLINE bool supports_relative_mouse() const;
   INLINE bool enable_dga_mouse();
   INLINE void disable_dga_mouse();
-  INLINE bool enable_raw_mouse();
-  INLINE void disable_raw_mouse();
+  bool enable_raw_mouse();
+  void disable_raw_mouse();
 
   static INLINE int disable_x_error_messages();
   static INLINE int enable_x_error_messages();


### PR DESCRIPTION
## Issue description
These two methods on x11GraphicsPipe were marked INLINE but are defined in the .cxx file.

## Solution description
Removed the INLINE marker.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
