### PR TITLE
Fix filled wireframe for nodes with vertex transform in shader

### DIFF
--- a/panda/src/pgraph/config_pgraph.cxx
+++ b/panda/src/pgraph/config_pgraph.cxx
@@ -373,6 +373,13 @@ ConfigVariableBool allow_live_flatten
           "only has an effect when Panda is not compiled for a release "
           "build."));
 
+ConfigVariableBool filled_wireframe_apply_shader
+("filled-wireframe-apply-shader", false,
+ PRC_DESC("Set this true to apply any shader configured on nodes onto the"
+          "filled wireframe overlay. It is helpful when the shader alters the"
+          "position of the vertices and makes the overlay wrong. This variable"
+          "has no effect on nodes without shader configured."));
+
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/src/pgraph/config_pgraph.h
+++ b/panda/src/pgraph/config_pgraph.h
@@ -74,6 +74,8 @@ extern ConfigVariableString default_model_extension;
 
 extern ConfigVariableBool allow_live_flatten;
 
+extern ConfigVariableBool filled_wireframe_apply_shader;
+
 extern EXPCL_PANDA_PGRAPH void init_libpgraph();
 
 #endif

--- a/panda/src/pgraph/cullResult.cxx
+++ b/panda/src/pgraph/cullResult.cxx
@@ -28,6 +28,7 @@
 #include "config_pgraph.h"
 #include "depthOffsetAttrib.h"
 #include "colorBlendAttrib.h"
+#include "shaderAttrib.h"
 
 TypeHandle CullResult::_type_handle;
 
@@ -133,8 +134,9 @@ add_object(CullableObject *object, const CullTraverser *traverser) {
   if (object->_state->get_attrib(rmode)) {
     if (rmode->get_mode() == RenderModeAttrib::M_filled_wireframe) {
       CullableObject *wireframe_part = new CullableObject(*object);
-      wireframe_part->_state = get_wireframe_overlay_state(rmode);
-
+      const ShaderAttrib *shader;
+      object->_state->get_attrib(shader);
+      wireframe_part->_state = get_wireframe_overlay_state(rmode, shader);
       if (wireframe_part->munge_geom
           (_gsg, _gsg->get_geom_munger(wireframe_part->_state, current_thread),
            traverser, force)) {
@@ -521,13 +523,36 @@ get_wireframe_filled_state() {
  */
 CPT(RenderState) CullResult::
 get_wireframe_overlay_state(const RenderModeAttrib *rmode) {
-  return RenderState::make(
+  return get_wireframe_overlay_state(rmode, nullptr);
+}
+
+/**
+ * Returns a RenderState that renders only the wireframe part of an
+ * M_filled_wireframe model.
+ * If a shader attrib is provided, a constant color is used in ColorBlendAttrib
+ * to emulate the flat color.
+ */
+CPT(RenderState) CullResult::
+get_wireframe_overlay_state(const RenderModeAttrib *rmode, const ShaderAttrib *shader) {
+  CPT(RenderState) state = RenderState::make(
     DepthOffsetAttrib::make(1, 0, 0.99999f),
-    ColorAttrib::make_flat(rmode->get_wireframe_color()),
-    ColorBlendAttrib::make(ColorBlendAttrib::M_add,
-                           ColorBlendAttrib::O_incoming_alpha,
-                           ColorBlendAttrib::O_one_minus_incoming_alpha),
     RenderModeAttrib::make(RenderModeAttrib::M_wireframe,
                            rmode->get_thickness(),
                            rmode->get_perspective()));
+  if (filled_wireframe_apply_shader && shader != nullptr) {
+    state = state->add_attrib(ColorBlendAttrib::make(ColorBlendAttrib::M_add,
+                                                     ColorBlendAttrib::O_zero,
+                                                     ColorBlendAttrib::O_constant_color,
+                                                     ColorBlendAttrib::M_add,
+                                                     ColorBlendAttrib::O_one,
+                                                     ColorBlendAttrib::O_one_minus_incoming_alpha,
+                                                     rmode->get_wireframe_color()));
+    state = state->add_attrib(shader);
+  } else {
+    state = state->add_attrib(ColorBlendAttrib::make(ColorBlendAttrib::M_add,
+                                                     ColorBlendAttrib::O_incoming_alpha,
+                                                     ColorBlendAttrib::O_one_minus_incoming_alpha));
+    state = state->add_attrib(ColorAttrib::make_flat(rmode->get_wireframe_color()));
+  }
+  return state;
 }

--- a/panda/src/pgraph/cullResult.h
+++ b/panda/src/pgraph/cullResult.h
@@ -78,6 +78,7 @@ private:
   static const RenderState *get_dual_opaque_state();
   static const RenderState *get_wireframe_filled_state();
   static CPT(RenderState) get_wireframe_overlay_state(const RenderModeAttrib *rmode);
+  static CPT(RenderState) get_wireframe_overlay_state(const RenderModeAttrib *rmode, const ShaderAttrib *shader);
 
   GraphicsStateGuardianBase *_gsg;
   PStatCollector _draw_region_pcollector;


### PR DESCRIPTION
## Issue description

Filled wireframe does not work on nodes which have a shader that perform vertex transform, see #1021

## Solution description

When creating the filled wireframe overlay state, we copy the shader attrib from the node and use the wireframe color as the blend color to replace the flat color mode of the non-shader version. 

The blend parameter could be wrong though, I could not configure them to have exactly the same output as with the current implementation.

I tried also to disable color write from the fragment shader, but it remove the whole wireframe altogether.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
