### PR TITLE
build_apps: Allow setting hidden imports via setuptools options

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -238,6 +238,7 @@ class build_apps(setuptools.Command):
             self.exclude_dependencies += ['bcrypt.dll']
 
         self.package_data_dirs = {}
+        self.hidden_imports = {}
 
         # We keep track of the zip files we've opened.
         self._zip_files = {}
@@ -271,6 +272,10 @@ class build_apps(setuptools.Command):
         self.platforms = _parse_list(self.platforms)
         self.plugins = _parse_list(self.plugins)
         self.extra_prc_files = _parse_list(self.extra_prc_files)
+        self.hidden_imports = {
+            key: _parse_list(value)
+            for key, value in _parse_dict(self.hidden_imports).items()
+        }
 
         if self.default_prc_dir is None:
             self.default_prc_dir = '<auto>etc' if not self.embed_prc_data else ''
@@ -639,7 +644,11 @@ class build_apps(setuptools.Command):
             return search_path
 
         def create_runtime(appname, mainscript, use_console):
-            freezer = FreezeTool.Freezer(platform=platform, path=path)
+            freezer = FreezeTool.Freezer(
+                platform=platform,
+                path=path,
+                hiddenImports=self.hidden_imports
+            )
             freezer.addModule('__main__', filename=mainscript)
             freezer.addModule('site', filename='site.py', text=SITE_PY)
             for incmod in self.include_modules.get(appname, []) + self.include_modules.get('*', []):


### PR DESCRIPTION
This is exposed as a hidden_imports option, which is a dictionary. The
keys are module name and the values are a list of modules to include
when an import for the key is found.

## Issue description
Currently hidden imports can only be addressed by modifying FreezeTool directly. Users *can* work around this by specifying `include_modules`. However, this is not ideal for tools such as [pman](https://github.com/Moguri/pman) that may want to conditionally include modules or if we expose pkg_resources entry point hooks for packages to modify this variable themselves.

## Solution description
This PR allows a user to specify `hidden_imports` which will get added to the ones already in FreezeTool. 

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
