### PR TITLE
Serialize BulletGhostNodes

### DIFF
--- a/panda/src/bullet/bulletGhostNode.cxx
+++ b/panda/src/bullet/bulletGhostNode.cxx
@@ -171,3 +171,27 @@ do_sync_b2p() {
     _sync_disable = false;
   }
 }
+
+/**
+ * Tells the BamReader how to create objects of type BulletGhostNode.
+ */
+void BulletGhostNode::
+register_with_read_factory() {
+  BamReader::get_factory()->register_factory(get_class_type(), make_from_bam);
+}
+
+/**
+ * This function is called by the BamReader's factory when a new object of
+ * this type is encountered in the Bam file.  It should create the ghost node.
+ */
+TypedWritable *BulletGhostNode::
+make_from_bam(const FactoryParams &params) {
+  BulletGhostNode *param = new BulletGhostNode;
+  DatagramIterator scan;
+  BamReader *manager;
+
+  parse_params(params, scan, manager);
+  param->fillin(scan, manager);
+
+  return param;
+}

--- a/panda/src/bullet/bulletGhostNode.h
+++ b/panda/src/bullet/bulletGhostNode.h
@@ -60,6 +60,12 @@ private:
   void do_transform_changed();
 
 public:
+  static void register_with_read_factory();
+
+protected:
+  static TypedWritable *make_from_bam(const FactoryParams &params);
+
+public:
   static TypeHandle get_class_type() {
     return _type_handle;
   }

--- a/panda/src/bullet/config_bullet.cxx
+++ b/panda/src/bullet/config_bullet.cxx
@@ -189,6 +189,7 @@ init_libbullet() {
   BulletDebugNode::register_with_read_factory();
   BulletPlaneShape::register_with_read_factory();
   BulletRigidBodyNode::register_with_read_factory();
+  BulletGhostNode::register_with_read_factory();
   BulletSphereShape::register_with_read_factory();
   BulletTriangleMesh::register_with_read_factory();
   BulletTriangleMeshShape::register_with_read_factory();

--- a/tests/bullet/test_bullet_bam.py
+++ b/tests/bullet/test_bullet_bam.py
@@ -131,3 +131,12 @@ def test_sphere_shape():
     assert shape.margin == shape2.margin
     assert shape.name == shape2.name
     assert shape.radius == shape2.radius
+
+
+def test_ghost():
+    node = bullet.BulletGhostNode("some ghost node")
+
+    node2 = reconstruct(node)
+
+    assert type(node) is type(node2)
+    assert node.name == node2.name


### PR DESCRIPTION
## Issue description
Allows bullet ghost nodes to be serialized.
Fixes #1099 

## Solution description
Add bam serialization/deserialization files

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
