### PR TITLE
maya: Allow more than three eggObjectTypes in a Maya model

### DIFF
--- a/pandatool/src/maya/eggObjectFlags.mel
+++ b/pandatool/src/maya/eggObjectFlags.mel
@@ -1,6 +1,6 @@
 //
-// This is a sample mel script to flag a Maya node with one, two, or
-// three eggObjectTypes* attributes.  These attributes are used to tag
+// This is a sample mel script to flag a Maya node with at least
+// one eggObjectTypes* attribute.  These attributes are used to tag
 // geometry with special meaning to Panda.  There are a handful of
 // attribute values that are predefined within Panda, but you can also
 // make up your own attribute values, and define an arbitrary egg
@@ -28,42 +28,22 @@
 // direct/src/configfiles/direct.prc.pp for examples of this.
 //
 
-global proc eggObjectFlags()
-{       
-string $sel[] =`ls -sl`;
-for ($i in $sel)
-  {
-  string $attrName = "eggObjectTypes";
+global proc eggObjectFlags() {
+  string $sel[] =`ls -sl`;
 
   // Modify this line as needed to add your own object types.
   string $eggFlags = "none:portal:polylight:seq24:seq12:indexed:model:dcs:barrier:sphere:tube:trigger:trigger-sphere:bubble:ghost:keep-all-uvsets";
-  
-  string $object = ($i + ".eggObjectTypes");
-  
-    if( `objExists ($object + "1")` ) 
-    {
-    
-      if( `objExists ($object + "2")` ) 
-      {
-      
-        if( `objExists ($object + "3")` ) 
-        {
-        warning("No More Egg Object Types Supported");
-        } 
-         else 
-        {
-        addAttr -ln ($attrName + "3") -k 1 -at "enum" -en ($eggFlags)  $i;
-        }
-      
-      } 
-       else 
-      {
-      addAttr -ln ($attrName + "2") -k 1 -at "enum" -en ($eggFlags)  $i;
-      }
-    } 
-     else 
-    {
-    addAttr -ln ($attrName + "1") -k 1 -at "enum" -en ($eggFlags)  $i;
+
+  for ($i in $sel) {
+    string $attrName = "eggObjectTypes";
+    string $object = ($i + "." + $attrName);
+
+    int $num = 1;
+
+    while (`objExists ($object + $num)`) {
+      $num++;
     }
+
+    addAttr -ln ($attrName + $num) -k 1 -at "enum" -en ($eggFlags) $i;
   }
 }

--- a/pandatool/src/mayaegg/mayaNodeTree.cxx
+++ b/pandatool/src/mayaegg/mayaNodeTree.cxx
@@ -32,6 +32,8 @@
 #include <maya/MGlobal.h>
 #include "post_maya_include.h"
 
+#include <sstream>
+
 using std::string;
 
 /**
@@ -341,13 +343,16 @@ get_egg_group(MayaNodeDesc *node_desc) {
       MObject dag_object = node_desc->get_dag_path().node();
       string object_type;
       LVector3d value;
-      if (get_enum_attribute(dag_object, "eggObjectTypes1", object_type)) {
-        egg_group->add_object_type(object_type);
-      }
-      if (get_enum_attribute(dag_object, "eggObjectTypes2", object_type)) {
-        egg_group->add_object_type(object_type);
-      }
-      if (get_enum_attribute(dag_object, "eggObjectTypes3", object_type)) {
+
+      for (unsigned int i = 1; ; i++) {
+        std::ostringstream attr;
+        attr << "eggObjectTypes" << i;
+
+        if (!get_enum_attribute(dag_object, attr.str(), object_type)) {
+          // We have run out of object types to add.
+          break;
+        }
+
         egg_group->add_object_type(object_type);
       }
 

--- a/pandatool/src/mayaegg/mayaNodeTree.cxx
+++ b/pandatool/src/mayaegg/mayaNodeTree.cxx
@@ -349,6 +349,11 @@ get_egg_group(MayaNodeDesc *node_desc) {
         attr << "eggObjectTypes" << i;
 
         if (!get_enum_attribute(dag_object, attr.str(), object_type)) {
+          if (i < 3) {
+            // Support out-of-order legacy object types.
+            continue;
+          }
+
           // We have run out of object types to add.
           break;
         }


### PR DESCRIPTION
## Issue description
As of right now, a Maya group node can contain three egg object types: `eggObjectTypes1`, `eggObjectTypes2` and `eggObjectTypes3`. Some nodes may have more than three object types set. These are lost during the maya2egg conversion process.

## Solution description
Instead of checking `eggObjectTypes1`, `eggObjectTypes2` and `eggObjectTypes3` for object type information, we will now check all attributes matching `eggObjectTypes[1...inf]`. As soon as we find an egg object type that is not set in this fashion, we will stop looking for object types to add to the group. This approach is backwards compatible.

The `eggObjectFlags.mel` Maya script has also been changed to allow more than 3 object types to be added. `eggObjectFlags.mel` is responsible for adding one egg object type to a group node. Before this commit, it would print a warning if more than 3 object types are present, but now, it will find the first empty object type slot to insert an object type into, removing this 3 object type limitation.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
