### PR TITLE
MacOS set _maximum_window_width/height

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsPipe.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsPipe.mm
@@ -49,6 +49,8 @@ CocoaGraphicsPipe(CGDirectDisplayID display) : _display(display) {
 
   _display_width = CGDisplayPixelsWide(_display);
   _display_height = CGDisplayPixelsHigh(_display);
+  _display_information -> _maximum_window_width = _display_width;
+  _display_information -> _maximum_window_height = _display_height;
   load_display_information();
 
   if (cocoadisplay_cat.is_debug()) {


### PR DESCRIPTION
## Issue description
1. _maximum_window_width / _maximum_window_height is always 0 for Mac

## Solution description
Setting _maximum_window_width/height to the pixel width height of the display

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
