### PR TITLE
support android no thread build

### DIFF
--- a/panda/src/pipeline/threadDummyImpl.I
+++ b/panda/src/pipeline/threadDummyImpl.I
@@ -16,6 +16,9 @@
  */
 INLINE ThreadDummyImpl::
 ThreadDummyImpl(Thread *) {
+#ifdef ANDROID
+  _jni_env = nullptr;
+#endif
 }
 
 /**
@@ -132,3 +135,13 @@ INLINE bool ThreadDummyImpl::
 get_context_switches(size_t &, size_t &) {
   return false;
 }
+
+#ifdef ANDROID
+/**
+ * Returns the JNIEnv object for the current thread.
+ */
+INLINE JNIEnv *ThreadDummyImpl::
+get_jni_env() const {
+  return _jni_env;
+}
+#endif

--- a/panda/src/pipeline/threadDummyImpl.cxx
+++ b/panda/src/pipeline/threadDummyImpl.cxx
@@ -25,6 +25,14 @@
 #include <windows.h>
 #endif
 
+#ifdef ANDROID
+const char *main_thread = "main_thread";
+#include "config_express.h"
+#include <jni.h>
+
+static JavaVM *java_vm = nullptr;
+#endif
+
 /**
  *
  */
@@ -47,5 +55,40 @@ Thread *ThreadDummyImpl::
 get_current_thread() {
   return Thread::get_main_thread();
 }
+
+#ifdef ANDROID
+/**
+ * Attaches the thread to the Java virtual machine.  If this returns true, a
+ * JNIEnv pointer can be acquired using get_jni_env().
+ */
+bool ThreadDummyImpl::
+attach_java_vm() {
+  assert(java_vm != nullptr);
+  JNIEnv *env;
+  JavaVMAttachArgs args;
+  args.version = JNI_VERSION_1_2;
+  args.name = main_thread;
+  args.group = nullptr;
+  if (java_vm->AttachCurrentThread(&env, &args) != 0) {
+    thread_cat.error()
+      << "Failed to attach Java VM to thread ";
+      _jni_env = nullptr;
+    return false;
+  }
+  _jni_env = env;
+  return true;
+}
+
+/**
+ * Binds the Panda thread to the current thread, assuming that the current
+ * thread is already a valid attached Java thread.  Called by JNI_OnLoad.
+ */
+void ThreadDummyImpl::
+bind_java_thread() {
+
+}
+#endif  // ANDROID
+
+
 
 #endif  // THREAD_DUMMY_IMPL

--- a/panda/src/pipeline/threadDummyImpl.h
+++ b/panda/src/pipeline/threadDummyImpl.h
@@ -31,6 +31,13 @@ class Thread;
 #include <windows.h>  // For Sleep().
 #endif
 
+#ifdef ANDROID
+//#include "config_express.h"
+#include <jni.h>
+typedef struct _JNIEnv _jni_env;
+//_jni_env = nullptr;
+#endif
+
 /**
  * A fake thread implementation for single-threaded applications.  This simply
  * fails whenever you try to start a thread.
@@ -58,7 +65,19 @@ public:
   INLINE static void yield();
   INLINE static void consider_yield();
 
+#ifdef ANDROID
+  INLINE JNIEnv *get_jni_env() const;
+  bool attach_java_vm();
+  static void bind_java_thread();
+#endif
+
   INLINE static bool get_context_switches(size_t &, size_t &);
+
+private:
+#ifdef ANDROID
+  JNIEnv *_jni_env;
+#endif
+
 };
 
 #include "threadDummyImpl.I"


### PR DESCRIPTION
dummy threading ( -DHAVE_THREADS=No ) does not provide android specifics slots handling jni environnement.

