### PR TITLE
mayaprogs: Resolve Maya conversion server memory leak by storing managers on the heap

### DIFF
--- a/pandatool/src/mayaprogs/mayaConversionClient.cxx
+++ b/pandatool/src/mayaprogs/mayaConversionClient.cxx
@@ -19,11 +19,8 @@
  * Initializes the Maya conversion client.
  */
 MayaConversionClient::
-MayaConversionClient()
+MayaConversionClient() : _qReader(&_qManager, 0), _cWriter(&_qManager, 0)
 {
-  _qManager = new QueuedConnectionManager();
-  _qReader = new QueuedConnectionReader(_qManager, 0);
-  _cWriter = new ConnectionWriter(_qManager, 0);
 }
 
 /**
@@ -44,12 +41,12 @@ bool MayaConversionClient::
 connect(NetAddress server) {
   if (_conn) {
     // Remove this connection from the readers list
-    _qReader->remove_connection(_conn);
+    _qReader.remove_connection(_conn);
     _conn = nullptr;
   }
 
   // Attempt to open a connection
-  _conn = _qManager->open_TCP_client_connection(server, 0);
+  _conn = _qManager.open_TCP_client_connection(server, 0);
 
   if (!_conn ||  _conn.is_null()) {
     // This connection could not be opened
@@ -57,7 +54,7 @@ connect(NetAddress server) {
   }
 
   // Add this connection to the readers list
-  _qReader->add_connection(_conn);
+  _qReader.add_connection(_conn);
   return true;
 }
 
@@ -94,17 +91,17 @@ queue(Filename working_directory, int argc, char *argv[], MayaConversionServer::
   datagram.add_uint8(conversion_type);
 
   // Send the conversion request
-  if (!_cWriter->send(datagram, _conn) || !_conn->flush()) {
+  if (!_cWriter.send(datagram, _conn) || !_conn->flush()) {
     nout << "Failed to send workload to server process.\n";
     return false;
   }
 
   // Wait for a response
-  while (_conn->get_socket()->Active() && !_qReader->data_available()) {
-    _qReader->poll();
+  while (_conn->get_socket()->Active() && !_qReader.data_available()) {
+    _qReader.poll();
   }
 
-  if (!_qReader->data_available()) {
+  if (!_qReader.data_available()) {
     // No response has been given by the server.
     nout << "No response has been given by the conversion server.\n";
     return false;
@@ -113,7 +110,7 @@ queue(Filename working_directory, int argc, char *argv[], MayaConversionServer::
   NetDatagram response;
 
   // Let's read the response now!
-  if (!_qReader->get_data(response)) {
+  if (!_qReader.get_data(response)) {
     nout << "The conversion response could not be read.\n";
     return false;
   }
@@ -147,13 +144,13 @@ close() {
   }
 
   while (true) {
-    _qReader->data_available();
+    _qReader.data_available();
 
-    if (_qManager->reset_connection_available()) {
+    if (_qManager.reset_connection_available()) {
       PT(Connection) connection;
 
-      if (_qManager->get_reset_connection(connection)) {
-        _qManager->close_connection(_conn);
+      if (_qManager.get_reset_connection(connection)) {
+        _qManager.close_connection(_conn);
         _conn = nullptr;
         return;
       }

--- a/pandatool/src/mayaprogs/mayaConversionClient.cxx
+++ b/pandatool/src/mayaprogs/mayaConversionClient.cxx
@@ -19,7 +19,7 @@
  * Initializes the Maya conversion client.
  */
 MayaConversionClient::
-MayaConversionClient() : _qReader(&_qManager, 0), _cWriter(&_qManager, 0)
+MayaConversionClient() : _reader(&_manager, 0), _writer(&_manager, 0)
 {
 }
 
