### PR TITLE
cocoadisplay: Add support for high-dpi screens

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -717,6 +717,7 @@ class build_apps(setuptools.Command):
             'CFBundlePackageType': 'APPL',
             'CFBundleSignature': '', #TODO
             'CFBundleExecutable': self.macos_main_app,
+            'NSHighResolutionCapable': 'True',
         }
 
         icon = self.icon_objects.get(

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.h
@@ -63,6 +63,7 @@ public:
   void handle_minimize_event(bool minimized);
   void handle_maximize_event(bool maximized);
   void handle_foreground_event(bool foreground);
+  void handle_backing_change_event();
   bool handle_close_request();
   void handle_close_event();
   void handle_key_event(NSEvent *event);

--- a/panda/src/cocoadisplay/cocoaPandaWindowDelegate.h
+++ b/panda/src/cocoadisplay/cocoaPandaWindowDelegate.h
@@ -29,6 +29,7 @@ class CocoaGraphicsWindow;
 - (void)windowDidDeminiaturize:(NSNotification *)notification;
 - (void)windowDidBecomeKey:(NSNotification *)notification;
 - (void)windowDidResignKey:(NSNotification *)notification;
+- (void)windowDidChangeBackingProperties:(NSNotification *)notification;
 - (BOOL)windowShouldClose:(id)sender;
 - (void)windowWillClose:(id)sender;
 

--- a/panda/src/cocoadisplay/cocoaPandaWindowDelegate.mm
+++ b/panda/src/cocoadisplay/cocoaPandaWindowDelegate.mm
@@ -51,6 +51,10 @@
   _graphicsWindow->handle_foreground_event(false);
 }
 
+- (void) windowDidChangeBackingProperties:(NSNotification *)notification {
+  _graphicsWindow->handle_backing_change_event();
+}
+
 - (BOOL) windowShouldClose:(id)sender {
   if (cocoadisplay_cat.is_debug()) {
     cocoadisplay_cat.debug()

--- a/panda/src/cocoadisplay/config_cocoadisplay.h
+++ b/panda/src/cocoadisplay/config_cocoadisplay.h
@@ -21,6 +21,7 @@
 NotifyCategoryDecl(cocoadisplay, EXPCL_PANDA_COCOADISPLAY, EXPTP_PANDA_COCOADISPLAY);
 
 extern ConfigVariableBool cocoa_invert_wheel_x;
+extern ConfigVariableBool dpi_aware;
 
 extern EXPCL_PANDA_COCOADISPLAY void init_libcocoadisplay();
 

--- a/panda/src/cocoadisplay/config_cocoadisplay.mm
+++ b/panda/src/cocoadisplay/config_cocoadisplay.mm
@@ -32,6 +32,11 @@ ConfigVariableBool cocoa_invert_wheel_x
 ("cocoa-invert-wheel-x", false,
  PRC_DESC("Set this to true to swap the wheel_left and wheel_right mouse "
           "button events, to restore to the pre-1.10.12 behavior."));
+ConfigVariableBool dpi_aware
+("dpi-aware", false,
+ PRC_DESC("The default behavior on macOS is for Panda3D to use upscaling on"
+          "high DPI screen. Set this to true to let the application use the"
+          "actual pixel density of the screen."));
 
 /**
  * Initializes the library.  This must be called at least once before any of


### PR DESCRIPTION
## Issue description

This PR add High-DPI support on macOS. Until now, on macOS a Panda3D application was not "dpi-aware" and so the OpenGL view was upscaled by the system. With this PR, an application can set `dpi-aware` to `true` to disable the scaling on High-DPI/Retina screen and use the full resolution of the display.

See also the discussion here : https://discourse.panda3d.org/t/updated-there-is-no-retina-support-on-mac-catalina-big-sur/27946

## Solution description

On macOS, an application should not be aware of the actual pixel density of a screen, the application uses display points that are then transformed into actual pixel coordinates by appkit. Pixel units (or more exactly backing store points), are to be used only for some specific case. On the other hand, in the philosophy of the High-DPI support of Panda3D the unit used is always display pixels. Therefore, with this PR, the size of the window and view are converted to display points when modified by the application, and converted from display point into pixels when updated by the system.

 NSApp, NSWindow and MSView can have their own value for the `NSHighResolutionCapable` flag, which control the automatic upscaling of the application/window/view.  To have a coherent behaviour between an application that is launched using the Python interpreter (which has this flag set to `True` since macOS 10.15) and an application built using deploy_ng, and also to allow an application to programmatically decide to support high dpi or not, this PR set the `NSHighResolutionCapable` flag to `True` in the `Info.plist` generated by deploy_ng. Therefore the application and the window will always be dpi aware. The `NSHighResolutionCapable` flag of the view is instead controlled by the `dpi-aware` configuration variable. 

As usual, there are a lot of quirks, weird behaviours and undocumented features in AppKit that I had to work around (I documented their occurence in the code).
There are two important modifications to be noted here : 

first, `CGLSetFullScreenOnDisplay()` seems to not support high-dpi mode (at least I could not find to make it work) and I had to remove its usage, otherwise the fullscreen view was always upscaled. As a consequence I also had to remove call to `CGDisplayCapture()`

Also, in the events fired by `makeFirstResponder()` the internal state of the NSView was wrong and lead to invalid size of position. That's why I forced a manual call to `handle_resize_event()` after each occurence.

Finally, on macOS the backing scale factor (used as `detected_display_zoom` in Panda3D) can be different between displays. On the other hand, in Panda3D there is only one value tied to the graphic pipe. That means on a hybrid setup, a window will be upscaled when moved from a low-dpi screen to a high-dpi screen even if the `dpi-aware` flag is set to `True`.

I tested this PR with several low and high dpi displays, in various configurations. I also tested fullscreen switching (from config and from in-app), the various mouse modes, ...

## Checklist
I have done my best to ensure that…
* [ x] …I have familiarized myself with the CONTRIBUTING.md file
* [ x] …this change follows the coding style and design patterns of the codebase
* [ x] …I own the intellectual property rights to this code
* [ x] …the intent of this change is clearly explained
* [ x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
