### PR TITLE
Add rpmversion for packaging.

### DIFF
--- a/makepanda/makepackage.py
+++ b/makepanda/makepackage.py
@@ -276,7 +276,7 @@ def MakeDebugSymbolArchive(zipname, dirname):
     zip.close()
 
 
-def MakeInstallerLinux(version, debversion=None, rpmrelease=1, runtime=False,
+def MakeInstallerLinux(version, debversion=None, rpmversion=None, rpmrelease=1, runtime=False,
                        python_versions=[], **kwargs):
     outputdir = GetOutputDir()
 
@@ -302,6 +302,8 @@ def MakeInstallerLinux(version, debversion=None, rpmrelease=1, runtime=False,
     major_version = '.'.join(version.split('.')[:2])
     if not debversion:
         debversion = version
+    if not rpmversion:
+        rpmversion = version
 
     # Clean and set up a directory to install Panda3D into
     oscmd("rm -rf targetroot data.tar.gz control.tar.gz panda3d.spec")
@@ -461,16 +463,16 @@ def MakeInstallerLinux(version, debversion=None, rpmrelease=1, runtime=False,
                     txt += "/usr/bin/%s\n" % (base)
 
         # Write out the spec file.
-        txt = txt.replace("VERSION", version)
+        txt = txt.replace("VERSION", rpmversion)
         txt = txt.replace("RPMRELEASE", str(rpmrelease))
         txt = txt.replace("PANDASOURCE", pandasource)
         WriteFile("panda3d.spec", txt)
 
         oscmd("fakeroot rpmbuild --define '_rpmdir "+pandasource+"' --buildroot '"+os.path.abspath("targetroot")+"' -bb panda3d.spec")
         if runtime:
-            oscmd("mv "+arch+"/panda3d-runtime-"+version+"-"+rpmrelease+"."+arch+".rpm .")
+            oscmd("mv "+arch+"/panda3d-runtime-"+rpmversion+"-"+rpmrelease+"."+arch+".rpm .")
         else:
-            oscmd("mv "+arch+"/panda3d-"+version+"-"+rpmrelease+"."+arch+".rpm .")
+            oscmd("mv "+arch+"/panda3d-"+rpmversion+"-"+rpmrelease+"."+arch+".rpm .")
         oscmd("rm -rf "+arch, True)
 
     else:
@@ -1130,6 +1132,7 @@ if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option('', '--version', dest='version', help='Panda3D version number (default: %s)' % (version), default=version)
     parser.add_option('', '--debversion', dest='debversion', help='Version number for .deb file', default=None)
+    parser.add_option('', '--rpmversion', dest='rpmversion', help='Version number for .rpm file', default=None)
     parser.add_option('', '--rpmrelease', dest='rpmrelease', help='Release number for .rpm file', default='1')
     parser.add_option('', '--outputdir', dest='outputdir', help='Makepanda\'s output directory (default: built)', default='built')
     parser.add_option('', '--verbose', dest='verbose', help='Enable verbose output', action='store_true', default=False)
@@ -1167,6 +1170,7 @@ if __name__ == "__main__":
                   optimize=GetOptimize(),
                   compressor=options.compressor,
                   debversion=options.debversion,
+                  rpmversion=options.rpmversion,
                   rpmrelease=options.rpmrelease,
                   runtime=options.runtime,
                   python_versions=ReadPythonVersionInfoFile(),

--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -56,6 +56,7 @@ DISTRIBUTOR=""
 VERSION=None
 DEBVERSION=None
 WHLVERSION=None
+RPMVERSION=None
 RPMRELEASE="1"
 GIT_COMMIT=None
 P3DSUFFIX=None
@@ -171,7 +172,7 @@ def usage(problem):
 def parseopts(args):
     global INSTALLER,WHEEL,RUNTESTS,RTDIST,RUNTIME,GENMAN,DISTRIBUTOR,VERSION
     global COMPRESSOR,THREADCOUNT,OSXTARGET,OSX_ARCHS,HOST_URL
-    global DEBVERSION,WHLVERSION,RPMRELEASE,GIT_COMMIT,P3DSUFFIX,RTDIST_VERSION
+    global DEBVERSION,WHLVERSION,RPMVERSION,RPMRELEASE,GIT_COMMIT,P3DSUFFIX,RTDIST_VERSION
     global STRDXSDKVERSION, WINDOWS_SDK, MSVC_VERSION, BOOUSEINTELCOMPILER
     global COPY_PYTHON
 
@@ -185,7 +186,7 @@ def parseopts(args):
         "help","distributor=","verbose","runtime","osxtarget=","tests",
         "optimize=","everything","nothing","installer","wheel","rtdist","nocolor",
         "version=","lzma","no-python","threads=","outputdir=","override=",
-        "static","host=","debversion=","rpmrelease=","p3dsuffix=","rtdist-version=",
+        "static","host=","debversion=","rpmversion=","rpmrelease=","p3dsuffix=","rtdist-version=",
         "directx-sdk=", "windows-sdk=", "msvc-version=", "clean", "use-icl",
         "universal", "target=", "arch=", "git-commit=", "no-copy-python",
         "cggl-incdir=", "cggl-libdir=",
@@ -236,6 +237,7 @@ def parseopts(args):
             elif (option=="--static"): SetLinkAllStatic(True)
             elif (option=="--host"): HOST_URL=value
             elif (option=="--debversion"): DEBVERSION=value
+            elif (option=="--rpmversion"): RPMVERSION=value
             elif (option=="--rpmrelease"): RPMRELEASE=value
             elif (option=="--git-commit"): GIT_COMMIT=value
             elif (option=="--p3dsuffix"): P3DSUFFIX=value
@@ -425,6 +427,9 @@ if RUNTIME or RTDIST:
 
 if DEBVERSION is None:
     DEBVERSION = VERSION
+
+if RPMVERSION is None:
+    RPMVERSION = VERSION
 
 MAJOR_VERSION = '.'.join(VERSION.split('.')[:2])
 
@@ -7186,7 +7191,7 @@ if INSTALLER:
 
     MakeInstaller(version=VERSION, outputdir=GetOutputDir(),
                   optimize=GetOptimize(), compressor=COMPRESSOR,
-                  debversion=DEBVERSION, rpmrelease=RPMRELEASE,
+                  debversion=DEBVERSION, rpmversion=RPMVERSION, rpmrelease=RPMRELEASE,
                   runtime=RUNTIME, python_versions=python_versions)
 
 if WHEEL:


### PR DESCRIPTION
## Issue description
The current way the package version is set for rpm builds is insufficient - although there is an `rpmrelease` field, this is insufficient for setting things like pre-release or post-release package versions.  Given conventions [in these guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/), a fuller versioning scheme is required.

Note that a "complete" rpm version is required if an effort is being made to build C++ modules for python against manylinux systems.

## Solution description
This PR just adds an `--rpmversion` option to mimic the `--debversion` option.

Adding additional versions this way may be unsustainable, though, if we anticipate more being added in the future.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
