### PR TITLE
VFSimporter: solve import can fail on _bootlocale module

### DIFF
--- a/direct/src/showbase/VFSImporter.py
+++ b/direct/src/showbase/VFSImporter.py
@@ -15,6 +15,10 @@ import marshal
 import imp
 import types
 
+# make sure modules are loaded for default encodings before hooking import system
+# file.py use TextIOWrapper that relies on the default preferred encoding
+__import__('locale').getpreferredencoding()
+
 #: The sharedPackages dictionary lists all of the "shared packages",
 #: special Python packages that automatically span multiple directories
 #: via magic in the VFSImporter.  You can make a package "shared"

--- a/direct/src/showbase/VFSImporter.py
+++ b/direct/src/showbase/VFSImporter.py
@@ -15,8 +15,10 @@ import marshal
 import imp
 import types
 
-# make sure modules are loaded for default encodings before hooking import system
-# file.py use TextIOWrapper that relies on the default preferred encoding
+# make sure all modules are loaded for default encoding before hooking the
+# import system : direct.ftd.file uses TextIOWrapper that relies
+# on gettting the default preferred encoding. Python 3.9 has a lazy import
+# of _bootlocale in some cases.
 __import__('locale').getpreferredencoding()
 
 #: The sharedPackages dictionary lists all of the "shared packages",


### PR DESCRIPTION
When on systems with missing or incomplete locale support ( eg android , emscripten ) and not using PYTHONUTF8=1 , the C module _bootlocale can fail to be imported lazily after VFS importer is already set up.
https://github.com/python/cpython/blob/3.9/Lib/locale.py#L658
