### PR TITLE
shaderpipeline: add support for specialization constants

### DIFF
--- a/panda/src/glstuff/glShaderContext_src.cxx
+++ b/panda/src/glstuff/glShaderContext_src.cxx
@@ -3425,7 +3425,11 @@ attach_shader(const ShaderModule *module) {
                                 (const char *)spv->get_data(),
                                 spv->get_data_size() * sizeof(uint32_t));
       }
-      _glgsg->_glSpecializeShader(handle, "main", 0, nullptr, nullptr);
+
+      const Shader::ModuleSpecConstants &consts = _shader->_module_spec_consts[module];
+      _glgsg->_glSpecializeShader(handle, "main", consts._indices.size(),
+                                  (GLuint *)consts._indices.data(),
+                                  (GLuint *)consts._values.data());
     }
     else
 #endif  // !OPENGLES

--- a/panda/src/gobj/shader.I
+++ b/panda/src/gobj/shader.I
@@ -222,6 +222,49 @@ set_cache_compiled_shader(bool flag) {
 }
 
 /**
+ * Sets a boolean value for the specialization constant with the indicated
+ * name.  All modules containing a specialization constant with this name
+ * will be given this value.
+ *
+ * Returns true if there was a specialization constant with this name on any of
+ * the modules, false otherwise.
+ */
+INLINE bool Shader::
+set_constant(CPT_InternalName name, bool value) {
+  return set_constant(name, (uint32_t)value);
+}
+
+/**
+ * Sets an integer value for the specialization constant with the indicated
+ * name.  All modules containing a specialization constant with this name
+ * will be given this value.
+ *
+ * Returns true if there was a specialization constant with this name on any of
+ * the modules, false otherwise.
+ */
+INLINE bool Shader::
+set_constant(CPT_InternalName name, int value) {
+  uint32_t val;
+  *((int *)&val) = value;
+  return set_constant(name, val);
+}
+
+/**
+ * Sets a float value for the specialization constant with the indicated
+ * name.  All modules containing a specialization constant with this name
+ * will be given this value.
+ *
+ * Returns true if there was a specialization constant with this name on any of
+ * the modules, false otherwise.
+ */
+INLINE bool Shader::
+set_constant(CPT_InternalName name, float value) {
+  uint32_t val;
+  *((float *)&val) = value;
+  return set_constant(name, val);
+}
+
+/**
  *
  */
 INLINE Shader::ShaderPtrData::
@@ -810,6 +853,30 @@ operator < (const Shader::ShaderFile &other) const {
     return (_compute < other._compute);
   }
   return false;
+}
+
+/**
+ * Sets an external value for the specialization constant with the given ID.
+ *
+ * Returns true if the value is different from what was already in there, false
+ * otherwise.
+ */
+INLINE bool Shader::ModuleSpecConstants::
+set_constant(uint32_t id, uint32_t value) {
+  auto it = std::find(_indices.begin(), _indices.end(), id);
+  if (it == _indices.end()) {
+    _indices.push_back(id);
+    _values.push_back(value);
+    return true;
+
+  } else {
+    size_t loc = it - _indices.begin();
+    if (_values[loc] != value) {
+      _values[loc] = value;
+      return true;
+    }
+    return false;
+  }
 }
 
 /**

--- a/panda/src/gobj/shader.h
+++ b/panda/src/gobj/shader.h
@@ -121,6 +121,11 @@ PUBLISHED:
   INLINE bool get_cache_compiled_shader() const;
   INLINE void set_cache_compiled_shader(bool flag);
 
+  INLINE bool set_constant(CPT_InternalName name, bool value);
+  INLINE bool set_constant(CPT_InternalName name, int value);
+  INLINE bool set_constant(CPT_InternalName name, float value);
+  bool set_constant(CPT_InternalName name, unsigned int value);
+
   PT(AsyncFuture) prepare(PreparedGraphicsObjects *prepared_objects);
   bool is_prepared(PreparedGraphicsObjects *prepared_objects) const;
   bool release(PreparedGraphicsObjects *prepared_objects);
@@ -439,6 +444,20 @@ public:
     std::string _compute;
   };
 
+  /**
+   * Contains external values given to the specialization constants of a single
+   * ShaderModule.
+   */
+  class ModuleSpecConstants {
+  public:
+    INLINE ModuleSpecConstants() {};
+
+    INLINE bool set_constant(uint32_t id, uint32_t value);
+  public:
+    pvector<uint32_t> _values;
+    pvector<uint32_t> _indices;
+  };
+
 protected:
   bool report_parameter_error(const InternalName *name, const ::ShaderType *type, const char *msg);
   bool expect_num_words(const InternalName *name, const ::ShaderType *type, size_t len);
@@ -486,6 +505,8 @@ public:
 
   typedef pvector<COWPT(ShaderModule)> Modules;
   Modules _modules;
+  typedef pmap<const ShaderModule *, ModuleSpecConstants> ModuleSpecConsts;
+  ModuleSpecConsts _module_spec_consts;
   uint32_t _module_mask = 0;
   int _used_caps = 0;
 

