### PR TITLE
egg: Implement egg object type rebuilding from scene graph to egg file

### DIFF
--- a/makepanda/confauto.in
+++ b/makepanda/confauto.in
@@ -78,11 +78,14 @@ egg-object-type-barrier         <Collide> { Polyset descend }
 egg-object-type-sphere          <Collide> { Sphere descend }
 egg-object-type-invsphere       <Collide> { InvSphere descend }
 egg-object-type-tube            <Collide> { Tube descend }
+egg-object-type-solidpoly       <Collide> { Polyset descend solid }
+egg-object-type-turnstile       <Collide> { Polyset descend turnstile }
 
 # As above, but these are flagged to be "intangible", so that they
 # will trigger an event but not stop an object from passing through.
 egg-object-type-trigger         <Collide> { Polyset descend intangible }
 egg-object-type-trigger-sphere  <Collide> { Sphere descend intangible }
+egg-object-type-eye-trigger     <Collide> { Polyset descend intangible center }
 
 # "floor" and "dupefloor" define the nodes in question as floor
 # polygons.  dupefloor means to duplicate the geometry first so that

--- a/panda/src/configfiles/panda.prc.in
+++ b/panda/src/configfiles/panda.prc.in
@@ -98,11 +98,14 @@ egg-object-type-barrier         <Collide> { Polyset descend }
 egg-object-type-sphere          <Collide> { Sphere descend }
 egg-object-type-invsphere       <Collide> { InvSphere descend }
 egg-object-type-tube            <Collide> { Tube descend }
+egg-object-type-solidpoly       <Collide> { Polyset descend solid }
+egg-object-type-turnstile       <Collide> { Polyset descend turnstile }
 
 # As above, but these are flagged to be "intangible", so that they
 # will trigger an event but not stop an object from passing through.
 egg-object-type-trigger         <Collide> { Polyset descend intangible }
 egg-object-type-trigger-sphere  <Collide> { Sphere descend intangible }
+egg-object-type-eye-trigger     <Collide> { Polyset descend intangible center }
 
 # "floor" and "dupefloor" define the nodes in question as floor
 # polygons.  dupefloor means to duplicate the geometry first so that

--- a/panda/src/egg/config_egg.cxx
+++ b/panda/src/egg/config_egg.cxx
@@ -169,6 +169,15 @@ ConfigVariableInt egg_precision
           "an egg file.  Leave this at 0 to use the default setting for the "
           "stream."));
 
+ConfigVariableBool egg_rebuild_object_types
+("egg-rebuild-object-types", false,
+  PRC_DESC("Set this true to enable the automatic rebuilding of egg object "
+           "types when saving a scene graph to an .egg file. This also "
+           "applies to scenarios such as .bam to .egg file conversion, "
+           "as the scene graph is built as an intermediary step in these "
+           "cases. This option can only rebuild egg object types that are "
+           "specified in your PRC configuration. Disabled by default."));
+
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/src/egg/config_egg.h
+++ b/panda/src/egg/config_egg.h
@@ -41,6 +41,7 @@ extern EXPCL_PANDA_EGG ConfigVariableDouble egg_coplanar_threshold;
 extern EXPCL_PANDA_EGG ConfigVariableInt egg_test_vref_integrity;
 extern EXPCL_PANDA_EGG ConfigVariableInt egg_recursion_limit;
 extern EXPCL_PANDA_EGG ConfigVariableInt egg_precision;
+extern EXPCL_PANDA_EGG ConfigVariableBool egg_rebuild_object_types;
 
 extern EXPCL_PANDA_EGG void init_libegg();
 

