### PR TITLE
direct: Fix undefined ConfigVariableBool name in ClockDelta

### DIFF
--- a/direct/src/distributed/ClockDelta.py
+++ b/direct/src/distributed/ClockDelta.py
@@ -1,7 +1,7 @@
 # ClockDelta provides the ability to use clock synchronization for
 # distributed objects
 
-from panda3d.core import ClockObject
+from panda3d.core import ClockObject, ConfigVariableBool
 from direct.directnotify import DirectNotifyGlobal
 from direct.showbase import DirectObject
 import math


### PR DESCRIPTION
## Issue description
ConfigVariableBool is not defined in direct/src/distributed/ClockDelta.py. ClockDelta cannot be used. This is a regression from 3fe1780f1678c562b669a5263cbff306db460be8: I've checked all other edited files to make sure they import.

## Solution description
Import ConfigVariableBool from panda3d.core.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
 