### PR TITLE
Fix wrong value of Py_OptimizeFlag in bundled apps

### DIFF
--- a/direct/src/dist/FreezeTool.py
+++ b/direct/src/dist/FreezeTool.py
@@ -379,6 +379,7 @@ Py_FrozenMain(int argc, char **argv)
     Py_FrozenFlag = 1; /* Suppress errors from getpath.c */
     Py_NoSiteFlag = 1;
     Py_NoUserSiteDirectory = 1;
+    Py_OptimizeFlag = 2;
 
     if ((p = Py_GETENV("PYTHONINSPECT")) && *p != '\\0')
         inspect = 1;

--- a/pandatool/src/deploy-stub/deploy-stub.c
+++ b/pandatool/src/deploy-stub/deploy-stub.c
@@ -387,6 +387,7 @@ int Py_FrozenMain(int argc, char **argv)
     Py_FrozenFlag = 1; /* Suppress errors from getpath.c */
     Py_NoSiteFlag = 0;
     Py_NoUserSiteDirectory = 1;
+    Py_OptimizeFlag = 2;
 
 #ifndef NDEBUG
     if ((p = Py_GETENV("PYTHONINSPECT")) && *p != '\0')


### PR DESCRIPTION
## Issue description

This is a trivial fix for #1343 

## Solution description

Set `Py_OptimizeFlag` to 2 in frozen main code of `FreezeTool.py` and 'deploy-stub.c` before `Py_Initialize()`

With that, `sys.flags.optimize` returns 2

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