--- a/panda/src/egg/eggGroup.cxx
+++ b/panda/src/egg/eggGroup.cxx
@@ -460,6 +460,227 @@ write_render_mode(ostream &out, int indent_level) const {
 }
 
 /**
+ * Checks if this group satisfies the given egg object type. Returns true if
+ * this group inherits all of the specified object type's egg attributes.
+ */
+bool EggGroup::
+satisfies_object_type(EggGroup *type) {
+  // First, check if our render mode satisfies the object type.
+  if (!EggRenderMode::satisfies_object_type(type)) {
+    return false;
+  }
+
+  // Check if our LOD settings are satisfied.
+  if (type->has_lod()) {
+    if (!has_lod() || type->get_lod() != get_lod()) {
+      return false;
+    }
+  }
+
+  // Check if our billboard settings are satisfied.
+  if (type->get_billboard_type() != BT_none) {
+    if (type->get_billboard_type() != get_billboard_type()) {
+      return false;
+    }
+  }
+
+  // Check if our billboard center matches the object type's billboard center.
+  if (type->has_billboard_center()) {
+    if (!has_billboard_center()) {
+      return false;
+    }
+    if (!type->get_billboard_center().almost_equal(get_billboard_center())) {
+      return false;
+    }
+  }
+
+  // Check if our collision solid type matches the object type.
+  if (type->get_cs_type() != CST_none) {
+    if (type->get_cs_type() != get_cs_type()) {
+      return false;
+    }
+
+    // Check if our collision name is the same, if set on the object type.
+    if (type->has_collision_name()) {
+      if (!has_collision_name()) {
+        return false;
+      }
+      if (type->get_collision_name() != get_collision_name()) {
+        return false;
+      }
+    }
+
+    // Check if our collide flags are satisfied. This is a direct comparison: we
+    // are not looking for bit matches, but for a complete match. This is
+    // because we don't want to match composite object types.
+    if (type->get_collide_flags() != CF_none) {
+      if (get_collide_flags() != type->get_collide_flags()) {
+        return false;
+      }
+    }
+  }
+
+  // Check if our overall collide mask satisfies the object type.
+  if (type->has_collide_mask()) {
+    if (get_collide_mask() != type->get_collide_mask()) {
+      return false;
+    }
+  }
+
+  // Check if our from collide mask satisfies the object type.
+  if (type->has_from_collide_mask()) {
+    if (type->get_from_collide_mask() != get_from_collide_mask()) {
+      return false;
+    }
+  }
+
+  // Check if our into collide mask satisfies the object type.
+  if (type->has_into_collide_mask()) {
+    if (type->get_into_collide_mask() != get_into_collide_mask()) {
+      return false;
+    }
+  }
+
+  // Check if our DCS type satisfies the object type.
+  if (type->has_dcs_type() && type->get_dcs_type() != get_dcs_type()) {
+    return false;
+  }
+
+  // Check if our dart type satisfies the object type.
+  if (type->get_dart_type() != DT_none) {
+    if (type->get_dart_type() != get_dart_type()) {
+      return false;
+    }
+  }
+
+  // Check if our <Model> flag satisfies the object type.
+  if (type->get_model_flag() && !get_model_flag()) {
+    return false;
+  }
+
+  // Check if our <TexList> flag satisfies the object type.
+  if (type->get_texlist_flag() && !get_texlist_flag()) {
+    return false;
+  }
+
+  // Check if our direct flag satisfies the object type.
+  if (type->get_direct_flag() && !get_direct_flag()) {
+    return false;
+  }
+
+  // Check if our <Decal> flag satisfies the object type.
+  if (type->get_decal_flag() && !get_decal_flag()) {
+    return false;
+  }
+
+  // Check if our animated switches match the object type.
+  if (type->get_switch_flag()) {
+    if (!get_switch_flag()) {
+      return false;
+    }
+
+    // Check if our switches have the same FPS, if set.
+    if (type->get_switch_fps() != 0.0) {
+      if (type->get_switch_fps() != get_switch_fps()) {
+        return false;
+      }
+    }
+  }
+
+  // Check if our transform matches the object type's transform, if set.
+  if (type->has_transform() && *(type->as_transform()) != *(as_transform())) {
+    return false;
+  }
+
+  // Check if our scroll U coordinate matches the object type.
+  if (type->get_scroll_u() != 0 && type->get_scroll_u() != get_scroll_u()) {
+    return false;
+  }
+
+  // Check if our scroll V coordinate matches the object type.
+  if (type->get_scroll_v() != 0 && type->get_scroll_v() != get_scroll_v()) {
+    return false;
+  }
+
+  // Check if our scroll W coordinate matches the object type.
+  if (type->get_scroll_w() != 0 && type->get_scroll_w() != get_scroll_w()) {
+    return false;
+  }
+
+  // Check if our scroll R coordinate matches the object type.
+  if (type->get_scroll_r() != 0 && type->get_scroll_r() != get_scroll_r()) {
+    return false;
+  }
+
+  // Check if our portal flag matches the object type.
+  if (type->get_portal_flag() && !get_portal_flag()) {
+    return false;
+  }
+
+  // Check if our occluder flag matches the object type.
+  if (type->get_occluder_flag() && !get_occluder_flag()) {
+    return false;
+  }
+
+  // Check if our polylight flag matches the object type.
+  if (type->get_polylight_flag() && !get_polylight_flag()) {
+    return false;
+  }
+
+  // Check if our indexed flag matches the object type.
+  if (type->has_indexed_flag()) {
+    if (!has_indexed_flag()) {
+      return false;
+    }
+    if (type->get_indexed_flag() != get_indexed_flag()) {
+      return false;
+    }
+  }
+
+  // Check if our scalar blend mode matches the object type.
+  if (type->get_blend_mode() != BM_unspecified) {
+    if (type->get_blend_mode() != get_blend_mode()) {
+      return false;
+    }
+  }
+
+  // Check if our blend A operand matches the object type.
+  if (type->get_blend_operand_a() != BO_unspecified) {
+    if (type->get_blend_operand_a() != get_blend_operand_a()) {
+      return false;
+    }
+  }
+
+  // Check if our blend B operand matches the object type.
+  if (type->get_blend_operand_b() != BO_unspecified) {
+    if (type->get_blend_operand_b() != get_blend_operand_b()) {
+      return false;
+    }
+  }
+
+  // Check if our blend color, if set, matches the object type.
+  if (type->has_blend_color()) {
+    if (!type->get_blend_color().almost_equal(get_blend_color())) {
+      return false;
+    }
+  }
+
+  // Check if we have all of the object type's tags.
+  TagData::const_iterator ti;
+
+  for (ti = type->_tag_data.begin(); ti != type->_tag_data.end(); ++ti) {
+    if (find(_tag_data.begin(), _tag_data.end(), (*ti)) == _tag_data.end()) {
+      // We don't have this tag, but our object type does. So we can't satisfy
+      // this object type.
+      return false;
+    }
+  }
+
+  // All of our criteria has been met! We satisfy this object type!
+  return true;
+}
+
+/**
  * Returns true if this particular node represents a <Joint> entry or not.
  * This is a handy thing to know since Joints are sorted to the end of their
  * sibling list when writing an egg file.  See EggGroupNode::write().

--- a/panda/src/egg/eggGroup.h
+++ b/panda/src/egg/eggGroup.h
@@ -147,6 +147,8 @@ PUBLISHED:
   void write_tags(std::ostream &out, int indent_level) const;
   void write_render_mode(std::ostream &out, int indent_level) const;
 
+  bool satisfies_object_type(EggGroup *type);
+
   virtual bool is_joint() const;
 
   virtual EggRenderMode *determine_alpha_mode();

--- a/panda/src/egg/eggRenderMode.cxx
+++ b/panda/src/egg/eggRenderMode.cxx
@@ -89,6 +89,63 @@ write(ostream &out, int indent_level) const {
 }
 
 /**
+ * Checks if this render mode satisfies the given egg object type. Returns true
+ * if this render mode inherits all of the specified object type's egg
+ * attributes.
+ */
+bool EggRenderMode::
+satisfies_object_type(EggRenderMode *type) {
+  // Test if our alpha mode satisfies this object type.
+  if (type->get_alpha_mode() != AM_unspecified) {
+    if (type->get_alpha_mode() != get_alpha_mode()) {
+      return false;
+    }
+  }
+
+  // Test if our depth write mode satisfies this object type.
+  if (type->get_depth_write_mode() != DWM_unspecified) {
+    if (type->get_depth_write_mode() != get_depth_write_mode()) {
+      return false;
+    }
+  }
+
+  // Next, test if our depth test mode satisfies this object type.
+  if (type->get_depth_test_mode() != DTM_unspecified) {
+    if (type->get_depth_test_mode() != get_depth_test_mode()) {
+      return false;
+    }
+  }
+
+  // See if our visibility mode matches this object type.
+  if (type->get_visibility_mode() != VM_unspecified) {
+    if (type->get_visibility_mode() != get_visibility_mode()) {
+      return false;
+    }
+  }
+
+  // See if our depth offset matches this object type.
+  if (type->has_depth_offset()) {
+    if (type->get_depth_offset() != get_depth_offset()) {
+      return false;
+    }
+  }
+
+  // See if our draw order matches this object type.
+  if (type->has_draw_order() && type->get_draw_order() != get_draw_order()) {
+    return false;
+  }
+
+  // See if our bin  name matches this object type.
+  if (type->has_bin() && type->get_bin() != get_bin()) {
+    return false;
+  }
+
+  // Hooray! This egg render mode completely matches the object type's render
+  // mode!
+  return true;
+}
+
+/**
  *
  */
 bool EggRenderMode::

