### PR TITLE
Fix mac refresh rate comparison

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1185,7 +1185,7 @@ find_display_modes(int width, int height) {
   }
 
   current_pixel_encoding = CGDisplayModeCopyPixelEncoding(mode);
-  refresh_rate = CGDisplayModeGetRefreshRate(mode);
+  refresh_rate = (int) CGDisplayModeGetRefreshRate(mode);
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
   // Calculate the pixel width and height of the fullscreen mode we want using
   // the currentdisplay mode dimensions and pixel dimensions.
@@ -1204,7 +1204,7 @@ find_display_modes(int width, int height) {
     // the mode width and height but also actual pixel widh and height.
     if (CGDisplayModeGetWidth(mode) == width &&
         CGDisplayModeGetHeight(mode) == height &&
-        CGDisplayModeGetRefreshRate(mode) == refresh_rate &&
+        (int) CGDisplayModeGetRefreshRate(mode) == refresh_rate &&
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
         (floor(NSAppKitVersionNumber) <= NSAppKitVersionNumber10_14 ||
         (CGDisplayModeGetPixelWidth(mode) == expected_pixel_width &&

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1185,7 +1185,7 @@ find_display_modes(int width, int height) {
   }
 
   current_pixel_encoding = CGDisplayModeCopyPixelEncoding(mode);
-  refresh_rate = (int) CGDisplayModeGetRefreshRate(mode);
+  refresh_rate = (int) (CGDisplayModeGetRefreshRate(mode) + 0.5);
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
   // Calculate the pixel width and height of the fullscreen mode we want using
   // the currentdisplay mode dimensions and pixel dimensions.
@@ -1204,7 +1204,7 @@ find_display_modes(int width, int height) {
     // the mode width and height but also actual pixel widh and height.
     if (CGDisplayModeGetWidth(mode) == width &&
         CGDisplayModeGetHeight(mode) == height &&
-        (int) CGDisplayModeGetRefreshRate(mode) == refresh_rate &&
+        (int) (CGDisplayModeGetRefreshRate(mode) + 0.5) == refresh_rate &&
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
         (floor(NSAppKitVersionNumber) <= NSAppKitVersionNumber10_14 ||
         (CGDisplayModeGetPixelWidth(mode) == expected_pixel_width &&


### PR DESCRIPTION
## Issue description
I'm having trouble with adding a fullscreen toggle on Mac. I created a small sample that reproduces this issue:

```
#!/usr/bin/env python

from panda3d.core import *
from direct.showbase.ShowBase import ShowBase
from direct.gui.OnscreenText import OnscreenText
import sys

class Demo(ShowBase):
    def __init__(self):
        ShowBase.__init__(self)
        self.title = OnscreenText(text="Panda3D", style=1,
            fg=(1, 1, 1, 1), shadow=(0, 0, 0, .5), parent=base.a2dBottomRight,
            align=TextNode.ARight, pos=(-0.1, 0.1), scale=.08)

        base.setBackgroundColor(0, 0, 0)

        self.accept('escape', sys.exit)
        self.accept('f', self.fullscreen)
      
    def fullscreen(self):
        props = WindowProperties(base.win.getProperties())
        props.setFullscreen(True)
    
        props.setSize(base.pipe.getDisplayWidth(), base.pipe.getDisplayHeight())
        base.win.requestProperties(props)
        base.openMainWindow(props=props, gsg=base.win.getGsg(), keepCamera=1)
 
Demo().run()
```

## Solution description
It looks like the refresh rate double comparison was failing which caused this sample to crash.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
