### PR TITLE
Update FilterManager.py

### DIFF
--- a/direct/src/filter/FilterManager.py
+++ b/direct/src/filter/FilterManager.py
@@ -323,7 +323,7 @@ class FilterManager(DirectObject):
             props.setAuxRgba(1)
         if auxtex1 is not None:
             props.setAuxRgba(2)
-        buffer=base.graphicsEngine.makeOutput(
+        buffer=self.engine.makeOutput(
             self.win.getPipe(), name, -1,
             props, winprops, GraphicsPipe.BFRefuseWindow | GraphicsPipe.BFResizeable,
             self.win.getGsg(), self.win)


### PR DESCRIPTION
Removes the silly dependency on the **ShowBase** instance. For example, this allows you to use [simplepbr](https://github.com/Moguri/panda3d-simplepbr) without creating an instance of **ShowBase**.
