### PR TITLE
direct: Fixed a crash with DistributedObject

### DIFF
--- a/direct/src/distributed/DistributedObject.py
+++ b/direct/src/distributed/DistributedObject.py
@@ -124,8 +124,8 @@ class DistributedObject(DistributedObjectBase):
                     if field is not None:
                         p = DCPacker()
                         p.setUnpackData(field.getDefaultValue())
-                        len = p.rawUnpackUint16() // 4
-                        for i in range(len):
+                        length = p.rawUnpackUint16() // 4
+                        for i in range(length):
                             zone = int(p.rawUnpackUint32())
                             autoInterests.add(zone)
                     autoInterests.update(autoInterests)
@@ -141,9 +141,9 @@ class DistributedObject(DistributedObjectBase):
         _getAutoInterests = None
         return list(autoInterests)
 
-    def setNeverDisable(self, bool):
-        assert bool == 1 or bool == 0
-        self.neverDisable = bool
+    def setNeverDisable(self, boolean):
+        assert boolean == 1 or boolean == 0
+        self.neverDisable = boolean
 
     def getNeverDisable(self):
         return self.neverDisable
@@ -177,9 +177,9 @@ class DistributedObject(DistributedObjectBase):
         # call this to throw out cached data from a previous instantiation
         self._cachedData[name].flush()
 
-    def setCacheable(self, bool):
-        assert bool == 1 or bool == 0
-        self.cacheable = bool
+    def setCacheable(self, boolean):
+        assert boolean == 1 or boolean == 0
+        self.cacheable = boolean
 
     def getCacheable(self):
         return self.cacheable

--- a/direct/src/distributed/DistributedObject.py
+++ b/direct/src/distributed/DistributedObject.py
@@ -124,7 +124,7 @@ class DistributedObject(DistributedObjectBase):
                     if field is not None:
                         p = DCPacker()
                         p.setUnpackData(field.getDefaultValue())
-                        len = p.rawUnpackUint16()/4
+                        len = p.rawUnpackUint16() // 4
                         for i in range(len):
                             zone = int(p.rawUnpackUint32())
                             autoInterests.add(zone)


### PR DESCRIPTION
```
  File "C:\Panda3D-1.11.0-x64\direct\distributed\DistributedObject.py", line 313, in generate
    self.cr.openAutoInterests(self)
  File "C:\Panda3D-1.11.0-x64\direct\distributed\DoInterestManager.py", line 405, in openAutoInterests
    autoInterests = obj.getAutoInterests()
  File "C:\Panda3D-1.11.0-x64\direct\distributed\DistributedObject.py", line 134, in getAutoInterests
    autoInterests = _getAutoInterests(self.__class__)
  File "C:\Panda3D-1.11.0-x64\direct\distributed\DistributedObject.py", line 119, in _getAutoInterests
    autoInterests.update(_getAutoInterests(base))
  File "C:\Panda3D-1.11.0-x64\direct\distributed\DistributedObject.py", line 128, in _getAutoInterests
    for i in range(len):
TypeError: 'float' object cannot be interpreted as an integer
```

- Fixed the above crash when generating a distributed object.
- Minor cleanup of distributed object code