--- a/panda/src/egg/eggRenderMode.h
+++ b/panda/src/egg/eggRenderMode.h
@@ -36,6 +36,8 @@ PUBLISHED:
 
   void write(std::ostream &out, int indent_level) const;
 
+  bool satisfies_object_type(EggRenderMode *type);
+
   enum AlphaMode {  // Specifies implementation of transparency.
     AM_unspecified,
     AM_off,     // No transparency.

--- a/panda/src/egg/eggSwitchCondition.I
+++ b/panda/src/egg/eggSwitchCondition.I
@@ -1,0 +1,57 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file eggSwitchCondition.I
+ * @author Derzsi Daniel
+ * @date 2021-01-01
+ */
+
+/**
+ * Checks if these two switch conditions are equivalent.
+ * If so, returns true.
+ */
+bool EggSwitchCondition::
+operator == (const EggSwitchCondition &other) const {
+  // These are equivalent only if both of them are castable to distance
+  // conditions and if both of these distance conditions are equivalent.
+
+  // Right now, only distance switch conditions exist.
+  const EggSwitchConditionDistance *distance = as_distance();
+  const EggSwitchConditionDistance *other_distance = other.as_distance();
+
+  return distance != nullptr && other_distance != nullptr
+    && (*distance) == (*other_distance);
+}
+
+/**
+ * Checks if these two switch conditions are NOT equivalent. If so, returns
+ * true.
+ */
+bool EggSwitchCondition::
+operator != (const EggSwitchCondition &other) const {
+  return !operator==(other);
+}
+
+/**
+ * Checks if these two distance switch conditions are equivalent. If so, returns
+ * true.
+ */
+bool EggSwitchConditionDistance::
+operator == (const EggSwitchConditionDistance &other) const {
+  return _switch_in == other._switch_in && _switch_out == other._switch_out
+    && _center.almost_equal(other._center) && _fade == other._fade;
+}
+
+/**
+ * Checks if these two distance switch conditions are NOT equivalent. If so,
+ * returns true.
+ */
+bool EggSwitchConditionDistance::
+operator != (const EggSwitchConditionDistance &other) const {
+  return !operator==(other);
+}

--- a/panda/src/egg/eggSwitchCondition.cxx
+++ b/panda/src/egg/eggSwitchCondition.cxx
@@ -73,3 +73,23 @@ transform(const LMatrix4d &mat) {
   _switch_in = in.length();
   _switch_out = out.length();
 }
+
+/**
+ * Returns the same switch condition pointer converted to a
+ * distance switch condition pointer, if this is in fact a
+ * distance switch condition; otherwise, returns nullptr.
+ */
+const EggSwitchConditionDistance *EggSwitchCondition::
+as_distance() const {
+  return nullptr;
+}
+
+/**
+ * Returns the same switch condition pointer converted to a
+ * distance switch condition pointer, if this is in fact a
+ * distance switch condition; otherwise, returns nullptr.
+ */
+const EggSwitchConditionDistance *EggSwitchConditionDistance::
+as_distance() const {
+  return this;
+}

--- a/panda/src/egg/eggSwitchCondition.h
+++ b/panda/src/egg/eggSwitchCondition.h
@@ -11,13 +11,15 @@
  * @date 1999-02-08
  */
 
-#ifndef EGGSWITCHCONDITION
-#define EGGSWITCHCONDITION
+#ifndef EGGSWITCHCONDITION_H
+#define EGGSWITCHCONDITION_H
 
 #include "pandabase.h"
 
 #include "eggObject.h"
 #include "luse.h"
+
+class EggSwitchConditionDistance;
 
 /**
  * This corresponds to a <SwitchCondition> entry within a group.  It indicates
@@ -33,6 +35,10 @@ PUBLISHED:
 
   virtual void transform(const LMatrix4d &mat)=0;
 
+  virtual const EggSwitchConditionDistance *as_distance() const;
+
+  INLINE bool operator == (const EggSwitchCondition &other) const;
+  INLINE bool operator != (const EggSwitchCondition &other) const;
 
 public:
 
@@ -68,6 +74,11 @@ PUBLISHED:
 
   virtual void transform(const LMatrix4d &mat);
 
+  virtual const EggSwitchConditionDistance *as_distance() const;
+
+  INLINE bool operator == (const EggSwitchConditionDistance &other) const;
+  INLINE bool operator != (const EggSwitchConditionDistance &other) const;
+
 public:
   double _switch_in, _switch_out, _fade;
   LPoint3d _center;
@@ -89,5 +100,6 @@ private:
   static TypeHandle _type_handle;
 };
 
+#include <eggSwitchCondition.I>
 
 #endif

--- a/panda/src/egg/eggTransform.I
+++ b/panda/src/egg/eggTransform.I
@@ -12,6 +12,23 @@
  */
 
 /**
+ * Checks if these two transforms are equivalent. If so, returns true.
+ */
+INLINE bool EggTransform::
+operator == (const EggTransform &other) const {
+  return _is_transform_2d == other._is_transform_2d
+    && _transform.almost_equal(other._transform);
+}
+
+/**
+ * Checks if these two transforms are NOT equivalent. If so, returns true.
+ */
+INLINE bool EggTransform::
+operator != (const EggTransform &other) const {
+  return !operator == (other);
+}
+
+/**
  *
  */
 INLINE EggTransform::Component::

--- a/panda/src/egg/eggTransform.h
+++ b/panda/src/egg/eggTransform.h
@@ -31,6 +31,9 @@ PUBLISHED:
   EggTransform();
   EggTransform(const EggTransform &copy);
   EggTransform &operator = (const EggTransform &copy);
+  INLINE bool operator == (const EggTransform &other) const;
+  INLINE bool operator != (const EggTransform &other) const;
+
   virtual ~EggTransform();
 
   INLINE void clear_transform();

--- a/panda/src/egg2pg/eggLoader.cxx
+++ b/panda/src/egg2pg/eggLoader.cxx
@@ -3711,43 +3711,7 @@ do_expand_object_type(EggGroup *egg_group, const pset<string> &expanded,
   if (!egg_object_type.has_value()) {
     // It wasn't defined in a config file.  Maybe it's built in?
 
-    if (cmp_nocase_uh(object_type, "barrier") == 0) {
-      egg_syntax = "<Collide> { Polyset descend }";
-
-    } else if (cmp_nocase_uh(object_type, "solidpoly") == 0) {
-      egg_syntax = "<Collide> { Polyset descend solid }";
-
-    } else if (cmp_nocase_uh(object_type, "turnstile") == 0) {
-      egg_syntax = "<Collide> { Polyset descend turnstile }";
-
-    } else if (cmp_nocase_uh(object_type, "sphere") == 0) {
-      egg_syntax = "<Collide> { Sphere descend }";
-
-    } else if (cmp_nocase_uh(object_type, "tube") == 0) {
-      egg_syntax = "<Collide> { Tube descend }";
-
-    } else if (cmp_nocase_uh(object_type, "trigger") == 0) {
-      egg_syntax = "<Collide> { Polyset descend intangible }";
-
-    } else if (cmp_nocase_uh(object_type, "trigger_sphere") == 0) {
-      egg_syntax = "<Collide> { Sphere descend intangible }";
-
-    } else if (cmp_nocase_uh(object_type, "eye_trigger") == 0) {
-      egg_syntax = "<Collide> { Polyset descend intangible center }";
-
-    } else if (cmp_nocase_uh(object_type, "bubble") == 0) {
-      egg_syntax = "<Collide> { Sphere keep descend }";
-
-    } else if (cmp_nocase_uh(object_type, "ghost") == 0) {
-      egg_syntax = "<Scalar> collide-mask { 0 }";
-
-    } else if (cmp_nocase_uh(object_type, "dcs") == 0) {
-      egg_syntax = "<DCS> { 1 }";
-
-    } else if (cmp_nocase_uh(object_type, "model") == 0) {
-      egg_syntax = "<Model> { 1 }";
-
-    } else if (cmp_nocase_uh(object_type, "none") == 0) {
+    if (cmp_nocase_uh(object_type, "none") == 0) {
       // ObjectType "none" is a special case, meaning nothing in particular.
       return true;
 

--- a/panda/src/egg2pg/eggSaver.h
+++ b/panda/src/egg2pg/eggSaver.h
@@ -60,6 +60,7 @@ PUBLISHED:
 
 private:
   typedef pmap<const CharacterJoint*, pvector<std::pair<EggVertex*,PN_stdfloat> > > CharacterJointMap;
+  typedef pvector<PT(EggGroup)> ObjectTypes;
 
   void convert_node(const WorkingNodePath &node_path, EggGroupNode *egg_parent,
                     bool has_decal, CharacterJointMap *joint_map);
@@ -98,15 +99,19 @@ private:
   bool apply_state_properties(EggRenderMode *egg_render_mode, const RenderState *state);
   bool apply_tags(EggGroup *egg_group, PandaNode *node);
   bool apply_tag(EggGroup *egg_group, PandaNode *node, const std::string &tag);
+  bool apply_object_types(EggGroup *egg_group);
 
   EggMaterial *get_egg_material(Material *tex);
   EggTexture *get_egg_texture(Texture *tex);
+
+  void build_object_types();
 
   PT(EggData) _data;
 
   PT(EggVertexPool) _vpool;
   EggMaterialCollection _materials;
   EggTextureCollection _textures;
+  ObjectTypes _object_types;
 };
 
 #include "eggSaver.I"

--- a/pandatool/src/eggbase/somethingToEgg.cxx
+++ b/pandatool/src/eggbase/somethingToEgg.cxx
@@ -14,6 +14,7 @@
 #include "somethingToEgg.h"
 #include "somethingToEggConverter.h"
 
+#include "config_egg.h"
 #include "config_putil.h"
 
 /**
@@ -59,6 +60,13 @@ SomethingToEgg(const std::string &format_name,
      "an error and the command aborted; with this option, an egg file will "
      "be generated anyway, referencing pathnames that do not exist.",
      &SomethingToEgg::dispatch_none, &_noexist);
+
+  add_option
+    ("notypes", "", 0,
+     "Don't attempt to rebuild egg object types. Enable this if you "
+     "want your model conversion to be independent of your PRC "
+     "configuration, or if your object types are rebuilt incorrectly.",
+    &SomethingToEgg::dispatch_none, &_no_object_types);
 
   add_option
     ("ignore", "", 0,
@@ -292,6 +300,10 @@ post_command_line() {
     directory = ".";
   }
   model_path.prepend_directory(directory);
+
+  // We want to rebuild object types if "-notypes" is not set.
+  // However, if it is set, do NOT rebuild object types
+  egg_rebuild_object_types = !_no_object_types;
 
   return EggConverter::post_command_line();
 }

--- a/pandatool/src/eggbase/somethingToEgg.h
+++ b/pandatool/src/eggbase/somethingToEgg.h
@@ -70,6 +70,7 @@ protected:
 
   bool _merge_externals;
   bool _noexist;
+  bool _no_object_types;
   bool _allow_errors;
 };
 


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
When converting BAM files to EGG files, for example, all EGG object types are lost in conversion.
This is because the BAM structure simply does not store the egg object types. It only stores the transformations that it has on the scene graph, but all information regarding which object type was used to induce those transformations is lost.

Because of this, it is not convenient to, for example, convert a BAM file to an EGG file, and then to a Maya MB file. A lot of information would be lost (alpha modes, collide masks, DCS flags, etc...). Modelers then have to spend extra time trying to figure out what egg object type to apply to what node.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
What if we could rebuild our object types using the information that is converted from the scene graph to the egg structure?

This PR adds a new strategy that rebuilds all object types in the egg structure, to the extent possible using the egg object types defined in the PRC config pages (egg-object-type-*).

Now, for example, when using bam2egg, all object types that match a group are added automatically to the group. This ensures that any further actions (for example, egg2maya) keep the object types, without losing them during the bam2egg process.

Here's a practical example:

Let's say we have an egg object type, `ground` defined in our configuration as such:
`egg-object-type-ground <Tag> cam { shground } <Scalar> bin { ground }`

When bam2egg converts the scene graph (with a "cam" tag set to "shground", and a "ground" bin name set) to an egg structure, it adds the following egg attributes:
```<Tag> cam {
    shground
}
<Scalar> draw-order { 0 }
<Scalar> bin { ground }```

Without the PR, the object type is completely lost.
With the PR, bam2egg yields the following attributes:
```<ObjectType> { ground }
<Tag> cam {
    shground
}
<Scalar> draw-order { 0 }
<Scalar> bin { ground }```

Keeping both the expanded version of the object type, and the ObjectType itself. Only object types that are defined in the loaded PRC files can be rebuilt.

To this end, I've added:
- Equality and inequality operators to EggTransform and EggSwitchCondition
- Object type satisfaction methods to EggGroup and EggRenderMode. They are similar to equality methods, but they only check equality for attributes that are explicitly set on the object type.
- An egg object type rebuilding algorithm (does not support recursive egg object types, none of the built-in egg object types are recursive currently)
- A new config option: `egg-rebuild-object-types`, which is disabled by default. It has to be set to true in order to enable egg object type rebuilding when explicitly using the EggSaver interface.
- A new command line option for something-to-egg utilities: `-notypes`, which disables egg object type rebuilding when converting scene graphs to egg files. Egg object type rebuilding is enabled by default when using the utilities.

Built-in egg object types have been moved out of the source tree and into the PRC files. Two deprecated flags have been removed: `trigger_sphere` and `eye_trigger`, which have been previously defined as (and used as) `trigger-sphere` and `eye-trigger` in the PRC files.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
