### PR TITLE
Restore webcam functionality on Linux

### DIFF
--- a/panda/src/vision/webcamVideoCursorV4L.cxx
+++ b/panda/src/vision/webcamVideoCursorV4L.cxx
@@ -217,7 +217,7 @@ WebcamVideoCursorV4L(WebcamVideoV4L *src) : MovieVideoCursor(src) {
 
   int mode = O_RDWR;
   if (!v4l_blocking) {
-    mode = O_NONBLOCK;
+    mode |= O_NONBLOCK;
   }
 
   _fd = open(src->_device.c_str(), mode);


### PR DESCRIPTION
## Issue description
Webcam support is broken on Linux. mmap() for the buffers always returns MAP_FAILED.

## Solution description
mmap() takes into account the mode flags of the underlying file descriptor. After auditing the code it turns out the O_RDWR mode flag is being overwritten with O_NONBLOCK, when instead it should be OR'ed.

Fixing this restores webcam functionality.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
