### PR TITLE
WIP: Cube map support for TexturePeeker

### DIFF
--- a/panda/src/gobj/texturePeeker.h
+++ b/panda/src/gobj/texturePeeker.h
@@ -71,6 +71,7 @@ private:
   typedef double GetComponentFunc(const unsigned char *&p);
   typedef void GetTexelFunc(LColor &color, const unsigned char *&p,
                             GetComponentFunc *get_component);
+  typedef void GetTexelLocFunc(int &x, int &y, int &z, int x_size, int y_size, int z_size, PN_stdfloat u, PN_stdfloat v, PN_stdfloat w);
 
   static void get_texel_r(LColor &color, const unsigned char *&p, GetComponentFunc *get_component);
   static void get_texel_g(LColor &color, const unsigned char *&p, GetComponentFunc *get_component);
@@ -83,6 +84,8 @@ private:
   static void get_texel_rgba(LColor &color, const unsigned char *&p, GetComponentFunc *get_component);
   static void get_texel_srgb(LColor &color, const unsigned char *&p, GetComponentFunc *get_component);
   static void get_texel_srgba(LColor &color, const unsigned char *&p, GetComponentFunc *get_component);
+  static void get_texel_loc_standard(int &x, int &y, int &z, int x_size, int y_size, int z_size, PN_stdfloat u, PN_stdfloat v, PN_stdfloat w);
+  static void get_texel_loc_cube(int &x, int &y, int &z, int x_size, int y_size, int z_size, PN_stdfloat u, PN_stdfloat v, PN_stdfloat w);
 
   int _x_size;
   int _y_size;
@@ -96,6 +99,7 @@ private:
 
   GetComponentFunc *_get_component;
   GetTexelFunc *_get_texel;
+  GetTexelLocFunc *_get_texel_loc;
 
   friend class Texture;
 };

--- a/panda/src/gobj/texturePeeker.h
+++ b/panda/src/gobj/texturePeeker.h
@@ -40,6 +40,7 @@ PUBLISHED:
   void lookup(LColor &color, PN_stdfloat u, PN_stdfloat v) const;
   void lookup(LColor &color, PN_stdfloat u, PN_stdfloat v, PN_stdfloat w) const;
   void fetch_pixel(LColor &color, int x, int y) const;
+  void fetch_pixel(LColor &color, int x, int y, int z) const;
   bool lookup_bilinear(LColor &color, PN_stdfloat u, PN_stdfloat v) const;
   void filter_rect(LColor &color,
                    PN_stdfloat min_u, PN_stdfloat min_v,


### PR DESCRIPTION
## Issue description
TexturePeeker does not support cube map textures

## Solution description
This PR adds support for cube maps and reduces some duplicate code. Marking this as draft to get the code out, but there is still some testing that should be done (e.g., checking if wrapping works as intended).

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
