### PR TITLE
x11GraphicsWindow: Only wait to draw on window reconfigures

### DIFF
--- a/panda/src/x11display/x11GraphicsWindow.cxx
+++ b/panda/src/x11display/x11GraphicsWindow.cxx
@@ -116,6 +116,7 @@ x11GraphicsWindow(GraphicsEngine *engine, GraphicsPipe *pipe,
   }
 
   _awaiting_configure = false;
+  _first_configure_done = false;
   _dga_mouse_enabled = false;
   _raw_mouse_enabled = false;
   _override_redirect = False;
@@ -1049,7 +1050,11 @@ set_properties_now(WindowProperties &properties) {
     XReconfigureWMWindow(_display, _xwindow, _screen, value_mask, &changes);
 
     // Don't draw anything until this is done reconfiguring.
-    _awaiting_configure = true;
+    if (_first_configure_done) {
+        _awaiting_configure = true;
+    } else {
+        _first_configure_done = true;
+    }
   }
 }
 

--- a/panda/src/x11display/x11GraphicsWindow.h
+++ b/panda/src/x11display/x11GraphicsWindow.h
@@ -104,6 +104,7 @@ protected:
 
   long _event_mask;
   bool _awaiting_configure;
+  bool _first_configure_done;
   bool _dga_mouse_enabled;
   bool _raw_mouse_enabled;
   Bool _override_redirect;


### PR DESCRIPTION
## Issue description
This is a fix for #1087 where Panda gets stuck waiting on an initial X11 window configure.

## Solution description
Instead of waiting on all configure/reconfigures, we only await on true Window reconfigures and stop waiting for a ConfigNotify for the initial window config.

Tested using
* i3wm+x11
* sway+xwayland
* kwin+x11
* kwin+xwayland

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
