### PR TITLE
panda: Remove PyEval_InitThreads calls when compiling against Python 3.9+

### DIFF
--- a/panda/src/event/pythonTask.cxx
+++ b/panda/src/event/pythonTask.cxx
@@ -71,11 +71,11 @@ PythonTask(PyObject *func_or_coro, const std::string &name) :
 
   __dict__ = PyDict_New();
 
-#ifndef SIMPLE_THREADS
+#if !defined(SIMPLE_THREADS) && defined(WITH_THREAD) && PY_VERSION_HEX < 0x03090000
   // Ensure that the Python threading system is initialized and ready to go.
-#ifdef WITH_THREAD  // This symbol defined within Python.h
+  // WITH_THREAD symbol defined within Python.h
+  // PyEval_InitThreads is now a deprecated no-op in Python 3.9+
   PyEval_InitThreads();
-#endif
 #endif
 }
 

--- a/panda/src/pipeline/pythonThread.cxx
+++ b/panda/src/pipeline/pythonThread.cxx
@@ -38,11 +38,11 @@ PythonThread(PyObject *function, PyObject *args,
 
   set_args(args);
 
-#ifndef SIMPLE_THREADS
+#if !defined(SIMPLE_THREADS) && defined(WITH_THREAD) && PY_VERSION_HEX < 0x03090000
   // Ensure that the Python threading system is initialized and ready to go.
-#ifdef WITH_THREAD  // This symbol defined within Python.h
+  // WITH_THREAD symbol defined within Python.h
+  // PyEval_InitThreads is now a deprecated no-op in Python 3.9+
   PyEval_InitThreads();
-#endif
 #endif
 }
 

--- a/panda/src/putil/pythonCallbackObject.cxx
+++ b/panda/src/putil/pythonCallbackObject.cxx
@@ -41,15 +41,16 @@ PythonCallbackObject(PyObject *function) {
 
   set_function(function);
 
-#ifndef SIMPLE_THREADS
+#if !defined(SIMPLE_THREADS) && defined(WITH_THREAD)
   // Ensure that the Python threading system is initialized and ready to go.
-#ifdef WITH_THREAD  // This symbol defined within Python.h
-
+  // WITH_THREAD symbol defined within Python.h
   Py_Initialize();
 
+#if PY_VERSION_HEX < 0x03090000
+  // PyEval_InitThreads is now a deprecated no-op in Python 3.9+
   PyEval_InitThreads();
-#endif
-#endif
+#endif // PY_VERSION_HEX
+#endif // WITH_THREAD
 }
 
 /**


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
When compiling on Python 3.9, the following compiler warning is shown:
```
[T3] Building C++ object built/tmp/cpython-39-x86_64-linux-gnu/p3event_pythonTask.o
panda/src/event/pythonTask.cxx: In constructor ‘PythonTask::PythonTask(PyObject*, const string&)’:
panda/src/event/pythonTask.cxx:77:22: warning: ‘void PyEval_InitThreads()’ is deprecated [-Wdeprecated-declarations]
   77 |   PyEval_InitThreads();
      |                      ^
```

Browsing the Python C API reference yields the following result: https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads

According to the API reference, in Python 3.9+ PyEval_InitThreads is now a no-op and will be removed in Python 3.11.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
PyEval_InitThreads calls are no longer built into Panda3D when compiling against Python 3.9 and older.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
