### PR TITLE
Avoid directly referencing PyObject reference counts

### DIFF
--- a/panda/src/putil/bamReader_ext.cxx
+++ b/panda/src/putil/bamReader_ext.cxx
@@ -79,7 +79,7 @@ static TypedWritable *factory_callback(const FactoryParams &params){
       // If the Python pointer is the last reference to it, make sure that the
       // object isn't destroyed.  We do this by calling unref(), which
       // decreases the reference count without destroying the object.
-      if (result->ob_refcnt <= 1) {
+      if (Py_REFCNT(result) <= 1) {
         ref_count->unref();
 
         // Tell the Python wrapper object that it shouldn't try to delete the


### PR DESCRIPTION
## Issue description

This change aims to make Panda3D compatibile with [this experimental implementation of a GIL-less CPython](https://github.com/colesbury/nogil). As this implementation makes significant changes to Python's reference counting implementation, direct references to an object's reference count are no longer possible.

## Solution description

Replace the (only) reference in the Panda3D codebase to a PyObject's `ob_refcnt` field with a use of the (supported) Py_REFCNT macro.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
