### PR TITLE
DirectNotify: Expand setVerbose function

### DIFF
--- a/direct/src/directnotify/DirectNotify.py
+++ b/direct/src/directnotify/DirectNotify.py
@@ -105,14 +105,14 @@ class DirectNotify:
         for categoryName in self.getCategories():
             self.setDconfigLevel(categoryName)
 
-    def setVerbose(self, info=1, warning=1, debug=1):
+    def setVerbose(self, warning=1, info=1, debug=1):
         """
         Change the severity output of all of the registered categories en masse.
         """
         for categoryName in self.getCategories():
             category = self.getCategory(categoryName)
-            category.setWarning(info)
-            category.setInfo(warning)
+            category.setWarning(warning)
+            category.setInfo(info)
             category.setDebug(debug)
 
     def popupControls(self, tl = None):

--- a/direct/src/directnotify/DirectNotify.py
+++ b/direct/src/directnotify/DirectNotify.py
@@ -105,12 +105,15 @@ class DirectNotify:
         for categoryName in self.getCategories():
             self.setDconfigLevel(categoryName)
 
-    def setVerbose(self):
+    def setVerbose(self, info=1, warning=1, debug=1):
+        """
+        Change the severity output of all of the registered categories en masse.
+        """
         for categoryName in self.getCategories():
             category = self.getCategory(categoryName)
-            category.setWarning(1)
-            category.setInfo(1)
-            category.setDebug(1)
+            category.setWarning(info)
+            category.setInfo(warning)
+            category.setDebug(debug)
 
     def popupControls(self, tl = None):
         # Don't use a regular import, to prevent ModuleFinder from picking

--- a/direct/src/directnotify/DirectNotify.py
+++ b/direct/src/directnotify/DirectNotify.py
@@ -8,12 +8,12 @@ from . import Logger
 class DirectNotify:
     """
     DirectNotify class: this class contains methods for creating
-    mulitple notify categories via a dictionary of Notifiers.
+    multiple notify categories via a dictionary of Notifiers.
     """
 
     def __init__(self):
         """
-        DirectNotify class keeps a dictionary of Notfiers
+        DirectNotify class keeps a dictionary of Notifiers
         """
         self.__categories = { }
         # create a default log file
@@ -30,7 +30,7 @@ class DirectNotify:
         """
         return "DirectNotify categories: %s" % (self.__categories)
 
-    #getters and setters
+    # getters and setters
     def getCategories(self):
         """
         Return list of category dictionary keys


### PR DESCRIPTION
## Issue description
The convenience function setVerbose in direct.directNotify.DirectNotify only provides the ability to enable _all_ forms of severity levels for each registered category. There isn't a complementary function to disable nor modify particular levels to output.

## Solution description
I've slightly expanded the setVerbose function to take three new optional arguments; any user who may be using this feature in their code should not experience any differences whatsoever. Now one can verbosely toggle on/off for each level of severity! (Besides the error severity, that is)
Additionally, I adjusted several minor grammatical issues with this class documentation.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
