### PR TITLE
ffmpeg: Resolve segmentation fault when statically linking ffmpeg

### DIFF
--- a/panda/src/ffmpeg/ffmpegAudio.h
+++ b/panda/src/ffmpeg/ffmpegAudio.h
@@ -38,7 +38,7 @@ public:
     return _type_handle;
   }
   static void init_type() {
-    TypedWritableReferenceCount::init_type();
+    MovieAudio::init_type();
     register_type(_type_handle, "FfmpegAudio",
                   MovieAudio::get_class_type());
   }


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
When statically linking the ffmpeg module, a nasty segmentation fault can occur at: 
https://github.com/panda3d/panda3d/blob/0fcfb8e372c71e5c15a20bfd064b51f8db831469/panda/src/ffmpeg/ffmpegAudio.h#L42

When Panda3D tries to register the `FfmpegAudio` type handle, it fails to evaluate the parent class `MovieAudio` as `FfmpegAudio` is registered before `MovieAudio` is registered. As such, a segmentation fault happens when accessing the parent class. This is hard to track down as it happens before the `main` method of the program is ever called.

This is due to a copy-paste gone wrong. `FfmpegVideo` uses `TypedWritableReferenceCount` as its parent class, and as such `FfmpegVideo` initializes `TypedWritableReferenceCount` before `FfmpegVideo` itself. `FfmpegAudio`, however, depends on `MovieAudio`. Most likely `FfmpegAudio` was copied from the `FfmpegVideo` class, and the initialization of the parent class was not changed.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
Initializing `MovieAudio` before initializing `FfmpegAudio` solves the problem and prevents the segmentation fault from happening.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
