### PR TITLE
Changed unsigned int to signed int for resync in DistributedSmoothNode.

### DIFF
--- a/direct/src/distributed/direct.dc
+++ b/direct/src/distributed/direct.dc
@@ -84,8 +84,8 @@ dclass DistributedSmoothNode: DistributedNode {
 
   suggestResync(uint32 avId, int16 timestampA, int16 timestampB,
                 int32 serverTimeSec, uint16 serverTimeUSec,
-                uint16 / 100 uncertainty);
+                int16 / 100 uncertainty);
   returnResync(uint32 avId, int16 timestampB,
                int32 serverTimeSec, uint16 serverTimeUSec,
-               uint16 / 100 uncertainty);
+               int16 / 100 uncertainty);
 }; 


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->

The current code in `direct.dc` is as follows:
```
  suggestResync(uint32 avId, int16 timestampA, int16 timestampB, int32 serverTimeSec, uint16 serverTimeUSec, uint16/100 uncertainty) ownrecv clsend;
  returnResync(uint32 avId, int16 timestampB, int32 serverTimeSec, uint16 serverTimeUSec, uint16/100 uncertainty) ownrecv clsend;
 ```
 
`suggestResync` is called in the method for `DistributedSmoothNode#setComponentTLive`, where `uncertainty = globalClockDelta.getUncertainty()`. The definition for `ClockDelta.getUncertainty()` states:

```
    def getUncertainty(self):
        # Returns our current uncertainty with our clock measurement,
        # as a number of seconds plus or minus.  Returns None,
        # representing infinite uncertainty, if we have never received
        # a time measurement.
```

Therefore, the return value can be either positive **or** negative. This is exemplified by the following exception trace, where `getUncertainty` happened to return a negative value:
```
ValueError: Value out of range on field: suggestResync[102679575, 9862, 9771, 253722.0, 288.0651640589349, -0.16683287050850307]
```

Since the associated method `returnResync` is called on the other party with the same value of the parameter `uncertainty`, fixing both is necessary to correct this issue.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

To fix this issue, the value of `uncertainty` should be a signed integer, since the documentation for the values it can take on indicate that it can be negative. 

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