--- a/panda/src/gobj/shaderModule.I
+++ b/panda/src/gobj/shaderModule.I
@@ -49,8 +49,8 @@ set_source_filename(const Filename &filename) {
  * Returns the SpecializationConstant at the indicated index.
  */
 INLINE const ShaderModule::SpecializationConstant &ShaderModule::
-get_spec_constant(size_t n) const {
-  return _spec_constants[n];
+get_spec_constant(size_t i) const {
+  return _spec_constants[i];
 }
 
 /**

--- a/panda/src/gobj/shaderModule.I
+++ b/panda/src/gobj/shaderModule.I
@@ -46,6 +46,22 @@ set_source_filename(const Filename &filename) {
 }
 
 /**
+ * Returns the SpecializationConstant at the indicated index.
+ */
+INLINE const ShaderModule::SpecializationConstant &ShaderModule::
+get_spec_constant(size_t n) const {
+  return _spec_constants[n];
+}
+
+/**
+ * Returns the number of SpecializationConstants in the module.
+ */
+INLINE size_t ShaderModule::
+get_num_spec_constants() const {
+  return _spec_constants.size();
+}
+
+/**
  * Returns the number of input variables in this shader stage.
  */
 INLINE size_t ShaderModule::

--- a/panda/src/gobj/shaderModule.h
+++ b/panda/src/gobj/shaderModule.h
@@ -77,7 +77,7 @@ public:
   INLINE const Filename &get_source_filename() const;
   INLINE void set_source_filename(const Filename &);
 
-  INLINE const SpecializationConstant &get_spec_constant(size_t n) const;
+  INLINE const SpecializationConstant &get_spec_constant(size_t i) const;
   INLINE size_t get_num_spec_constants() const;
 
   size_t get_num_inputs() const;
@@ -101,6 +101,7 @@ PUBLISHED:
   MAKE_PROPERTY(stage, get_stage);
   MAKE_SEQ_PROPERTY(inputs, get_num_inputs, get_input);
   MAKE_SEQ_PROPERTY(outputs, get_num_outputs, get_output);
+  MAKE_SEQ_PROPERTY(spec_constants, get_num_spec_constants, get_spec_constant);
 
   virtual std::string get_ir() const=0;
 

--- a/panda/src/gobj/shaderModule.h
+++ b/panda/src/gobj/shaderModule.h
@@ -57,6 +57,16 @@ PUBLISHED:
     int _location;
   };
 
+  /**
+   * Defines a specialization constant.
+   */
+  struct SpecializationConstant {
+  PUBLISHED:
+    const ShaderType *type;
+    CPT(InternalName) name;
+    uint32_t id;
+  };
+
 public:
   ShaderModule(Stage stage);
   virtual ~ShaderModule();
@@ -66,6 +76,9 @@ public:
 
   INLINE const Filename &get_source_filename() const;
   INLINE void set_source_filename(const Filename &);
+
+  INLINE const SpecializationConstant &get_spec_constant(size_t n) const;
+  INLINE size_t get_num_spec_constants() const;
 
   size_t get_num_inputs() const;
   const Variable &get_input(size_t i) const;
@@ -171,6 +184,9 @@ protected:
   Variables _inputs;
   Variables _outputs;
   Variables _parameters;
+
+  typedef pvector<SpecializationConstant> SpecializationConstants;
+  SpecializationConstants _spec_constants;
 
   friend class Shader;
 

--- a/panda/src/shaderpipeline/shaderModuleSpirV.h
+++ b/panda/src/shaderpipeline/shaderModuleSpirV.h
@@ -124,6 +124,7 @@ public:
     DT_function_parameter,
     DT_function,
     DT_local,
+    DT_spec_constant,
   };
 
   enum DefinitionFlags {
@@ -165,6 +166,7 @@ public:
     uint32_t _array_stride = 0;
     uint32_t _origin_id = 0; // set for loads, tracks original variable ID
     uint32_t _function_id = 0;
+    uint32_t _spec_id = 0;
     MemberDefinitions _members;
     int _flags = 0;
 
@@ -228,6 +230,7 @@ public:
     void record_ext_inst_import(uint32_t id, const char *import);
     void record_function(uint32_t id, uint32_t type_id);
     void record_local(uint32_t id, uint32_t type_id, uint32_t from_id, uint32_t function_id);
+    void record_spec_constant(uint32_t id, uint32_t type_id);
 
     void mark_used(uint32_t id);
 


### PR DESCRIPTION
## Issue description
Adds support for specialization constants to the shaderpipeline branch.  Can be used in place of preprocessor definitions to set values that are constant for the entire shader, without requiring a complete recompilation of the shader from source.

## Solution description
Each `ShaderModule` contains a list of `SpecializationConstants`, which individually store the name, type, and constant ID.  `ShaderModuleSpirV` fills in that list when parsing the SPIR-V instructions.  In `Shader`, external values given to the constants are stored per-module in two lists with matching indices: the constant IDs and the values.  To set a constant from application code, the usage is `Shader.set_constant(name, value)`.  The matchup is done by name, so multiple shader modules containing a spec constant with the same name are given the same value.  This also requires spec constants with the same name across multiple modules to have the same type.  Changing the value of a specialization constant will force the shader to re-prepare itself.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
