### PR TITLE
makepanda: Create 7-zip debug symbol archives by default, if available

### DIFF
--- a/makepanda/makepandacore.py
+++ b/makepanda/makepandacore.py
@@ -572,6 +572,26 @@ def GetFlexVersion():
         Warn("Unable to detect flex version")
         return (0, 0, 0)
 
+SEVENZIP = None
+def GetSevenZip():
+    global SEVENZIP
+    if SEVENZIP is not None:
+        return SEVENZIP
+
+    win_util = os.path.join(GetThirdpartyBase(), 'win-util')
+    if GetHost() == 'windows' and os.path.isdir(win_util):
+        SEVENZIP = GetThirdpartyBase() + "/win-util/7za.exe"
+    elif LocateBinary('7z'):
+        SEVENZIP = '7z'
+    else:
+        # We don't strictly need it, so don't give an error
+        return None
+
+    return SEVENZIP
+
+def HasSevenZip():
+    return GetSevenZip() is not None
+
 ########################################################################
 ##
 ## LocateBinary


### PR DESCRIPTION
7-zip archives will only be created if 7-zip is available during the build phase. When 7-zip is unavailable, ZIP archives will be created as a fallback.

Benchmarks:

- Default ZIP compression: ~23.5 seconds, 162 MB
- 7-zip compression: ~7.5 seconds, 108 MB
- 7-zip compression, `--lzma` set: ~44 seconds, 88 MB
- 7-zip compression, solid archive: ~5 minutes, 83 MB (not implemented)

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
The makepanda system takes up quite some time creating debug archives on Windows. For how much time it's spending creating ZIP archives, the end result is quite disappointing: 23.5 seconds on average yields a 162 MB archive.

If we were packing these PDB files into a 7-Zip archive instead, we could save on both disk space and CPU cores.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
When 7-zip is available, makepanda will now build 7-zip archives. There are two modes available:
- No `--lzma` set: an LZMA2 7-Zip archive will be created with compression level 3. An average archive will take around 7.5 seconds to create, and will weigh around 108 megabytes - a 33.3% size reduction (on my testing machine)
- `--lzma` set: an LZMA2 7-Zip archive will be created with default settings. An average archive will take around 44 seconds to create, and will weigh around 88 megabytes, a 46% size reduction (on my testing machine)

If 7-zip is unavailable, a simple ZIP archive will be created like before.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