@@ -41,12 +41,12 @@ bool MayaConversionClient::
 connect(NetAddress server) {
   if (_conn) {
     // Remove this connection from the readers list
-    _qReader.remove_connection(_conn);
+    _reader.remove_connection(_conn);
     _conn = nullptr;
   }
 
   // Attempt to open a connection
-  _conn = _qManager.open_TCP_client_connection(server, 0);
+  _conn = _manager.open_TCP_client_connection(server, 0);
 
   if (!_conn ||  _conn.is_null()) {
     // This connection could not be opened
@@ -54,7 +54,7 @@ connect(NetAddress server) {
   }
 
   // Add this connection to the readers list
-  _qReader.add_connection(_conn);
+  _reader.add_connection(_conn);
   return true;
 }
 
@@ -91,17 +91,17 @@ queue(Filename working_directory, int argc, char *argv[], MayaConversionServer::
   datagram.add_uint8(conversion_type);
 
   // Send the conversion request
-  if (!_cWriter.send(datagram, _conn) || !_conn->flush()) {
+  if (!_writer.send(datagram, _conn) || !_conn->flush()) {
     nout << "Failed to send workload to server process.\n";
     return false;
   }
 
   // Wait for a response
-  while (_conn->get_socket()->Active() && !_qReader.data_available()) {
-    _qReader.poll();
+  while (_conn->get_socket()->Active() && !_reader.data_available()) {
+    _reader.poll();
   }
 
-  if (!_qReader.data_available()) {
+  if (!_reader.data_available()) {
     // No response has been given by the server.
     nout << "No response has been given by the conversion server.\n";
     return false;
@@ -110,7 +110,7 @@ queue(Filename working_directory, int argc, char *argv[], MayaConversionServer::
   NetDatagram response;
 
   // Let's read the response now!
-  if (!_qReader.get_data(response)) {
+  if (!_reader.get_data(response)) {
     nout << "The conversion response could not be read.\n";
     return false;
   }
@@ -144,13 +144,13 @@ close() {
   }
 
   while (true) {
-    _qReader.data_available();
+    _reader.data_available();
 
-    if (_qManager.reset_connection_available()) {
+    if (_manager.reset_connection_available()) {
       PT(Connection) connection;
 
-      if (_qManager.get_reset_connection(connection)) {
-        _qManager.close_connection(_conn);
+      if (_manager.get_reset_connection(connection)) {
+        _manager.close_connection(_conn);
         _conn = nullptr;
         return;
       }

--- a/pandatool/src/mayaprogs/mayaConversionClient.h
+++ b/pandatool/src/mayaprogs/mayaConversionClient.h
@@ -44,9 +44,9 @@ public:
   int main(int argc, char *argv[], MayaConversionServer::ConversionType conversion_type);
 
 private:
-  QueuedConnectionManager *_qManager;
-  QueuedConnectionReader *_qReader;
-  ConnectionWriter *_cWriter;
+  QueuedConnectionManager _qManager;
+  QueuedConnectionReader _qReader;
+  ConnectionWriter _cWriter;
   PT(Connection) _conn;
 };
 

--- a/pandatool/src/mayaprogs/mayaConversionClient.h
+++ b/pandatool/src/mayaprogs/mayaConversionClient.h
@@ -44,9 +44,9 @@ public:
   int main(int argc, char *argv[], MayaConversionServer::ConversionType conversion_type);
 
 private:
-  QueuedConnectionManager _qManager;
-  QueuedConnectionReader _qReader;
-  ConnectionWriter _cWriter;
+  QueuedConnectionManager _manager;
+  QueuedConnectionReader _reader;
+  ConnectionWriter _writer;
   PT(Connection) _conn;
 };
 

--- a/pandatool/src/mayaprogs/mayaConversionServer.h
+++ b/pandatool/src/mayaprogs/mayaConversionServer.h
@@ -40,7 +40,6 @@ public:
   };
 
   MayaConversionServer();
-  ~MayaConversionServer();
 
   void listen();
   void poll();
@@ -49,10 +48,10 @@ protected:
   typedef pset< PT(Connection) > Clients;
   Clients _clients;
 
-  QueuedConnectionManager *_qManager;
-  QueuedConnectionListener *_qListener;
-  QueuedConnectionReader *_qReader;
-  ConnectionWriter *_cWriter;
+  QueuedConnectionManager _qManager;
+  QueuedConnectionListener _qListener;
+  QueuedConnectionReader _qReader;
+  ConnectionWriter _cWriter;
 };
 
 #endif

--- a/pandatool/src/mayaprogs/mayaConversionServer.h
+++ b/pandatool/src/mayaprogs/mayaConversionServer.h
@@ -48,10 +48,10 @@ protected:
   typedef pset< PT(Connection) > Clients;
   Clients _clients;
 
-  QueuedConnectionManager _qManager;
-  QueuedConnectionListener _qListener;
-  QueuedConnectionReader _qReader;
-  ConnectionWriter _cWriter;
+  QueuedConnectionManager _manager;
+  QueuedConnectionListener _listener;
+  QueuedConnectionReader _reader;
+  ConnectionWriter _writer;
 };
 
 #endif


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
As @rdb has pointed out, `MayaConversionClient` is creating three objects on the heap but neglecting to clean it up in a missing destructor.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
Instead of creating a destructor, I've decided to take the objects off the heap completely. Instead, the constructor will initialize these connection management objects directly on the object on both `MayaConversionClient` and `MayaConversionServer`.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
