### PR TITLE
Correct documentation

### DIFF
--- a/panda/src/mathutil/triangulator.cxx
+++ b/panda/src/mathutil/triangulator.cxx
@@ -125,9 +125,7 @@ triangulate() {
     permute.push_back(i + 1);
   }
 
-  // Actually, I'm not sure why we should shuffle the index.  That makes the
-  // result non-deterministic, and isn't one order--for instance, the initial
-  // order--as good as any other?
+  // Shuffling the index ensures n*logn time complexity
   /*
   Randomizer randomizer;
   for (i = 0; i < num_segments; ++i) {


### PR DESCRIPTION
See first paragraph of https://graphics.stanford.edu/courses/cs268-09-winter/notes/handout6.pdf

## Issue description
I'm trying to learn about trapezoidation, and I found this code. A [comment](https://github.com/panda3d/panda3d/blob/master/panda/src/mathutil/triangulator.cxx#L128) in triangulator.cxx suggests that the randomization process is skipped, [but it exists to ensure the algorithm performs in O(n*log(n)) time on average.](https://graphics.stanford.edu/courses/cs268-09-winter/notes/handout6.pdf)

It shuffles afterward anyway to dodge errors, so there's no problem, but it could be misleading to maintainers.


## Solution description
I corrected the comment, but left functionality unchanged

## Checklist
I have done my best to ensure that…
* [ x] …I have familiarized myself with the CONTRIBUTING.md file
* [ x] …this change follows the coding style and design patterns of the codebase
* [ x] …I own the intellectual property rights to this code
* [ x] …the intent of this change is clearly explained
* [ x] …existing uses of the Panda3D API are not broken
* [ x] …the changed code is adequately covered by the test suite, where possible.
