### PR TITLE
maya: Add support for Maya 2022

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -1040,7 +1040,7 @@ if (COMPILER=="GCC"):
             LibName(pkg, "-lDependEngine")
             LibName(pkg, "-lCommandEngine")
             LibName(pkg, "-lFoundation")
-            if pkg != "MAYA2020":
+            if pkg not in ("MAYA2020", "MAYA2022"):
                 LibName(pkg, "-lIMFbase")
             if GetTarget() != 'darwin':
                 LibName(pkg, "-lOpenMayalib")

--- a/makepanda/makepandacore.py
+++ b/makepanda/makepandacore.py
@@ -108,6 +108,7 @@ MAYAVERSIONINFO = [("MAYA6",   "6.0"),
                    ("MAYA2018","2018"),
                    ("MAYA2019","2019"),
                    ("MAYA2020","2020"),
+                   ("MAYA2022","2022"),
 ]
 
 MAXVERSIONINFO = [("MAX6", "SOFTWARE\\Autodesk\\3DSMAX\\6.0", "installdir", "maxsdk\\cssdk\\include"),

--- a/pandatool/src/mayaprogs/mayapath.cxx
+++ b/pandatool/src/mayaprogs/mayapath.cxx
@@ -108,6 +108,7 @@ struct MayaVerInfo maya_versions[] = {
   { "MAYA2018", "2018"},
   { "MAYA2019", "2019"},
   { "MAYA2020", "2020"},
+  { "MAYA2022", "2022"},
   { 0, 0 },
 };
 


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
Maya 2022 was released earlier this year. Currently, Panda3D does not support the compilation of Maya 2022 utilities.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
This PR adds support for Maya 2022 utility compilation by adding the necessary definitions into `makepandacore.py` and `mayapath.cxx`.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
