### PR TITLE
dist: Add platform name to NSIS installer filename and generate it into the dist directory

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -1369,7 +1369,6 @@ class bdist_apps(setuptools.Command):
             for i in apps
         ]
 
-        fullname = self.distribution.get_fullname()
         shortname = self.distribution.get_name()
 
         # Create the .nsi installer script
@@ -1379,7 +1378,7 @@ class bdist_apps(setuptools.Command):
 
         # Some global info
         nsi.write('Name "%s"\n' % shortname)
-        nsi.write('OutFile "%s"\n' % (fullname+'.exe'))
+        nsi.write('OutFile "%s"\n' % os.path.join(self.dist_dir, basename+'.exe'))
         if is_64bit:
             nsi.write('InstallDir "$PROGRAMFILES64\\%s"\n' % shortname)
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Games/Entertainment
     Topic :: Multimedia


### PR DESCRIPTION
## Issue description

When generating a NSIS installer, the platform name is missing from the installer filename. If more than one platform is build at the same time, only the installer for the latest one is available.

Also the installer is generated in the build/ directory, not in the dist/ directory, this is because makensis consider OutFile relative to the NSI script file.

## Solution description

Use basename instead of fullname to include the platform, also the path specified for OutFile is concatenated with dist_dir.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
