### PR TITLE
direct: Fix actor initialization

### DIFF
--- a/direct/src/actor/Actor.py
+++ b/direct/src/actor/Actor.py
@@ -163,8 +163,10 @@ class Actor(DirectObject, NodePath):
             #the actor for a few frames, otherwise it has no effect
             a.fixBounds()
         """
-        if not hasattr(self, 'Actor_initialized'):
-            self.Actor_initialized = 1
+        if hasattr(self, 'Actor_initialized'):
+            return
+
+        self.Actor_initialized = 1
 
         # initialize our NodePath essence
         NodePath.__init__(self)


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
Actors were acting up in extraordinary ways!

Turns out that the Actor `__init__` method was broken in be9dde1eee22e8d83c44399f042c1a12aa18942a.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
If Actor_initialized is set, actors will not be re-initialized anymore (this has always been the default behavior)

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
