### PR TITLE
missing include for subdivideCollision()

### DIFF
--- a/direct/src/extensions_native/NodePath_extensions.py
+++ b/direct/src/extensions_native/NodePath_extensions.py
@@ -789,6 +789,7 @@ def r_subdivideCollisions(self, solids, numSolidsInLeaves):
         return newSolids
 
 def r_constructCollisionTree(self, solidTree, parentNode, colName):
+        from panda3d.core import CollisionNode
         for item in solidTree:
             if type(item[0]) == type([]):
                 newNode = parentNode.attachNewNode('%s-branch' % colName)


### PR DESCRIPTION
When running NodePath.subdivideCollisions(some_int) there is an import error.
Added the import, fixed the problem.
