### PR TITLE
makepanda: Record cache timestamps as integers rather than floats

### DIFF
--- a/makepanda/makepandacore.py
+++ b/makepanda/makepandacore.py
@@ -717,7 +717,7 @@ def GetTimestamp(path):
     if path in TIMESTAMPCACHE:
         return TIMESTAMPCACHE[path]
     try:
-        date = os.path.getmtime(path)
+        date = int(os.path.getmtime(path))
     except:
         date = 0
     TIMESTAMPCACHE[path] = date
@@ -871,7 +871,7 @@ def JavaGetImports(path):
 ##
 ########################################################################
 
-DCACHE_VERSION = 2
+DCACHE_VERSION = 3
 DCACHE_BACKED_UP = False
 
 def SaveDependencyCache():


### PR DESCRIPTION
We don't need the extra precision, in fact it is detrimental to restoring build caches in a cross-platform way.

This commit will invalidate all current build caches.

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
The makepanda system currently saves the last built timestamps encountered for each file. This can be a problem when caching the `built` folder of a build attempt, as the saved / restored granularity of the timestamps might not match between different platforms, leading to the build cache being completely disregarded after being restored.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
This pull request resolves this problem by storing timestamps as integers in the build cache. It also increments the version number of the build cache, leading to a single rebuild being required after pulling this change.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
