### PR TITLE
Properly handle update fields in Python if ConnectionRepositoryBase does not have owner view.

### DIFF
--- a/direct/src/distributed/ClientRepositoryBase.py
+++ b/direct/src/distributed/ClientRepositoryBase.py
@@ -468,6 +468,9 @@ class ClientRepositoryBase(ConnectionRepository):
                         "Asked to update non-existent DistObj " + str(doId) + "and failed to find it")
 
     def __doUpdateOwner(self, doId, di):
+        if not self.hasOwnerView():
+            return False
+
         ovObj = self.doId2ownerView.get(doId)
         if ovObj:
             odg = Datagram(di.getDatagram())


### PR DESCRIPTION
## Issue description
Currently, if DO object updates are handled in Python in ConnectionRepositoryBase, and the repository does not have owner view, then the engine will crash as `__doUpdateOwner` will attempt to access an undefined dictionary `doId2ownerView`.

## Solution description
This pull request simply adds a check in `__doUpdateOwner` to see if the repository has owner view and returns early if not, so the nonexistent property is not accessed.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
