### PR TITLE
Make AI update take time into account

### DIFF
--- a/contrib/src/ai/aiCharacter.cxx
+++ b/contrib/src/ai/aiCharacter.cxx
@@ -42,7 +42,7 @@ AICharacter::~AICharacter() {
  * direction of the force.
  */
 void AICharacter::
-update() {
+update(PN_stdfloat dt) {
   if (!_steering->is_off(_steering->_none)) {
     static const LRotation ai_flip = LRotation(180, 0, 0);
     static const LMatrix4 ai_flip_matrix = LMatrix4::rotate_mat(ai_flip.get_angle(), ai_flip.get_axis_normalized());
@@ -50,9 +50,9 @@ update() {
     LVecBase3 steering_force = _steering->calculate_prioritized();
     LVecBase3 acceleration = steering_force / _mass;
 
-    _velocity = acceleration;
+    _velocity += acceleration * dt;
 
-    _ai_char_np.set_pos(old_pos + _velocity) ;
+    _ai_char_np.set_pos(old_pos + _velocity * dt);
 
     if (steering_force.length() > 0) {
       LVecBase3 direction = _steering->_steering_force;

--- a/contrib/src/ai/aiCharacter.cxx
+++ b/contrib/src/ai/aiCharacter.cxx
@@ -44,22 +44,21 @@ AICharacter::~AICharacter() {
 void AICharacter::
 update() {
   if (!_steering->is_off(_steering->_none)) {
-    const LRotation ai_flip = LRotation(180, 0, 0);
-    const LMatrix4 ai_flip_matrix = LMatrix4::rotate_mat(ai_flip.get_angle(), ai_flip.get_axis_normalized());
+    static const LRotation ai_flip = LRotation(180, 0, 0);
+    static const LMatrix4 ai_flip_matrix = LMatrix4::rotate_mat(ai_flip.get_angle(), ai_flip.get_axis_normalized());
     LVecBase3 old_pos = _ai_char_np.get_pos();
     LVecBase3 steering_force = _steering->calculate_prioritized();
     LVecBase3 acceleration = steering_force / _mass;
 
     _velocity = acceleration;
 
-
-    LVecBase3 direction = _steering->_steering_force;
-    direction.normalize();
-    ai_flip_matrix.xform_vec_in_place(direction);
-
     _ai_char_np.set_pos(old_pos + _velocity) ;
 
     if (steering_force.length() > 0) {
+      LVecBase3 direction = _steering->_steering_force;
+      direction.normalize();
+      ai_flip_matrix.xform_vec_in_place(direction);
+
       _ai_char_np.look_at(_ai_char_np.get_pos() + direction);
     }
   } else {

--- a/contrib/src/ai/aiCharacter.cxx
+++ b/contrib/src/ai/aiCharacter.cxx
@@ -44,22 +44,23 @@ AICharacter::~AICharacter() {
 void AICharacter::
 update() {
   if (!_steering->is_off(_steering->_none)) {
+    const LRotation ai_flip = LRotation(180, 0, 0);
+    const LMatrix4 ai_flip_matrix = LMatrix4::rotate_mat(ai_flip.get_angle(), ai_flip.get_axis_normalized());
     LVecBase3 old_pos = _ai_char_np.get_pos();
     LVecBase3 steering_force = _steering->calculate_prioritized();
     LVecBase3 acceleration = steering_force / _mass;
 
     _velocity = acceleration;
 
+
     LVecBase3 direction = _steering->_steering_force;
     direction.normalize();
+    ai_flip_matrix.xform_vec_in_place(direction);
 
     _ai_char_np.set_pos(old_pos + _velocity) ;
 
     if (steering_force.length() > 0) {
-      _ai_char_np.look_at(old_pos + (direction * 5));
-      _ai_char_np.set_h(_ai_char_np.get_h() + 180);
-      _ai_char_np.set_p(-_ai_char_np.get_p());
-      _ai_char_np.set_r(-_ai_char_np.get_r());
+      _ai_char_np.look_at(_ai_char_np.get_pos() + direction);
     }
   } else {
     _steering->_steering_force = LVecBase3(0.0, 0.0, 0.0);

--- a/contrib/src/ai/aiCharacter.cxx
+++ b/contrib/src/ai/aiCharacter.cxx
@@ -54,7 +54,7 @@ update(PN_stdfloat dt) {
 
     _ai_char_np.set_pos(old_pos + _velocity * dt);
 
-    if (steering_force.length() > 0) {
+    if (steering_force.length_squared() > 0) {
       LVecBase3 direction = _steering->_steering_force;
       direction.normalize();
       ai_flip_matrix.xform_vec_in_place(direction);

--- a/contrib/src/ai/aiCharacter.h
+++ b/contrib/src/ai/aiCharacter.h
@@ -41,7 +41,7 @@ class EXPCL_PANDAAI AICharacter : public ReferenceCount {
   NodePath _ai_char_np;
   bool _pf_guide;
 
-  void update();
+  void update(PN_stdfloat dt = 1.0);
   void set_velocity(LVecBase3 vel);
   void set_char_render(NodePath render);
   NodePath get_char_render();

--- a/contrib/src/ai/aiWorld.cxx
+++ b/contrib/src/ai/aiWorld.cxx
@@ -70,9 +70,9 @@ void AIWorld::print_list() {
  * The AIWorld update function calls the update function of all the AI
  * characters which have been added to the AIWorld.
  */
-void AIWorld::update() {
+void AIWorld::update(PN_stdfloat dt) {
   for (AICharacter *ai_char : _ai_char_pool) {
-    ai_char->update();
+    ai_char->update(dt);
   }
 }
 

--- a/contrib/src/ai/aiWorld.h
+++ b/contrib/src/ai/aiWorld.h
@@ -56,7 +56,7 @@ PUBLISHED:
     void remove_obstacle(NodePath obstacle);
 
     void print_list();
-    void update();
+    void update(PN_stdfloat dt = 1.0);
 };
 
 #endif


### PR DESCRIPTION
## Issue description
Currently, the contrib ai system doesn't take the time between updates into account, which means that ai-powered objects move slower at lower frame rates (and faster at higher ones). 

The way facing updated would, if the object was supposed to move more than ~5 meters per update, make the object face _backwards_ to the direction of travel.

## Solution description
 - Corrects facing to be based off the current position and force direction, instead of the previous position.
 - Applies time to velocity/position calculations.
   - If a current project is using a fixed 30/60 fps no updates are likely to be required, but outside of that delta-time should be threaded through, and object mass/force updated as appropriate.  Frame rates below ~10 fps may interact poorly with the physics system due to no substeps.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
