### PR TITLE
showbase: Fix an entire DirectSession being (re)created on node selection

### DIFF
--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -152,6 +152,7 @@ class ShowBase(DirectObject.DirectObject):
         self.wantStats = self.config.GetBool('want-pstats', 0)
         self.wantTk = False
         self.wantWx = False
+        self.wantDirect = False
 
         #: Fill this in with a function to invoke when the user "exits"
         #: the program by closing the main window.
@@ -3264,7 +3265,12 @@ class ShowBase(DirectObject.DirectObject):
     def startDirect(self, fWantDirect = 1, fWantTk = 1, fWantWx = 0):
         self.startTk(fWantTk)
         self.startWx(fWantWx)
+
+        if self.wantDirect == fWantDirect:
+            return
+
         self.wantDirect = fWantDirect
+
         if self.wantDirect:
             # Use importlib to prevent this import from being picked up
             # by modulefinder when packaging an application.


### PR DESCRIPTION
## Issue description
Selecting nodes in a DIRECT session would often result in a client freeze. I've managed to figure out the source of the problem: Everytime the "select" NodePath extension runs, it calls the following code: `base.startDirect(fWantTk = 0)`, which creates a DirectSession every time it's called, even if a DirectSession is already active. Therefore, multiple DirectSessions are listening for events at the same time, which causes many issues with the Direct system.

## Solution description
ShowBase's `startDirect` method no longer creates another DirectSession if one has already been created.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
