### PR TITLE
cocoadisplay: Restore desktop display mode when closing a fullscreen window

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -76,7 +76,7 @@ CocoaGraphicsWindow(GraphicsEngine *engine, GraphicsPipe *pipe,
   if (NSApp == nil) {
     [CocoaPandaApp sharedApplication];
 
-    CocoaPandaAppDelegate *delegate = [[CocoaPandaAppDelegate alloc] init];
+    CocoaPandaAppDelegate *delegate = [[CocoaPandaAppDelegate alloc] initWithEngine:engine];
     [NSApp setDelegate:delegate];
 
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];

--- a/panda/src/cocoadisplay/cocoaPandaAppDelegate.h
+++ b/panda/src/cocoadisplay/cocoaPandaAppDelegate.h
@@ -14,9 +14,16 @@
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
 
-// Cocoa is picky about where and when certain methods are called in the initialization process.
-@interface CocoaPandaAppDelegate : NSObject<NSApplicationDelegate>
+class GraphicsEngine;
 
+// Cocoa is picky about where and when certain methods are called in the initialization process.
+@interface CocoaPandaAppDelegate : NSObject<NSApplicationDelegate> {
+  @private
+    GraphicsEngine *_engine;
+}
+
+- (id) initWithEngine:(GraphicsEngine *)engine;
 - (void)applicationDidFinishLaunching:(NSNotification *)notification;
+- (void)applicationWillTerminate:(NSNotification *)notification;
 
 @end

--- a/panda/src/cocoadisplay/cocoaPandaAppDelegate.mm
+++ b/panda/src/cocoadisplay/cocoaPandaAppDelegate.mm
@@ -12,12 +12,28 @@
 */
 
 #import "cocoaPandaAppDelegate.h"
+#include "graphicsEngine.h"
 
 @implementation CocoaPandaAppDelegate
+
+- (id) initWithEngine:(GraphicsEngine *)engine {
+
+  if (self = [super init]) {
+    _engine = engine;
+  }
+
+  return self;
+}
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
   // This only seems to work when called here.
   [NSApp activateIgnoringOtherApps:YES];
+}
+
+- (void)applicationWillTerminate:(NSNotification *)notification {
+  // The application is about to be closed, tell the graphics engine to close
+  // all the windows.
+  _engine->remove_all_windows();
 }
 
 @end


### PR DESCRIPTION
## Issue description

On macOS, when one closes a fullscreen window which display mode is not the desktop display mode, the desktop display mode is not properly restored, resulting in a unexpected change of layout.
## Solution description

This PR should fix this problem by restoring the desktop display mode (stored in `_windowed_mode`) when `handle_close_event()` is called (when the user click the close window button), or when the `open` window property is set to `false` (this happens when the application closes itself).

When the application is requested to close by the system, for example when using `Command-Q`, there is no event or property update received and so the mode is not restored.
To support also this scenario, I updated the application delegate to listen to `applicationWillTerminate` which is called when the application is about to be closed, and I call `remove_all_windows()` on GraphicsEngine. This cause in fine `set_properties_now()` to be called with the `open` property set to `false` like the previous scenario.

Note that I also tried to put the restore code in the destructor of `CocoaGraphicsWindow` but when the application is closed by `Command-Q` the destructor is never called.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
