### PR TITLE
Floor result of size multiplier in Filter Manager (#1231)

### DIFF
--- a/direct/src/filter/FilterManager.py
+++ b/direct/src/filter/FilterManager.py
@@ -15,6 +15,7 @@ Still need to implement:
 * Do something about window-size roundoff problems.
 
 """
+import math
 
 from panda3d.core import NodePath
 from panda3d.core import Texture
@@ -123,8 +124,8 @@ class FilterManager(DirectObject):
             winy = winy // div
 
         if mul != 1:
-            winx = winx * mul
-            winy = winy * mul
+            winx = math.floor(winx * mul)
+            winy = math.floor(winy * mul)
 
         return winx,winy
 


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
This solves issue #1231 

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
This uses math.floor to floor the result of multiplying the provided multiplier in the getScaledSize function.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
