### PR TITLE
Correct location searched for 64-bit libc-2.24

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -497,7 +497,7 @@ elif target == 'linux' and (os.path.isfile("/lib/libc-2.17.so") or os.path.isfil
     else:
         PLATFORM = 'manylinux2014-i686'
 
-elif target == 'linux' and (os.path.isfile("/lib/i386-linux-gnu/libc-2.24.so") or os.path.isfile("/lib/x86_64/libc-2.24.so")) and os.path.isdir("/opt/python"):
+elif target == 'linux' and (os.path.isfile("/lib/i386-linux-gnu/libc-2.24.so") or os.path.isfile("/lib/x86_64-linux-gnu/libc-2.24.so")) and os.path.isdir("/opt/python"):
     # Same sloppy check for manylinux_2_24.
     if GetTargetArch() in ('x86_64', 'amd64'):
         PLATFORM = 'manylinux_2_24-x86_64'

--- a/makepanda/makewheel.py
+++ b/makepanda/makewheel.py
@@ -558,7 +558,7 @@ def makewheel(version, output_dir, platform=None):
                     platform = platform.replace("linux", "manylinux2010")
                 elif os.path.isfile("/lib/libc-2.17.so") or os.path.isfile("/lib64/libc-2.17.so"):
                     platform = platform.replace("linux", "manylinux2014")
-                elif os.path.isfile("/lib/i386-linux-gnu/libc-2.24.so") or os.path.isfile("/lib/x86_64/libc-2.24.so"):
+                elif os.path.isfile("/lib/i386-linux-gnu/libc-2.24.so") or os.path.isfile("/lib/x86_64-linux-gnu/libc-2.24.so"):
                     platform = platform.replace("linux", "manylinux_2_24")
 
     platform = platform.replace('-', '_').replace('.', '_')


### PR DESCRIPTION
## Issue description
Fixes an error introduced with a723567a3a4a32a1f7167bcb049aeea5b69ab7cf - the search path was not complete, and caused 64-bit wheels to not properly detect as `manylinux_2_24`.
I think this must have been a copy error on my part...?

In any case, I have built the wheel from the live version of the repository this time around (as opposed to building off a local clone).

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
