### PR TITLE
Redefine play_rate property in MetaInterval class

### DIFF
--- a/direct/src/interval/MetaInterval.py
+++ b/direct/src/interval/MetaInterval.py
@@ -348,9 +348,13 @@ class MetaInterval(CMetaInterval):
     def getManager(self):
         return self.__manager
 
+    manager = property(getManager, setManager)
+
     def setT(self, t):
         self.__updateIvals()
         CMetaInterval.setT(self, t)
+
+    t = property(CMetaInterval.getT, setT)
 
     def start(self, startT = 0.0, endT = -1.0, playRate = 1.0):
         self.__updateIvals()
@@ -550,6 +554,8 @@ class MetaInterval(CMetaInterval):
 
         self.__updateIvals()
         return CMetaInterval.getDuration(self)
+
+    duration = property(getDuration)
 
     def __repr__(self, *args, **kw):
         # This function overrides from the parent level to force it to

--- a/direct/src/interval/MetaInterval.py
+++ b/direct/src/interval/MetaInterval.py
@@ -475,6 +475,8 @@ class MetaInterval(CMetaInterval):
         else:
             CMetaInterval.setPlayRate(self, playRate)
 
+    play_rate = property(CMetaInterval.getPlayRate, setPlayRate)
+
     def __doPythonCallbacks(self):
         # This function invokes any Python-level Intervals that need
         # to be invoked at this point in time.  It must be called


### PR DESCRIPTION
## Issue description
The `play_rate` property of classes derived from `MetaInterval` invokes the underlying C++ `set_play_rate` method, which leads to a bug (#1202).

## Solution description
The property is now redefined in `MetaInterval` to make it invoke the overriding `MetaInterval.set_play_rate` method instead.
