### PR TITLE
Fix cocoadisplay mouse bugs

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -143,9 +143,11 @@ move_pointer(int device, int x, int y) {
                           y + _properties.get_y_origin());
     }
 
-    // I don't know what the difference between these two methods is.  if
-    // (CGWarpMouseCursorPosition(point) == kCGErrorSuccess) {
-    if (CGDisplayMoveCursorToPoint(_display, point) == kCGErrorSuccess) {
+    if (CGWarpMouseCursorPosition(point) == kCGErrorSuccess) {
+      //After moving (or warping) the mouse position, CG starts an event
+      // suppression interval during which no more mouse events can occur
+      // This interval can be interupted by the following call :
+      CGAssociateMouseAndMouseCursorPosition(YES);
       // Generate a mouse event.
       NSPoint pos = [_window mouseLocationOutsideOfEventStream];
       NSPoint loc = [_view convertPoint:pos fromView:nil];
@@ -1886,6 +1888,10 @@ handle_mouse_moved_event(bool in_window, double x, double y, bool absolute) {
     }
 
     if (CGWarpMouseCursorPosition(point) == kCGErrorSuccess) {
+      //After moving (or warping) the mouse position, CG starts an event
+      // suppression interval during which no more mouse events can occur
+      // This interval can be interupted by the following call :
+      CGAssociateMouseAndMouseCursorPosition(YES);
       in_window = true;
     } else {
       cocoadisplay_cat.warning() << "Failed to return mouse pointer to window\n";

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -137,10 +137,10 @@ move_pointer(int device, int x, int y) {
   if (device == 0) {
     CGPoint point;
     if (_properties.get_fullscreen()) {
-      point = CGPointMake(x, y + 1);
+      point = CGPointMake(x, y);
     } else {
       point = CGPointMake(x + _properties.get_x_origin(),
-                          y + _properties.get_y_origin() + 1);
+                          y + _properties.get_y_origin());
     }
 
     // I don't know what the difference between these two methods is.  if
@@ -1861,9 +1861,8 @@ handle_mouse_moved_event(bool in_window, double x, double y, bool absolute) {
       }
     }
 
-    // Strangely enough, in Cocoa, mouse Y coordinates are 1-based.
     nx = x;
-    ny = y - 1;
+    ny = y;
 
   } else {
     // We received deltas, so add it to the current mouse position.
@@ -1880,10 +1879,10 @@ handle_mouse_moved_event(bool in_window, double x, double y, bool absolute) {
     ny = std::max(0., std::min((double) get_y_size() - 1, ny));
 
     if (_properties.get_fullscreen()) {
-      point = CGPointMake(nx, ny + 1);
+      point = CGPointMake(nx, ny);
     } else {
       point = CGPointMake(nx + _properties.get_x_origin(),
-                          ny + _properties.get_y_origin() + 1);
+                          ny + _properties.get_y_origin());
     }
 
     if (CGWarpMouseCursorPosition(point) == kCGErrorSuccess) {

--- a/panda/src/cocoadisplay/cocoaPandaView.mm
+++ b/panda/src/cocoadisplay/cocoaPandaView.mm
@@ -121,9 +121,7 @@
   NSPoint loc = [self convertPoint:[event locationInWindow] fromView:nil];
   BOOL inside = [self mouse:loc inRect:[self bounds]];
 
-  // the correlation between mouse deltas and location are "debounced"
-  // apparently, so send deltas for both relative and confined modes
-  if (_graphicsWindow->get_properties().get_mouse_mode() != WindowProperties::M_absolute) {
+  if (_graphicsWindow->get_properties().get_mouse_mode() == WindowProperties::M_relative) {
     _graphicsWindow->handle_mouse_moved_event(inside, [event deltaX], [event deltaY], false);
   } else {
     _graphicsWindow->handle_mouse_moved_event(inside, loc.x, loc.y, true);

--- a/panda/src/cocoadisplay/cocoaPandaWindowDelegate.mm
+++ b/panda/src/cocoadisplay/cocoaPandaWindowDelegate.mm
@@ -30,6 +30,7 @@
 - (void) windowDidResize:(NSNotification *)notification {
   // Forcing a move event is unfortunately necessary because Cocoa does not
   // call windowDidMove in case of window zooms.
+  _graphicsWindow->handle_move_event();
   _graphicsWindow->handle_resize_event();
 }
 


### PR DESCRIPTION
## Issue description

This PR aims to solve a couple of issues wrt the mouse behaviour on macOS.

1. Resizing a window may change window origin

When resizing a window, the origin of the window may change, for example when the window is maximized or when the window is resized using the left or top side of the window. See #1312 

2. The mouse Y-coordinates is off by one point.

When retrieving the mouse pointer position using `[event locationInWindow]` the Y-coordinate has 1 for base, however this is converted by `NSView convertPoint:fromView:nil` However in the code that offset is also compensated, resulting in a pointer position off by one point.
This can be tested by moving the pointer to position (16, -1) this point is outside the view and on the window bar and dragging the mouse from that position should move the window alongside. However this is not the case, one must move the position to (16, -2) to be on the first point of the window bar

3. Confined mouse mode is not properly working

When in mouse confined mode, when the cursor is moved against one of the border, it sorts of bounce back inside the window once it reaches the border (the effect is more visible if the mouse is moved fast). This is due to using `[event delta]` when in confined mode instead of the actual mouse pointer position. Deltas are not accurate, and so the derived mouse pointer position calculated by accumulating all the received deltas is wrong.

4. Mouse pointer freezes for half a second after being moved

When the mouse pointer is moved programmatically, either because we are in confined mode or we change the pointer position, the mouse pointer becomes unresponsive for half a second. This is an obscure mechanism inside CG that is triggered when moving (or warping) the mouse pointer.

## Solution description

1. Fix in 6bcf7d1f525892cad35cbab149419076b0d2d3fa consists of calling `handle_move_event()` also when resizing (as was expected by the comment in the code)

2. The fix in 0093bacef423636a52d2d0df61ca38ea6ba8241d simply removes the extraneous coordinates change.

3. The fix in dbc199ce47d35e2fb6baef4d7732e947f137873a uses the delta only for the relative mouse mode.

4. The fix in a61debd7aa28743abba94dd153c087e97619b62b calls `CGAssociateMouseAndMouseCursorPosition()` to disable the event suppresion interval that causes the mouse freeze.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
