### PR TITLE
Add ability to get name from AICharacter

### DIFF
--- a/contrib/src/ai/aiCharacter.cxx
+++ b/contrib/src/ai/aiCharacter.cxx
@@ -13,6 +13,8 @@
 
 #include "aiCharacter.h"
 
+using std::string;
+
 AICharacter::AICharacter(std::string model_name, NodePath model_np, double mass, double movt_force, double max_force) {
   _name = model_name;
   _ai_char_np = model_np;
@@ -107,6 +109,10 @@ void AICharacter::set_node_path(NodePath np) {
 
 AIBehaviors * AICharacter::get_ai_behaviors() {
   return _steering;
+}
+
+string AICharacter::get_name() {
+  return _name;
 }
 
 void AICharacter::set_char_render(NodePath render) {

--- a/contrib/src/ai/aiCharacter.h
+++ b/contrib/src/ai/aiCharacter.h
@@ -60,6 +60,8 @@ PUBLISHED:
 
     AIBehaviors * get_ai_behaviors();
 
+    std::string get_name();
+
     // This function is used to enable or disable the guides for path finding.
     void set_pf_guide(bool pf_guide);
 


### PR DESCRIPTION
## Issue description
Removing characters from an AIWorld requires passing the character name; however, there's currently no way to get the name of a given character.

## Solution description
Add the ability to get the name of a character.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
