### PR TITLE
distributed: Import inspect only during DC file read

### DIFF
--- a/direct/src/distributed/ConnectionRepository.py
+++ b/direct/src/distributed/ConnectionRepository.py
@@ -9,7 +9,6 @@ from direct.showbase import GarbageReport
 from direct.showbase.MessengerGlobal import messenger
 from .PyDatagramIterator import PyDatagramIterator
 
-import inspect
 import gc
 
 __all__ = ["ConnectionRepository", "GCTrigger"]
@@ -311,6 +310,8 @@ class ConnectionRepository(
 
         # Now get the class definition for the classes named in the DC
         # file.
+        import inspect
+
         for i in range(dcFile.getNumClasses()):
             dclass = dcFile.getClass(i)
             number = dclass.getNumber()


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
I am planning to distribute a build of my game without the Python `inspect` module. Unfortunately, due to ConnectionRepository's DC file read depending on it, I have run into some issues. I cannot import ConnectionRepository in such an environment.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
This PR simply moves the `inspect` import to within readDCFile, reducing the dependency of the entire module on the `inspect` module. This shouldn't cause much of an issue, and I would greatly appreciate it.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
