### PR TITLE
cmake tweaks for emsdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,16 @@ unset(_s)
 
 enable_testing()
 
+if (EMSCRIPTEN)
+
+# for dynamic linking, experimental do not use with stable emsdk
+#   set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
+
+    set(HAVE_THREADS OFF CACHE BOOL "wasm: force threads off" FORCE)
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "wasm: force static librairies" FORCE)
+    set(HAVE_SSE2 "NO")
+endif()
+
 string(REPLACE "$(EFFECTIVE_PLATFORM_NAME)" "" PANDA_CFG_INTDIR "${CMAKE_CFG_INTDIR}")
 
 # Add generic modules to cmake module path,

--- a/dtool/src/prc/CMakeLists.txt
+++ b/dtool/src/prc/CMakeLists.txt
@@ -69,6 +69,11 @@ if(ANDROID)
     androidLogStream.cxx)
 endif()
 
+if(EMSCRIPTEN)
+  set(P3PRC_SOURCES ${P3PRC_SOURCES}
+    emscriptenLogStream.cxx)
+endif()
+
 if(HAVE_OPENSSL)
   list(APPEND P3PRC_SOURCES encryptStreamBuf.cxx encryptStream.cxx)
 endif()


### PR DESCRIPTION
apart from an annoying recurring `warning: overriding currently unsupported use of floating point exceptions on this target [-Wunsupported-floating-point-opt]` build went very well and was a bit faster than with makepanda.