### PR TITLE
git: Ignore SDK folder used by makepanda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /thirdparty/
 /targetroot/
 /dstroot/
+/sdks/
 
 # Core dumps and traces
 core


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
makepanda allows builders to dump the Maya and Max SDKs into a folder called `sdks`. The build system picks up these SDKs from the `sdks` folder, forgoing all of the registry checks and program path searching.

Problem is, Git picks up those SDKs as potential new files.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
I've added the `sdks` folder to the `.gitignore` file. It is no longer possible to accidentally add those files into the version history.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
