### PR TITLE
Add make_pos_quat to TransformState

### DIFF
--- a/panda/src/bullet/bullet_utils.cxx
+++ b/panda/src/bullet/bullet_utils.cxx
@@ -118,10 +118,9 @@ btTransform LMatrix4_to_btTrans(const LMatrix4 &m) {
  */
 LMatrix4 btTrans_to_LMatrix4(const btTransform &trans) {
 
-  return TransformState::make_pos_quat_scale(
+  return TransformState::make_pos_quat(
     btVector3_to_LVector3(trans.getOrigin()),
-    btQuat_to_LQuaternion(trans.getRotation()),
-    LVector3(1.0f, 1.0f, 1.0f))->get_mat();
+    btQuat_to_LQuaternion(trans.getRotation()))->get_mat();
 }
 
 /**

--- a/panda/src/pgraph/transformState.I
+++ b/panda/src/pgraph/transformState.I
@@ -83,6 +83,15 @@ make_pos_hpr(const LVecBase3 &pos, const LVecBase3 &hpr) {
  * Makes a new TransformState with the specified components.
  */
 INLINE CPT(TransformState) TransformState::
+make_pos_quat(const LVecBase3 &pos, const LQuaternion &quat) {
+  return make_pos_quat_scale(pos, quat,
+                             LVecBase3(1.0, 1.0f, 1.0f));
+}
+
+/**
+ * Makes a new TransformState with the specified components.
+ */
+INLINE CPT(TransformState) TransformState::
 make_scale(PN_stdfloat scale) {
   // We actually map this 3-d uniform make_scale() to the 2-d version--might
   // as well call it a 2-d scale.

--- a/panda/src/pgraph/transformState.h
+++ b/panda/src/pgraph/transformState.h
@@ -76,6 +76,8 @@ PUBLISHED:
   INLINE static CPT(TransformState) make_quat(const LQuaternion &quat);
   INLINE static CPT(TransformState) make_pos_hpr(const LVecBase3 &pos,
                                                  const LVecBase3 &hpr);
+  INLINE static CPT(TransformState) make_pos_quat(const LVecBase3 &pos,
+                                                  const LQuaternion &quat);
   INLINE static CPT(TransformState) make_scale(PN_stdfloat scale);
   INLINE static CPT(TransformState) make_scale(const LVecBase3 &scale);
   INLINE static CPT(TransformState) make_shear(const LVecBase3 &shear);

--- a/pandatool/src/assimp/assimpLoader.cxx
+++ b/pandatool/src/assimp/assimpLoader.cxx
@@ -1035,7 +1035,7 @@ load_light(const aiLight &light) {
     LPoint3 pos (light.mPosition.x, light.mPosition.y, light.mPosition.z);
     LQuaternion quat;
     ::look_at(quat, LPoint3(vec.x, vec.y, vec.z), LVector3::up());
-    plight->set_transform(TransformState::make_pos_quat_scale(pos, quat, LVecBase3(1, 1, 1)));
+    plight->set_transform(TransformState::make_pos_quat(pos, quat));
     break; }
 
   // This is a somewhat recent addition to Assimp, so let's be kind to those


### PR DESCRIPTION
Adds what appears to be a missing `TransformState.make_pos_quat()` (to complement `TransformState.make_pos_hpr()`

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
