### PR TITLE
assimp: Support compilation with Assimp 5.x

### DIFF
--- a/pandatool/src/assimp/pandaLogger.cxx
+++ b/pandatool/src/assimp/pandaLogger.cxx
@@ -43,6 +43,15 @@ void PandaLogger::OnDebug(const char *message) {
 /**
  *
  */
+void PandaLogger::OnVerboseDebug(const char *message) {
+  if (assimp_cat.is_spam()) {
+    assimp_cat.spam() << message << "\n";
+  }
+}
+
+/**
+ *
+ */
 void PandaLogger::OnError(const char *message) {
   assimp_cat.error() << message << "\n";
 }

--- a/pandatool/src/assimp/pandaLogger.h
+++ b/pandatool/src/assimp/pandaLogger.h
@@ -30,11 +30,17 @@ protected:
   INLINE bool attachStream(Assimp::LogStream*, unsigned int) {
     return false;
   };
+  INLINE bool detachStream(Assimp::LogStream*, unsigned int) {
+    return false;
+  };
+
+  // Kept for compatibility with Assimp 4.x
   INLINE bool detatchStream(Assimp::LogStream*, unsigned int) {
     return false;
   };
 
   void OnDebug(const char *message);
+  void OnVerboseDebug(const char *message);
   void OnError(const char *message);
   void OnInfo(const char *message);
   void OnWarn(const char *message);


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
Attempting to build Panda3D with Assimp support on Debian Bookworm or Debian Sid fails with the following compilation error:

```
[T1] Building C++ object built/tmp/p3assimp_composite1.o
In file included from pandatool/src/assimp/p3assimp_composite1.cxx:7:
pandatool/src/assimp/pandaLogger.cxx: In static member function ‘static void Pan
pandatool/src/assimp/pandaLogger.cxx:27:16: error: invalid new-expression of abs
   27 |     _ptr = new PandaLogger;
      |                ^~~~~~~~~~~
In file included from pandatool/src/assimp/assimpLoader.cxx:40,
                 from pandatool/src/assimp/p3assimp_composite1.cxx:3:
pandatool/src/assimp/pandaLogger.h:25:7: note:   because the following virtual f
   25 | class PandaLogger : public Assimp::Logger {
      |       ^~~~~~~~~~~
In file included from pandatool/src/assimp/pandaLogger.h:19,
                 from pandatool/src/assimp/assimpLoader.cxx:40,
                 from pandatool/src/assimp/p3assimp_composite1.cxx:3:
/usr/include/assimp/Logger.hpp:182:18: note:     ‘virtual bool Assimp::Logger::d
  182 |     virtual bool detachStream(LogStream *pStream,
      |                  ^~~~~~~~~~~~
```

The Assimp commit that breaks compatibility with the current Panda3D tree is the following: https://github.com/assimp/assimp/commit/5e0136d737ebaa6f2547c20c72dc24edb8e3d3d4

It fixes a typo in the "detatchStream" function signature, and adds a new method called OnVerboseDebug, which are missing from the Panda3D implementation.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
This commit solves compatibility issues with Assimp 5.x by implementing OnVerboseDebug (which is translated into logging with "spam" level in Panda3D) and detachStream, while keeping the old detatchStream method for compatibility with Assimp 4.x.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
