### PR TITLE
directtools: Fix empty scaling node of object handle

### DIFF
--- a/direct/src/directtools/DirectManipulation.py
+++ b/direct/src/directtools/DirectManipulation.py
@@ -1066,7 +1066,7 @@ class ObjectHandles(NodePath, DirectObject):
         # Load up object handles model and assign it to self
         self.assign(loader.loadModel('models/misc/objectHandles'))
         self.setName(name)
-        self.scalingNode = NodePath(self)
+        self.scalingNode = self.getChild(0)
         self.scalingNode.setName('ohScalingNode')
         self.ohScalingFactor = 1.0
         self.directScalingFactor = 1.0


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
The commit 98000eaac010f73d2b1cee32849d975bf0d15e0f has broken the scaling node of object handles within the DirectManipulation system. `scalingNode` now refers to an empty model. This leads to `scalingNode.getBounds()` breaking, causing issues during render traversal in the Direct system: `AssertionError: !mat.is_nan() at line 91 of P:\P3D\panda3d\panda\src\mathutil\boundingSphere.cxx`

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
Revert commit 98000eaac010f73d2b1cee32849d975bf0d15e0f. `self.getChild(0)` returns the objectHandles model as expected, which is non-empty (therefore, bounds can now be calculated)

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
