### PR TITLE
openal: Fix paused sounds not resuming from where they were paused

### DIFF
--- a/panda/src/audiotraits/openalAudioSound.cxx
+++ b/panda/src/audiotraits/openalAudioSound.cxx
@@ -831,6 +831,8 @@ set_active(bool active) {
         if (_loop_count==0) {
           // ...we're pausing a looping sound.
           _paused=true;
+          // Store off the current time so we can resume from where we paused.
+          _start_time = get_time();
         }
         stop();
       }

--- a/panda/src/audiotraits/openalAudioSound.cxx
+++ b/panda/src/audiotraits/openalAudioSound.cxx
@@ -831,9 +831,9 @@ set_active(bool active) {
         if (_loop_count==0) {
           // ...we're pausing a looping sound.
           _paused=true;
-          // Store off the current time so we can resume from where we paused.
-          _start_time = get_time();
         }
+        // Store off the current time so we can resume from where we paused.
+        _start_time = get_time();
         stop();
       }
     }


### PR DESCRIPTION
## Issue description
Calling `setActive(False)` on a sound is intended to pause the sound, and a future call to `setActive(True)` is intended to resume the paused sound.  Paused sounds were being restarted instead of resumed where they left off.

## Solution description
Before pausing the sound, store the current time as the start time for when the sound is resumed.  This is what the Miles implementation did, and what FMOD _tries_ to do, but the start time is mistakenly overridden to 0 (I'm working on improving FMOD).

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
