### PR TITLE
Fixed script to allow offline rendering on Linux

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -5535,8 +5535,10 @@ if (GetTarget() == 'android' and PkgSkip("EGL")==0 and PkgSkip("GLES")==0 and no
 # DIRECTORY: panda/src/tinydisplay/
 #
 
-if (not RUNTIME and (GetTarget() in ('windows', 'darwin') or PkgSkip("X11")==0) and PkgSkip("TINYDISPLAY")==0):
-  OPTS=['DIR:panda/src/tinydisplay', 'BUILDING:TINYDISPLAY', 'X11']
+if (not RUNTIME and (GetTarget() in ('windows', 'darwin', 'linux') or PkgSkip("X11")==0) and PkgSkip("TINYDISPLAY")==0):
+  OPTS=['DIR:panda/src/tinydisplay', 'BUILDING:TINYDISPLAY']
+  if PkgSkip("X11")==0:
+    OPTS += ['X11']
   TargetAdd('p3tinydisplay_composite1.obj', opts=OPTS, input='p3tinydisplay_composite1.cxx')
   TargetAdd('p3tinydisplay_composite2.obj', opts=OPTS, input='p3tinydisplay_composite2.cxx')
   TargetAdd('p3tinydisplay_ztriangle_1.obj', opts=OPTS, input='ztriangle_1.cxx')
@@ -5551,7 +5553,7 @@ if (not RUNTIME and (GetTarget() in ('windows', 'darwin') or PkgSkip("X11")==0) 
   elif GetTarget() == 'windows':
     TargetAdd('libp3tinydisplay.dll', input='libp3windisplay.dll')
     TargetAdd('libp3tinydisplay.dll', opts=['WINIMM', 'WINGDI', 'WINKERNEL', 'WINOLDNAMES', 'WINUSER', 'WINMM'])
-  else:
+  elif PkgSkip("X11")==0:
     TargetAdd('libp3tinydisplay.dll', input='p3x11display_composite1.obj')
     TargetAdd('libp3tinydisplay.dll', opts=['X11'])
   TargetAdd('libp3tinydisplay.dll', input='p3tinydisplay_composite1.obj')


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->

5 years ago I made a small change to makepanda.py to allow offscreen rendering to build for Linux using only the p3tinydisplay software rendering and have been using it since.  I'm finally getting around to contributing the change back.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

This PR removes the restriction that X11 must be enabled to build the software rendering.

## Checklist
I have done my best to ensure that…
* [✓] …I have familiarized myself with the CONTRIBUTING.md file
* [✓] …this change follows the coding style and design patterns of the codebase
* [✓] …I own the intellectual property rights to this code
* [✓] …the intent of this change is clearly explained
* [✓] …existing uses of the Panda3D API are not broken
* [✓] …the changed code is adequately covered by the test suite, where possible.
