### PR TITLE
create PY_EXTENSION and friends

### DIFF
--- a/dtool/src/dtoolbase/dtoolbase.h
+++ b/dtool/src/dtoolbase/dtoolbase.h
@@ -53,16 +53,16 @@
 #ifdef _WIN32
 #ifndef NOMINMAX
 #define NOMINMAX
-#endif
-#endif
+#endif // !NOMINMAX
+#endif // _WIN32
 
 #ifndef __has_builtin
 #define __has_builtin(x) 0
-#endif
+#endif // !__has_builtin
 
 #ifndef __has_attribute
 #define __has_attribute(x) 0
-#endif
+#endif // !__has_attribute
 
 // Use NODEFAULT to optimize a switch() stmt to tell MSVC to automatically go
 // to the final untested case after it has failed all the other cases (i.e.
@@ -73,30 +73,30 @@
 #define NODEFAULT  default: __builtin_unreachable();
 #elif defined(_MSC_VER)
 #define NODEFAULT  default: __assume(0);   // special VC keyword
-#else
+#else // NODEFAULT
 #define NODEFAULT
-#endif
+#endif // NODEFAULT
 
 // Use this to hint the compiler that a memory address is aligned.
 #if __has_builtin(__builtin_assume_aligned) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)
 #define ASSUME_ALIGNED(x, y) (__builtin_assume_aligned(x, y))
-#else
+#else // ASSUME_ALIGNED
 #define ASSUME_ALIGNED(x, y) (x)
-#endif
+#endif // ASSUME_ALIGNED
 
 #if __has_attribute(assume_aligned) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
 #define RETURNS_ALIGNED(x) __attribute__((assume_aligned(x)))
-#else
+#else // RETURNS_ALIGNED
 #define RETURNS_ALIGNED(x)
-#endif
+#endif // RETURNS_ALIGNED
 
 #ifdef __GNUC__
 #define LIKELY(x) __builtin_expect(!!(x), 1)
 #define UNLIKELY(x) __builtin_expect(!!(x), 0)
-#else
+#else // LIKELY/UNLIKELY
 #define LIKELY(x) (x)
 #define UNLIKELY(x) (x)
-#endif
+#endif // LIKELY/UNLIKELY
 
 /*
   include win32 defns for everything up to WinServer2003, and assume
@@ -105,17 +105,17 @@
 */
 #ifdef _WIN32_WINNT
 #undef _WIN32_WINNT
-#endif
+#endif // _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
 
 #ifdef __cplusplus
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
-#endif
+#endif // !__STDC_LIMIT_MACROS
 #ifndef __STDC_CONSTANT_MACROS
 #define __STDC_CONSTANT_MACROS
-#endif
-#endif
+#endif // !__STDC_CONSTANT_MACROS
+#endif // __cplusplus
 
 // This is a workaround for a glibc bug that is triggered by clang when
 // compiling with -ffast-math.
@@ -123,8 +123,8 @@
 #include <sys/cdefs.h>
 #ifndef __extern_always_inline
 #define __extern_always_inline extern __always_inline
-#endif
-#endif
+#endif // !__extern_always_inline
+#endif // __clang__ && __GLIBC__
 
 // Instead of including the Python headers, which will implicitly add a linker
 // flag to link in Python, we'll just excerpt the forward declaration of
@@ -134,7 +134,7 @@ typedef struct _object PyObject;
 #ifndef HAVE_EIGEN
 // If we don't have the Eigen library, don't define LINMATH_ALIGN.
 #undef LINMATH_ALIGN
-#endif
+#endif // !HAVE_EIGEN
 
 #include "dtoolsymbols.h"
 
@@ -146,73 +146,75 @@ typedef struct _object PyObject;
 // headers
 #define _FILE_OFFSET_BITS 64
 #define _LARGEFILE_SOURCE 1
-#endif
+#endif // __GNUC__
 
 #ifdef PHAVE_TYPES_H
 #include <types.h>
-#endif
+#endif // PHAVE_TYPES_H
 
 #ifdef PHAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif
+#endif // PHAVE_SYS_TYPES_H
 
 #ifdef PHAVE_MALLOC_H
 #include <malloc.h>
-#endif
+#endif // PHAVE_MALLOC_H
 
 #ifdef PHAVE_SYS_MALLOC_H
 #include <sys/malloc.h>
-#endif
+#endif // PHAVE_SYS_MALLOC_H
 
 #ifdef PHAVE_ALLOCA_H
 #include <alloca.h>
-#endif
+#endif // PHAVE_ALLOCA_H
 
 #ifdef PHAVE_UNISTD_H
 #include <unistd.h>
-#endif
+#endif // PHAVE_UNISTD_H
 
 #ifdef PHAVE_IO_H
 #include <io.h>
-#endif
+#endif // PHAVE_IO_H
 
 #ifdef PHAVE_LOCALE_H
 #include <locale.h>
-#endif
+#endif // PHAVE_LOCALE_H
 
 #ifdef PHAVE_STRING_H
 #include <string.h>
-#endif
+#endif // PHAVE_STRING_H
 
 #ifdef PHAVE_STDLIB_H
 #include <stdlib.h>
-#endif
+#endif // PHAVE_STDLIB_H
 
 #ifdef PHAVE_LIMITS_H
 #include <limits.h>
-#endif
+#endif // PHAVE_LIMITS_H
 
 #ifdef PHAVE_SYS_TIME_H
 #include <sys/time.h>
-#endif
+#endif // PHAVE_SYS_TIME_H
 
 #ifdef PHAVE_STDINT_H
 #include <stdint.h>
-#endif
+#endif // PHAVE_STDINT_H
 
 #ifdef CPPPARSER
 #include <stdtypedefs.h>
 
+#ifdef HAVE_PYTHON
 // Also pick up the forward declaration of PyObject.
 #include <Python.h>
-#endif
+#endif // HAVE_PYTHON
+#endif // CPPPARSER
 
 #ifdef USE_TAU
 /* If we're building with the Tau instrumentor, include the
    appropriate header file to pick up the TAU macros. */
 #include <TAU.h>
 #include <Profile/Profiler.h>
-#else
+#else // USE_TAU
 /* Otherwise, if we're not building with the Tau instrumentor, turn
    off all the TAU macros.  We could include the Tau header file to do
    this, but it's better not to assume that Tau is installed. */
@@ -324,7 +326,7 @@ typedef struct _object PyObject;
 #undef WORDS_BIGENDIAN
 #define WORDS_BIGENDIAN 1
 
-#endif
+#endif // WORDS_BIGENDIAN
 
 /* Try to determine if we're compiling in a 64-bit mode. */
 
@@ -332,9 +334,9 @@ typedef struct _object PyObject;
 #define NATIVE_WORDSIZE __WORDSIZE
 #elif defined(_LP64) || defined(_WIN64)
 #define NATIVE_WORDSIZE 64
-#else
+#else // __WORDSIZE
 #define NATIVE_WORDSIZE 32
-#endif
+#endif // __WORDSIZE
 
 /* Some byte-alignment macros. */
 #ifdef CPPPARSER
@@ -355,13 +357,13 @@ typedef struct _object PyObject;
 #define ALIGN_16BYTE __attribute__ ((aligned (16)))
 #define ALIGN_32BYTE __attribute__ ((aligned (32)))
 #define ALIGN_64BYTE __attribute__ ((aligned (64)))
-#else
+#else // ALIGN_*
 #define ALIGN_4BYTE
 #define ALIGN_8BYTE
 #define ALIGN_16BYTE
 #define ALIGN_32BYTE
 #define ALIGN_64BYTE
-#endif
+#endif // ALIGN_*
 
 // Do we need to implement memory-alignment enforcement within the MemoryHook
 // class, or will the underlying malloc implementation provide it
@@ -398,13 +400,13 @@ typedef struct _object PyObject;
 #elif defined(MEMORY_HOOK_DO_ALIGN)
 // We need memory alignment, and we're willing to provide it ourselves.
 
-#else
+#else // malloc alignment
 // We need memory alignment, and we haven't specified whether it should be
 // provided on top of the existing malloc library, or otherwise.  Let's rely
 // on dlmalloc to provide it, it seems to be the most memory-efficient option.
 #define USE_MEMORY_DLMALLOC 1
 
-#endif
+#endif // malloc alignment
 
 #ifdef LINMATH_ALIGN
 /* We require 16-byte alignment of certain structures, to support SSE2.  We
@@ -413,37 +415,37 @@ typedef struct _object PyObject;
 /* Eigen uses AVX instructions, but let's only enable this when compiling with
    double precision, so that we can keep our ABI a bit more stable. */
 #define MEMORY_HOOK_ALIGNMENT 32
-#else
+#else // HAVE_EIGEN alignment
 #define MEMORY_HOOK_ALIGNMENT 16
-#endif
+#endif // HAVE_EIGEN alignment
 /* Otherwise, align to two words.  This seems to be pretty standard to the
    point where some code may rely on this being the case. */
 #elif defined(IS_OSX) || NATIVE_WORDSIZE >= 64
 #define MEMORY_HOOK_ALIGNMENT 16
-#else
+#else // memory alignment
 #define MEMORY_HOOK_ALIGNMENT 8
-#endif
+#endif // memory alignment
 
 #ifdef HAVE_EIGEN
 /* Make sure that Eigen doesn't assume alignment guarantees we don't offer. */
 #define EIGEN_MAX_ALIGN_BYTES MEMORY_HOOK_ALIGNMENT
 #ifndef EIGEN_MPL2_ONLY
 #define EIGEN_MPL2_ONLY 1
-#endif
+#endif // !EIGEN_MPL2_ONLY
 #if !defined(_DEBUG) && !defined(EIGEN_NO_DEBUG)
 #define EIGEN_NO_DEBUG 1
-#endif
-#endif
+#endif // !_DEBUG && !EIGEN_NO_DEBUG
+#endif // HAVE_EIGEN
 
 /* Determine our memory-allocation requirements. */
 #if defined(USE_MEMORY_MIMALLOC) || defined(USE_MEMORY_PTMALLOC2) || defined(USE_MEMORY_DLMALLOC) || defined(DO_MEMORY_USAGE) || defined(MEMORY_HOOK_DO_ALIGN)
 /* In this case we have some custom memory management requirements. */
-#else
+#else // memory allocation wrappers
 /* Otherwise, if we have no custom memory management needs at all, we
    might as well turn it all off and go straight to the OS-level
    calls. */
 #define USE_MEMORY_NOWRAPPERS 1
-#endif
+#endif // memory allocation wrappers
 
 /* We must always use the STL allocator nowadays, because we have
    redefined the constructors for pvector, pmap, etc. */
@@ -468,7 +470,18 @@ typedef struct _object PyObject;
 #define MAKE_MAP_KEYS_SEQ(property_name, ...) __make_map_keys_seq(property_name, __VA_ARGS__)
 #define EXTENSION(x) __extension x
 #define EXTEND __extension
-#else
+#ifdef HAVE_PYTHON
+#define PY_EXTENSION(x) __extension x
+#define PY_EXTEND(...) __extension __VA_ARGS__
+#define PY_MAKE_PROPERTY(property_name, ...) __make_property(property_name, __VA_ARGS__)
+#define PY_MAKE_SEQ_PROPERTY(property_name, ...) __make_seq_property(property_name, __VA_ARGS__)
+#else // HAVE_PYTHON
+#define PY_EXTENSION(x)
+#define PY_EXTEND(...)
+#define PY_MAKE_PROPERTY(property_name, ...)
+#define PY_MAKE_SEQ_PROPERTY(property_name, ...)
+#endif // HAVE_PYTHON
+#else // CPPPARSER
 #define BEGIN_PUBLISH
 #define END_PUBLISH
 #define BLOCKING
@@ -480,7 +493,11 @@ typedef struct _object PyObject;
 #define MAKE_MAP_KEYS_SEQ(property_name, ...)
 #define EXTENSION(x)
 #define EXTEND
-#endif
+#define PY_EXTENSION(x)
+#define PY_EXTEND(...)
+#define PY_MAKE_PROPERTY(property_name, ...)
+#define PY_MAKE_SEQ_PROPERTY(property_name, ...)
+#endif // CPPPARSER
 
 /* These symbols are used in dtoolsymbols.h and pandasymbols.h. */
 #if defined(_WIN32) && !defined(CPPPARSER) && !defined(LINK_ALL_STATIC)
@@ -489,10 +506,10 @@ typedef struct _object PyObject;
 #elif __GNUC__ >= 4 && !defined(CPPPARSER) && !defined(LINK_ALL_STATIC)
 #define EXPORT_CLASS __attribute__((visibility("default")))
 #define IMPORT_CLASS
-#else
+#else // IMPORT/EXPORT
 #define EXPORT_CLASS
 #define IMPORT_CLASS
-#endif
+#endif // IMPORT/EXPORT
 
 /* "extern template" is now part of the C++11 standard. */
 #if defined(CPPPARSER) || defined(LINK_ALL_STATIC)
@@ -507,13 +524,13 @@ typedef struct _object PyObject;
    duplicate template instantiations that this causes. */
 #define EXPORT_TEMPL
 #define IMPORT_TEMPL extern
-#else
+#else // IMPORT/EXPORT template
 #define EXPORT_TEMPL extern
 #define IMPORT_TEMPL extern
-#endif
+#endif // IMPORT/EXPORT template
 
 #ifdef __cplusplus
 #include "dtoolbase_cc.h"
-#endif
+#endif // __cplusplus
 
-#endif
+#endif // !DTOOLBASE_H

--- a/dtool/src/dtoolbase/typeHandle.h
+++ b/dtool/src/dtoolbase/typeHandle.h
@@ -97,9 +97,7 @@ PUBLISHED:
   // its value, it  might happen after the value had already been set
   // previously by another static initializer!
 
-#ifdef HAVE_PYTHON
-  EXTENSION(static TypeHandle make(PyTypeObject *classobj));
-#endif
+  PY_EXTENSION(static TypeHandle make(PyTypeObject *classobj));
 
   INLINE bool operator == (const TypeHandle &other) const;
   INLINE bool operator != (const TypeHandle &other) const;
@@ -139,10 +137,8 @@ PUBLISHED:
   MAKE_SEQ_PROPERTY(parent_classes, get_num_parent_classes, get_parent_class);
   MAKE_SEQ_PROPERTY(child_classes, get_num_child_classes, get_child_class);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__reduce__() const);
-  EXTENSION(void __setstate__(PyObject *));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__reduce__() const);
+  PY_EXTENSION(void __setstate__(PyObject *));
 
 public:
 #ifdef HAVE_PYTHON

--- a/dtool/src/dtoolutil/filename.h
+++ b/dtool/src/dtoolutil/filename.h
@@ -66,11 +66,9 @@ PUBLISHED:
   INLINE Filename();
   explicit Filename(const Filename &dirname, const Filename &basename);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(Filename(PyObject *path));
+  PY_EXTENSION(Filename(PyObject *path));
 
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
 
   // Static constructors to explicitly create a filename that refers to a text
   // or binary file.  This is in lieu of calling set_text() or set_binary() or
@@ -114,10 +112,8 @@ PUBLISHED:
   INLINE size_t length() const;
   INLINE char operator [] (size_t n) const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__repr__() const);
-  EXTENSION(PyObject *__fspath__() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__repr__() const);
+  PY_EXTENSION(PyObject *__fspath__() const);
 
   INLINE std::string substr(size_t begin) const;
   INLINE std::string substr(size_t begin, size_t end) const;
@@ -202,9 +198,7 @@ PUBLISHED:
   int find_on_searchpath(const DSearchPath &searchpath);
 
   bool scan_directory(vector_string &contents) const;
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *scan_directory() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *scan_directory() const);
 
   bool open_read(std::ifstream &stream) const;
   bool open_write(std::ofstream &stream, bool truncate = true) const;

--- a/dtool/src/dtoolutil/textEncoder.h
+++ b/dtool/src/dtoolutil/textEncoder.h
@@ -54,28 +54,28 @@ PUBLISHED:
   INLINE static Encoding get_default_encoding();
   MAKE_PROPERTY(default_encoding, get_default_encoding, set_default_encoding);
 
-#if defined(CPPPARSER) && defined(HAVE_PYTHON)
-  EXTEND void set_text(PyObject *text);
-  EXTEND void set_text(PyObject *text, Encoding encoding);
-#else // CPPPARSER && HAVE_PYTHON
+#if defined(CPPPARSER)
+  PY_EXTEND(void set_text(PyObject *text));
+  PY_EXTEND(void set_text(PyObject *text, Encoding encoding));
+#else // CPPPARSER
   INLINE void set_text(const std::string &text);
   INLINE void set_text(const std::string &text, Encoding encoding);
-#endif // CPPPARSER && HAVE_PYTHON
+#endif // CPPPARSER
   INLINE void clear_text();
   INLINE bool has_text() const;
 
   void make_upper();
   void make_lower();
 
-#if defined(CPPPARSER) && defined(HAVE_PYTHON)
-  EXTEND PyObject *get_text() const;
-  EXTEND PyObject *get_text(Encoding encoding) const;
-  EXTEND void append_text(PyObject *text);
-#else // CPPPARSER && HAVE_PYTHON
+#if defined(CPPPARSER)
+  PY_EXTEND(PyObject *get_text() const);
+  PY_EXTEND(PyObject *get_text(Encoding encoding) const);
+  PY_EXTEND(void append_text(PyObject *text));
+#else // CPPPARSER
   INLINE std::string get_text() const;
   INLINE std::string get_text(Encoding encoding) const;
   INLINE void append_text(const std::string &text);
-#endif // CPPPARSER && HAVE_PYTHON
+#endif // CPPPARSER
   INLINE void append_unicode_char(char32_t character);
   INLINE size_t get_num_chars() const;
   INLINE int get_unicode_char(size_t index) const;
@@ -108,19 +108,19 @@ PUBLISHED:
   std::wstring get_wtext_as_ascii() const;
   bool is_wtext() const;
 
-#if defined(CPPPARSER) && defined(HAVE_PYTHON)
-  EXTEND static PyObject *encode_wchar(char32_t ch, Encoding encoding);
-  EXTEND INLINE PyObject *encode_wtext(const std::wstring &wtext) const;
-  EXTEND static PyObject *encode_wtext(const std::wstring &wtext, Encoding encoding);
-  EXTEND INLINE PyObject *decode_text(PyObject *text) const;
-  EXTEND static PyObject *decode_text(PyObject *text, Encoding encoding);
-#else // CPPPARSER && HAVE_PYTHON
+#if defined(CPPPARSER)
+  PY_EXTEND(static PyObject *encode_wchar(char32_t ch, Encoding encoding));
+  PY_EXTEND(INLINE PyObject *encode_wtext(const std::wstring &wtext) const);
+  PY_EXTEND(static PyObject *encode_wtext(const std::wstring &wtext, Encoding encoding));
+  PY_EXTEND(INLINE PyObject *decode_text(PyObject *text) const);
+  PY_EXTEND(static PyObject *decode_text(PyObject *text, Encoding encoding));
+#else // CPPPARSER
   static std::string encode_wchar(char32_t ch, Encoding encoding);
   INLINE std::string encode_wtext(const std::wstring &wtext) const;
   static std::string encode_wtext(const std::wstring &wtext, Encoding encoding);
   INLINE std::wstring decode_text(const std::string &text) const;
   static std::wstring decode_text(const std::string &text, Encoding encoding);
-#endif // CPPPARSER && HAVE_PYTHON
+#endif // CPPPARSER
 
   MAKE_PROPERTY(text, get_text, set_text);
 

--- a/dtool/src/prc/configVariable.h
+++ b/dtool/src/prc/configVariable.h
@@ -44,9 +44,7 @@ PUBLISHED:
 
   INLINE size_t get_num_words() const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
 
 protected:
   INLINE const ConfigDeclaration *get_default_value() const;

--- a/dtool/src/prc/pnotify.h
+++ b/dtool/src/prc/pnotify.h
@@ -36,10 +36,10 @@ PUBLISHED:
   ~Notify();
 
 #if defined(CPPPARSER) && defined(HAVE_PYTHON)
-  EXTEND void set_ostream_ptr(PyObject *ostream_ptr, bool delete_later);
-#else
+  PY_EXTEND(void set_ostream_ptr(PyObject *ostream_ptr, bool delete_later));
+#else // CPPPARSER && HAVE_PYTHON
   void set_ostream_ptr(std::ostream *ostream_ptr, bool delete_later);
-#endif
+#endif // CPPPARSER && HAVE_PYTHON
   std::ostream *get_ostream_ptr() const;
 
   typedef bool AssertHandler(const char *expression, int line,

--- a/dtool/src/prc/streamReader.h
+++ b/dtool/src/prc/streamReader.h
@@ -68,12 +68,10 @@ PUBLISHED:
 
   BLOCKING void skip_bytes(size_t size);
   BLOCKING size_t extract_bytes(unsigned char *into, size_t size);
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *extract_bytes(size_t size));
+  PY_EXTENSION(PyObject *extract_bytes(size_t size));
 
-  EXTENSION(PyObject *readline());
-  EXTENSION(PyObject *readlines());
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *readline());
+  PY_EXTENSION(PyObject *readlines());
 public:
   BLOCKING vector_uchar extract_bytes(size_t size);
   BLOCKING std::string readline();

--- a/dtool/src/prc/streamWriter.h
+++ b/dtool/src/prc/streamWriter.h
@@ -70,9 +70,7 @@ PUBLISHED:
   BLOCKING INLINE void add_fixed_string(const std::string &str, size_t size);
 
   BLOCKING void pad_bytes(size_t size);
-#ifdef HAVE_PYTHON
-  EXTENSION(void append_data(PyObject *data));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(void append_data(PyObject *data));
 
   BLOCKING INLINE void flush();
 

--- a/panda/src/collide/collisionHandlerEvent.h
+++ b/panda/src/collide/collisionHandlerEvent.h
@@ -69,8 +69,8 @@ PUBLISHED:
   void flush();
 
   // These help implement Python pickle support.
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-  EXTENSION(void __setstate__(PyObject *self, vector_uchar data));
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(void __setstate__(PyObject *self, vector_uchar data));
 
   virtual void write_datagram(Datagram &destination) const;
   virtual void read_datagram(DatagramIterator &source);

--- a/panda/src/collide/collisionHandlerPhysical.h
+++ b/panda/src/collide/collisionHandlerPhysical.h
@@ -54,8 +54,8 @@ PUBLISHED:
 PUBLISHED:
   MAKE_PROPERTY2(center, has_center, get_center, set_center, clear_center);
 
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-  EXTENSION(void __setstate__(PyObject *self, vector_uchar data, PyObject *nodepaths));
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(void __setstate__(PyObject *self, vector_uchar data, PyObject *nodepaths));
 
 protected:
   bool _has_contact; // Are we in contact with anything?

--- a/panda/src/collide/collisionHandlerQueue.h
+++ b/panda/src/collide/collisionHandlerQueue.h
@@ -46,7 +46,7 @@ PUBLISHED:
   void output(std::ostream &out) const;
   void write(std::ostream &out, int indent_level = 0) const;
 
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
 
 private:
   typedef pvector< PT(CollisionEntry) > Entries;

--- a/panda/src/collide/collisionPolygon.h
+++ b/panda/src/collide/collisionPolygon.h
@@ -59,8 +59,8 @@ PUBLISHED:
   bool is_valid() const;
   bool is_concave() const;
 
-  EXTENSION(static bool verify_points(PyObject *points));
-  EXTENSION(void setup_points(PyObject *points));
+  PY_EXTENSION(static bool verify_points(PyObject *points));
+  PY_EXTENSION(void setup_points(PyObject *points));
 
 PUBLISHED:
   MAKE_SEQ_PROPERTY(points, get_num_points, get_point);

--- a/panda/src/collide/collisionTraverser.h
+++ b/panda/src/collide/collisionTraverser.h
@@ -80,8 +80,8 @@ PUBLISHED:
   void output(std::ostream &out) const;
   void write(std::ostream &out, int indent_level) const;
 
-  EXTENSION(PyObject *__getstate__() const);
-  EXTENSION(void __setstate__(PyObject *state));
+  PY_EXTENSION(PyObject *__getstate__() const);
+  PY_EXTENSION(void __setstate__(PyObject *state));
 
 private:
   typedef pvector<CollisionLevelStateSingle> LevelStatesSingle;

--- a/panda/src/display/frameBufferProperties.h
+++ b/panda/src/display/frameBufferProperties.h
@@ -144,10 +144,8 @@ PUBLISHED:
   MAKE_PROPERTY(float_color, get_float_color, set_float_color);
   MAKE_PROPERTY(float_depth, get_float_depth, set_float_depth);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__getstate__() const);
-  EXTENSION(void __setstate__(PyObject *self, PyObject *state));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__getstate__() const);
+  PY_EXTENSION(void __setstate__(PyObject *self, PyObject *state));
 
   // Other.
 

--- a/panda/src/display/graphicsPipeSelection.h
+++ b/panda/src/display/graphicsPipeSelection.h
@@ -52,9 +52,7 @@ PUBLISHED:
 
   INLINE static GraphicsPipeSelection *get_global_ptr();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__reduce__() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__reduce__() const);
 
 public:
   typedef PT(GraphicsPipe) PipeConstructorFunc();

--- a/panda/src/display/graphicsStateGuardian.h
+++ b/panda/src/display/graphicsStateGuardian.h
@@ -254,9 +254,7 @@ PUBLISHED:
   MAKE_PROPERTY(texture_quality_override, get_texture_quality_override,
                                           set_texture_quality_override);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_prepared_textures() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *get_prepared_textures() const);
   typedef bool TextureCallback(TextureContext *tc, void *callback_arg);
   void traverse_prepared_textures(TextureCallback *func, void *callback_arg);
 

--- a/panda/src/display/graphicsWindow.h
+++ b/panda/src/display/graphicsWindow.h
@@ -56,9 +56,7 @@ PUBLISHED:
   void clear_rejected_properties();
   WindowProperties get_rejected_properties() const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(void request_properties(PyObject *args, PyObject *kwds));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(void request_properties(PyObject *args, PyObject *kwds));
 
   INLINE bool is_closed() const;
   virtual bool is_active() const;

--- a/panda/src/display/windowProperties.h
+++ b/panda/src/display/windowProperties.h
@@ -44,9 +44,7 @@ PUBLISHED:
     M_confined,
   };
 
-#ifdef HAVE_PYTHON
-  EXTENSION(WindowProperties(PyObject *self, PyObject *args, PyObject *kwds));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(WindowProperties(PyObject *self, PyObject *args, PyObject *kwds));
 
 PUBLISHED:
   void operator = (const WindowProperties &copy);
@@ -207,10 +205,8 @@ PUBLISHED:
   MAKE_PROPERTY2(parent_window, has_parent_window, get_parent_window,
                                 set_parent_window, clear_parent_window);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__getstate__(PyObject *self) const);
-  EXTENSION(void __setstate__(PyObject *self, PyObject *state));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__getstate__(PyObject *self) const);
+  PY_EXTENSION(void __setstate__(PyObject *self, PyObject *state));
 
   void add_properties(const WindowProperties &other);
 

--- a/panda/src/egg/eggComment.h
+++ b/panda/src/egg/eggComment.h
@@ -41,7 +41,7 @@ PUBLISHED:
 
   virtual void write(std::ostream &out, int indent_level) const;
 
-  EXTENSION(PyObject *__reduce__() const);
+  PY_EXTENSION(PyObject *__reduce__() const);
 
 private:
   std::string _comment;

--- a/panda/src/egg/eggCoordinateSystem.h
+++ b/panda/src/egg/eggCoordinateSystem.h
@@ -36,7 +36,7 @@ PUBLISHED:
 
   virtual void write(std::ostream &out, int indent_level) const;
 
-  EXTENSION(PyObject *__reduce__() const);
+  PY_EXTENSION(PyObject *__reduce__() const);
 
 private:
   CoordinateSystem _value;

--- a/panda/src/egg/eggGroupNode.h
+++ b/panda/src/egg/eggGroupNode.h
@@ -108,8 +108,8 @@ PUBLISHED:
   EggNode *get_first_child();
   EggNode *get_next_child();
 
-  EXTENSION(PyObject *get_children() const);
-  MAKE_PROPERTY(children, get_children);
+  PY_EXTENSION(PyObject *get_children() const);
+  PY_MAKE_PROPERTY(children, get_children);
 
   EggNode *add_child(EggNode *node);
   PT(EggNode) remove_child(EggNode *node);

--- a/panda/src/egg/eggNode.h
+++ b/panda/src/egg/eggNode.h
@@ -93,7 +93,7 @@ PUBLISHED:
   void test_under_integrity() const { }
 #endif  // _DEBUG
 
-  EXTENSION(PyObject *__reduce__() const);
+  PY_EXTENSION(PyObject *__reduce__() const);
 
 protected:
   enum UnderFlags {

--- a/panda/src/event/asyncFuture.h
+++ b/panda/src/event/asyncFuture.h
@@ -62,16 +62,12 @@ PUBLISHED:
   INLINE AsyncFuture();
   virtual ~AsyncFuture();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(static PyObject *__await__(PyObject *self));
-  EXTENSION(static PyObject *__iter__(PyObject *self));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(static PyObject *__await__(PyObject *self));
+  PY_EXTENSION(static PyObject *__iter__(PyObject *self));
 
   INLINE bool done() const;
   INLINE bool cancelled() const;
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *result(PyObject *self, PyObject *timeout = Py_None) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *result(PyObject *self, PyObject *timeout = Py_None) const);
 
   virtual bool cancel();
 
@@ -79,11 +75,9 @@ PUBLISHED:
   INLINE const std::string &get_done_event() const;
   MAKE_PROPERTY(done_event, get_done_event, set_done_event);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *add_done_callback(PyObject *self, PyObject *fn));
+  PY_EXTENSION(PyObject *add_done_callback(PyObject *self, PyObject *fn));
 
-  EXTENSION(static PyObject *gather(PyObject *args));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(static PyObject *gather(PyObject *args));
   INLINE static PT(AsyncFuture) shield(PT(AsyncFuture) future);
 
   virtual void output(std::ostream &out) const;
@@ -91,9 +85,7 @@ PUBLISHED:
   BLOCKING void wait();
   BLOCKING void wait(double timeout);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(void set_result(PyObject *));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(void set_result(PyObject *));
 public:
   INLINE void set_result(std::nullptr_t);
   INLINE void set_result(TypedReferenceCount *result);

--- a/panda/src/express/datagram.h
+++ b/panda/src/express/datagram.h
@@ -95,11 +95,9 @@ public:
   INLINE const void *get_data() const;
 
 PUBLISHED:
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE PyObject *get_message() const);
-  EXTENSION(INLINE PyObject *__bytes__() const);
-  EXTENSION(PyObject *__reduce__() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE PyObject *get_message() const);
+  PY_EXTENSION(INLINE PyObject *__bytes__() const);
+  PY_EXTENSION(PyObject *__reduce__() const);
 
   INLINE size_t get_length() const;
 

--- a/panda/src/express/memoryUsagePointers.h
+++ b/panda/src/express/memoryUsagePointers.h
@@ -50,9 +50,9 @@ PUBLISHED:
   std::string get_type_name(size_t n) const;
   double get_age(size_t n) const;
 
-#if defined(DO_MEMORY_USAGE) && defined(HAVE_PYTHON)
-  EXTENSION(PyObject *get_python_pointer(size_t n) const);
-#endif // DO_MEMORY_USAGE && HAVE_PYTHON
+#if defined(DO_MEMORY_USAGE)
+  PY_EXTENSION(PyObject *get_python_pointer(size_t n) const);
+#endif // DO_MEMORY_USAGE
 
   void clear();
 

--- a/panda/src/express/multifile.h
+++ b/panda/src/express/multifile.h
@@ -84,10 +84,8 @@ PUBLISHED:
   std::string update_subfile(const std::string &subfile_name, const Filename &filename,
                         int compression_level);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE PyObject *set_encryption_password(PyObject *encryption_password) const);
-  EXTENSION(INLINE PyObject *get_encryption_password() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE PyObject *set_encryption_password(PyObject *encryption_password) const);
+  PY_EXTENSION(INLINE PyObject *get_encryption_password() const);
 
 #ifdef HAVE_OPENSSL
   bool add_signature(const Filename &certificate,

--- a/panda/src/express/pointerToArray.h
+++ b/panda/src/express/pointerToArray.h
@@ -96,9 +96,7 @@ PUBLISHED:
   INLINE static PointerToArray<Element> empty_array(size_type n, TypeHandle type_handle = get_type_handle(Element));
   INLINE PointerToArray(const PointerToArray<Element> &copy);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PointerToArray(PyObject *self, PyObject *source));
-#endif // HAVE_PYTHON */
+  PY_EXTENSION(PointerToArray(PyObject *self, PyObject *source));
 
   INLINE void clear();
 
@@ -109,25 +107,21 @@ PUBLISHED:
   INLINE void set_element(size_type n, const Element &value);
   EXTENSION(const Element &__getitem__(size_type n) const);
   EXTENSION(void __setitem__(size_type n, const Element &value));
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_data() const);
-  EXTENSION(void set_data(PyObject *data));
-  EXTENSION(PyObject *get_subdata(size_type n, size_type count) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *get_data() const);
+  PY_EXTENSION(void set_data(PyObject *data));
+  PY_EXTENSION(PyObject *get_subdata(size_type n, size_type count) const);
   INLINE void set_subdata(size_type n, size_type count, const std::string &data);
   INLINE int get_ref_count() const;
   INLINE int get_node_ref_count() const;
 
   INLINE size_t count(const Element &) const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
 
-  EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags));
-  EXTENSION(void __releasebuffer__(PyObject *self, Py_buffer *view) const);
+  PY_EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags));
+  PY_EXTENSION(void __releasebuffer__(PyObject *self, Py_buffer *view) const);
 
-  EXTENSION(PointerToArray<Element> __deepcopy__(PyObject *memo) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PointerToArray<Element> __deepcopy__(PyObject *memo) const);
 
 #else  // CPPPARSER
   // This is the actual, complete interface.
@@ -273,23 +267,19 @@ PUBLISHED:
   INLINE size_type size() const;
   INLINE const Element &get_element(size_type n) const;
   EXTENSION(const Element &__getitem__(size_type n) const);
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_data() const);
-  EXTENSION(PyObject *get_subdata(size_type n, size_type count) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *get_data() const);
+  PY_EXTENSION(PyObject *get_subdata(size_type n, size_type count) const);
   INLINE int get_ref_count() const;
   INLINE int get_node_ref_count() const;
 
   INLINE size_t count(const Element &) const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
 
-  EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
-  EXTENSION(void __releasebuffer__(PyObject *self, Py_buffer *view) const);
+  PY_EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
+  PY_EXTENSION(void __releasebuffer__(PyObject *self, Py_buffer *view) const);
 
-  EXTENSION(ConstPointerToArray<Element> __deepcopy__(PyObject *memo) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(ConstPointerToArray<Element> __deepcopy__(PyObject *memo) const);
 
 #else  // CPPPARSER
   // This is the actual, complete interface.

--- a/panda/src/express/ramfile.h
+++ b/panda/src/express/ramfile.h
@@ -27,20 +27,16 @@ PUBLISHED:
 
   INLINE void seek(size_t pos);
   INLINE size_t tell() const;
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *read(size_t length));
-  EXTENSION(PyObject *readline());
-  EXTENSION(PyObject *readlines());
+  PY_EXTENSION(PyObject *read(size_t length));
+  PY_EXTENSION(PyObject *readline());
+  PY_EXTENSION(PyObject *readlines());
 
-  EXTENSION(PyObject *get_data() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *get_data() const);
   INLINE size_t get_data_size() const;
   INLINE void clear();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__getstate__() const);
-  EXTENSION(void __setstate__(PyObject *state));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__getstate__() const);
+  PY_EXTENSION(void __setstate__(PyObject *state));
 public:
   std::string read(size_t length);
   std::string readline();

--- a/panda/src/express/stringStream.h
+++ b/panda/src/express/stringStream.h
@@ -30,9 +30,7 @@ public:
   INLINE StringStream(vector_uchar source);
 
 PUBLISHED:
-#ifdef HAVE_PYTHON
-  EXTENSION(StringStream(PyObject *source));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(StringStream(PyObject *source));
   INLINE StringStream();
 
 #if _MSC_VER >= 1800
@@ -42,12 +40,10 @@ PUBLISHED:
   INLINE void clear_data();
   INLINE size_t get_data_size();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_data());
-  EXTENSION(void set_data(PyObject *data));
+  PY_EXTENSION(PyObject *get_data());
+  PY_EXTENSION(void set_data(PyObject *data));
 
-  MAKE_PROPERTY(data, get_data, set_data);
-#endif // HAVE_PYTHON
+  PY_MAKE_PROPERTY(data, get_data, set_data);
 
 public:
 #ifndef CPPPARSER

--- a/panda/src/express/virtualFile.h
+++ b/panda/src/express/virtualFile.h
@@ -56,16 +56,12 @@ PUBLISHED:
   BLOCKING void ls(std::ostream &out = std::cout) const;
   BLOCKING void ls_all(std::ostream &out = std::cout) const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *read_file(bool auto_unwrap) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *read_file(bool auto_unwrap) const);
   BLOCKING virtual std::istream *open_read_file(bool auto_unwrap) const;
   BLOCKING virtual void close_read_file(std::istream *stream) const;
   virtual bool was_read_successful() const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *write_file(PyObject *data, bool auto_wrap));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *write_file(PyObject *data, bool auto_wrap));
   BLOCKING virtual std::ostream *open_write_file(bool auto_wrap, bool truncate);
   BLOCKING virtual std::ostream *open_append_file();
   BLOCKING virtual void close_write_file(std::ostream *stream);

--- a/panda/src/express/virtualFileSystem.h
+++ b/panda/src/express/virtualFileSystem.h
@@ -98,15 +98,11 @@ PUBLISHED:
 
   static VirtualFileSystem *get_global_ptr();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *read_file(const Filename &filename, bool auto_unwrap) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *read_file(const Filename &filename, bool auto_unwrap) const);
   BLOCKING std::istream *open_read_file(const Filename &filename, bool auto_unwrap) const;
   BLOCKING static void close_read_file(std::istream *stream);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *write_file(const Filename &filename, PyObject *data, bool auto_wrap));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *write_file(const Filename &filename, PyObject *data, bool auto_wrap));
   BLOCKING std::ostream *open_write_file(const Filename &filename, bool auto_wrap, bool truncate);
   BLOCKING std::ostream *open_append_file(const Filename &filename);
   BLOCKING static void close_write_file(std::ostream *stream);

--- a/panda/src/gobj/geomVertexArrayData.h
+++ b/panda/src/gobj/geomVertexArrayData.h
@@ -114,11 +114,9 @@ PUBLISHED:
   static void lru_epoch();
   INLINE static VertexDataBook &get_book();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags));
-  EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
-  EXTENSION(void __releasebuffer__(PyObject *self, Py_buffer *view) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags));
+  PY_EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
+  PY_EXTENSION(void __releasebuffer__(PyObject *self, Py_buffer *view) const);
 
 public:
   virtual void evict_lru();
@@ -310,14 +308,12 @@ PUBLISHED:
                          const unsigned char *source,
                          size_t from_start, size_t from_size);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(void copy_data_from(PyObject *buffer));
-  EXTENSION(void copy_subdata_from(size_t to_start, size_t to_size,
+  PY_EXTENSION(void copy_data_from(PyObject *buffer));
+  PY_EXTENSION(void copy_subdata_from(size_t to_start, size_t to_size,
                                    PyObject *buffer));
-  EXTENSION(void copy_subdata_from(size_t to_start, size_t to_size,
+  PY_EXTENSION(void copy_subdata_from(size_t to_start, size_t to_size,
                                    PyObject *buffer,
                                    size_t from_start, size_t from_size));
-#endif // HAVE_PYTHON
 
   INLINE vector_uchar get_data() const;
   void set_data(const vector_uchar &data);

--- a/panda/src/gobj/geomVertexArrayData.h
+++ b/panda/src/gobj/geomVertexArrayData.h
@@ -310,10 +310,10 @@ PUBLISHED:
 
   PY_EXTENSION(void copy_data_from(PyObject *buffer));
   PY_EXTENSION(void copy_subdata_from(size_t to_start, size_t to_size,
-                                   PyObject *buffer));
+                                      PyObject *buffer));
   PY_EXTENSION(void copy_subdata_from(size_t to_start, size_t to_size,
-                                   PyObject *buffer,
-                                   size_t from_start, size_t from_size));
+                                      PyObject *buffer,
+                                      size_t from_start, size_t from_size));
 
   INLINE vector_uchar get_data() const;
   void set_data(const vector_uchar &data);

--- a/panda/src/gobj/internalName.h
+++ b/panda/src/gobj/internalName.h
@@ -94,13 +94,11 @@ PUBLISHED:
   INLINE static PT(InternalName) get_view();
   INLINE static PT(InternalName) get_instance_matrix();
 
-#ifdef HAVE_PYTHON
   // These versions are exposed to Python, which have additional logic to map
   // from Python interned strings.
-  EXTENSION(static PT(InternalName) make(PyObject *str));
+  PY_EXTENSION(static PT(InternalName) make(PyObject *str));
 
-  EXTENSION(PyObject *__reduce__() const);
-#endif
+  PY_EXTENSION(PyObject *__reduce__() const);
 
 public:
 #ifdef HAVE_PYTHON

--- a/panda/src/gobj/texture.h
+++ b/panda/src/gobj/texture.h
@@ -462,7 +462,7 @@ PUBLISHED:
   void set_ram_image_as(CPTA_uchar image, const std::string &provided_format);
 #else // !CPPPARSER || !HAVE_PYTHON
   PY_EXTEND(void set_ram_image(PyObject *image, CompressionMode compression = CM_off,
-                            size_t page_size = 0));
+                               size_t page_size = 0));
   PY_EXTEND(void set_ram_image_as(PyObject *image, const std::string &provided_format));
 #endif // !CPPPARSER || !HAVE_PYTHON
   INLINE void clear_ram_image();

--- a/panda/src/gobj/texture.h
+++ b/panda/src/gobj/texture.h
@@ -461,9 +461,9 @@ PUBLISHED:
                             size_t page_size = 0);
   void set_ram_image_as(CPTA_uchar image, const std::string &provided_format);
 #else // !CPPPARSER || !HAVE_PYTHON
-  EXTEND void set_ram_image(PyObject *image, CompressionMode compression = CM_off,
-                            size_t page_size = 0);
-  EXTEND void set_ram_image_as(PyObject *image, const std::string &provided_format);
+  PY_EXTEND(void set_ram_image(PyObject *image, CompressionMode compression = CM_off,
+                            size_t page_size = 0));
+  PY_EXTEND(void set_ram_image_as(PyObject *image, const std::string &provided_format));
 #endif // !CPPPARSER || !HAVE_PYTHON
   INLINE void clear_ram_image();
   INLINE void set_keep_ram_image(bool keep_ram_image);
@@ -474,7 +474,7 @@ PUBLISHED:
   MAKE_PROPERTY(keep_ram_image, get_keep_ram_image, set_keep_ram_image);
   MAKE_PROPERTY(cacheable, is_cacheable);
 
-  EXTENSION(PT(Texture) __deepcopy__(PyObject *memo) const);
+  PY_EXTENSION(PT(Texture) __deepcopy__(PyObject *memo) const);
 
   BLOCKING INLINE bool compress_ram_image(CompressionMode compression = CM_on,
                                           QualityLevel quality_level = QL_default,

--- a/panda/src/gobj/textureCollection.h
+++ b/panda/src/gobj/textureCollection.h
@@ -29,10 +29,8 @@ PUBLISHED:
   void operator = (const TextureCollection &copy);
   INLINE ~TextureCollection();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(TextureCollection(PyObject *self, PyObject *sequence));
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-#endif
+  PY_EXTENSION(TextureCollection(PyObject *self, PyObject *sequence));
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
 
   void add_texture(Texture *texture);
   bool remove_texture(Texture *texture);

--- a/panda/src/gobj/texturePool.h
+++ b/panda/src/gobj/texturePool.h
@@ -98,11 +98,9 @@ PUBLISHED:
   TexturePoolFilter *get_filter(size_t i) const;
   MAKE_SEQ_PROPERTY(filters, get_num_filters, get_filter);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(bool register_filter(PyObject *tex_filter));
-  EXTENSION(bool unregister_filter(PyObject *tex_filter));
-  EXTENSION(bool is_filter_registered(PyObject *tex_filter));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(bool register_filter(PyObject *tex_filter));
+  PY_EXTENSION(bool unregister_filter(PyObject *tex_filter));
+  PY_EXTENSION(bool is_filter_registered(PyObject *tex_filter));
 
   static TexturePool *get_global_ptr();
 

--- a/panda/src/linmath/lmatrix3_src.h
+++ b/panda/src/linmath/lmatrix3_src.h
@@ -68,9 +68,7 @@ PUBLISHED:
                                      const FLOATNAME(LVecBase3) &);
   ALLOC_DELETED_CHAIN(FLOATNAME(LMatrix3));
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
 
   void fill(FLOATTYPE fill_value);
   INLINE_LINMATH void set(

--- a/panda/src/linmath/lmatrix4_src.h
+++ b/panda/src/linmath/lmatrix4_src.h
@@ -72,9 +72,7 @@ PUBLISHED:
                                      const FLOATNAME(LVecBase4) &);
   ALLOC_DELETED_CHAIN(FLOATNAME(LMatrix4));
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
 
   // Construct a 4x4 matrix given a 3x3 rotation matrix and an optional
   // translation component.

--- a/panda/src/linmath/lpoint2_src.h
+++ b/panda/src/linmath/lpoint2_src.h
@@ -22,10 +22,8 @@ PUBLISHED:
   INLINE_LINMATH FLOATNAME(LPoint2)(FLOATTYPE fill_value);
   INLINE_LINMATH FLOATNAME(LPoint2)(FLOATTYPE x, FLOATTYPE y);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
-  EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
+  PY_EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
 
   INLINE_LINMATH static const FLOATNAME(LPoint2) &zero();
   INLINE_LINMATH static const FLOATNAME(LPoint2) &unit_x();

--- a/panda/src/linmath/lpoint3_src.h
+++ b/panda/src/linmath/lpoint3_src.h
@@ -26,10 +26,8 @@ PUBLISHED:
   INLINE_LINMATH FLOATNAME(LPoint3)(FLOATTYPE x, FLOATTYPE y, FLOATTYPE z);
   INLINE_LINMATH FLOATNAME(LPoint3)(const FLOATNAME(LVecBase2) &copy, FLOATTYPE z);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
-  EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
+  PY_EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
 
   INLINE_LINMATH static const FLOATNAME(LPoint3) &zero();
   INLINE_LINMATH static const FLOATNAME(LPoint3) &unit_x();

--- a/panda/src/linmath/lpoint4_src.h
+++ b/panda/src/linmath/lpoint4_src.h
@@ -22,10 +22,8 @@ PUBLISHED:
   INLINE_LINMATH FLOATNAME(LPoint4)(FLOATTYPE x, FLOATTYPE y, FLOATTYPE z, FLOATTYPE w);
   INLINE_LINMATH FLOATNAME(LPoint4)(const FLOATNAME(LVecBase3) &copy, FLOATTYPE w);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
-  EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
+  PY_EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
 
   INLINE_LINMATH static const FLOATNAME(LPoint4) &zero();
   INLINE_LINMATH static const FLOATNAME(LPoint4) &unit_x();

--- a/panda/src/linmath/lvecBase2_src.h
+++ b/panda/src/linmath/lvecBase2_src.h
@@ -44,11 +44,9 @@ PUBLISHED:
   INLINE_LINMATH static const FLOATNAME(LVecBase2) &unit_x();
   INLINE_LINMATH static const FLOATNAME(LVecBase2) &unit_y();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
-  EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
-  EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
+  PY_EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
 
   INLINE_LINMATH FLOATTYPE operator [](int i) const;
   INLINE_LINMATH FLOATTYPE &operator [](int i);
@@ -135,19 +133,17 @@ PUBLISHED:
 
   INLINE_LINMATH void componentwise_mult(const FLOATNAME(LVecBase2) &other);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__rmul__(PyObject *self, FLOATTYPE scalar) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__rmul__(PyObject *self, FLOATTYPE scalar) const);
 
-  EXTENSION(INLINE_LINMATH PyObject *__floordiv__(PyObject *self, FLOATTYPE scalar) const);
-  EXTENSION(INLINE_LINMATH PyObject *__ifloordiv__(PyObject *self, FLOATTYPE scalar));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__floordiv__(PyObject *self, FLOATTYPE scalar) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__ifloordiv__(PyObject *self, FLOATTYPE scalar));
 
-  EXTENSION(INLINE_LINMATH PyObject *__pow__(PyObject *self, FLOATTYPE exponent) const);
-  EXTENSION(INLINE_LINMATH PyObject *__ipow__(PyObject *self, FLOATTYPE exponent));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__pow__(PyObject *self, FLOATTYPE exponent) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__ipow__(PyObject *self, FLOATTYPE exponent));
 
-  EXTENSION(INLINE_LINMATH PyObject *__round__(PyObject *self));
-  EXTENSION(INLINE_LINMATH PyObject *__floor__(PyObject *self));
-  EXTENSION(INLINE_LINMATH PyObject *__ceil__(PyObject *self));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__round__(PyObject *self));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__floor__(PyObject *self));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__ceil__(PyObject *self));
 
   INLINE_LINMATH FLOATNAME(LVecBase2) fmax(const FLOATNAME(LVecBase2) &other) const;
   INLINE_LINMATH FLOATNAME(LVecBase2) fmin(const FLOATNAME(LVecBase2) &other) const;
@@ -164,9 +160,7 @@ PUBLISHED:
   INLINE_LINMATH void write_datagram(Datagram &destination) const;
   INLINE_LINMATH void read_datagram(DatagramIterator &source);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
 
 public:
   // The underlying implementation is via the Eigen library, if available.

--- a/panda/src/linmath/lvecBase3_src.h
+++ b/panda/src/linmath/lvecBase3_src.h
@@ -46,11 +46,9 @@ PUBLISHED:
   INLINE_LINMATH static const FLOATNAME(LVecBase3) &unit_y();
   INLINE_LINMATH static const FLOATNAME(LVecBase3) &unit_z();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
-  EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
-  EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
+  PY_EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
 
   INLINE_LINMATH FLOATTYPE operator [](int i) const;
   INLINE_LINMATH FLOATTYPE &operator [](int i);
@@ -154,19 +152,17 @@ PUBLISHED:
 
   INLINE_LINMATH void componentwise_mult(const FLOATNAME(LVecBase3) &other);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__rmul__(PyObject *self, FLOATTYPE scalar) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__rmul__(PyObject *self, FLOATTYPE scalar) const);
 
-  EXTENSION(INLINE_LINMATH PyObject *__floordiv__(PyObject *self, FLOATTYPE scalar) const);
-  EXTENSION(INLINE_LINMATH PyObject *__ifloordiv__(PyObject *self, FLOATTYPE scalar));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__floordiv__(PyObject *self, FLOATTYPE scalar) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__ifloordiv__(PyObject *self, FLOATTYPE scalar));
 
-  EXTENSION(INLINE_LINMATH PyObject *__pow__(PyObject *self, FLOATTYPE exponent) const);
-  EXTENSION(INLINE_LINMATH PyObject *__ipow__(PyObject *self, FLOATTYPE exponent));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__pow__(PyObject *self, FLOATTYPE exponent) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__ipow__(PyObject *self, FLOATTYPE exponent));
 
-  EXTENSION(INLINE_LINMATH PyObject *__round__(PyObject *self));
-  EXTENSION(INLINE_LINMATH PyObject *__floor__(PyObject *self));
-  EXTENSION(INLINE_LINMATH PyObject *__ceil__(PyObject *self));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__round__(PyObject *self));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__floor__(PyObject *self));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__ceil__(PyObject *self));
 
   INLINE_LINMATH FLOATNAME(LVecBase3) fmax(const FLOATNAME(LVecBase3) &other) const;
   INLINE_LINMATH FLOATNAME(LVecBase3) fmin(const FLOATNAME(LVecBase3) &other) const;
@@ -185,9 +181,7 @@ PUBLISHED:
   INLINE_LINMATH void write_datagram(Datagram &destination) const;
   INLINE_LINMATH void read_datagram(DatagramIterator &source);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
 
 public:
   // The underlying implementation is via the Eigen library, if available.

--- a/panda/src/linmath/lvecBase4_src.h
+++ b/panda/src/linmath/lvecBase4_src.h
@@ -56,11 +56,9 @@ PUBLISHED:
   INLINE_LINMATH static const FLOATNAME(LVecBase4) &unit_z();
   INLINE_LINMATH static const FLOATNAME(LVecBase4) &unit_w();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
-  EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
-  EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
+  PY_EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
 
   INLINE_LINMATH FLOATTYPE operator [](int i) const;
   INLINE_LINMATH FLOATTYPE &operator [](int i);
@@ -162,19 +160,17 @@ PUBLISHED:
 
   INLINE_LINMATH void componentwise_mult(const FLOATNAME(LVecBase4) &other);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__rmul__(PyObject *self, FLOATTYPE scalar) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__rmul__(PyObject *self, FLOATTYPE scalar) const);
 
-  EXTENSION(INLINE_LINMATH PyObject *__floordiv__(PyObject *self, FLOATTYPE scalar) const);
-  EXTENSION(INLINE_LINMATH PyObject *__ifloordiv__(PyObject *self, FLOATTYPE scalar));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__floordiv__(PyObject *self, FLOATTYPE scalar) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__ifloordiv__(PyObject *self, FLOATTYPE scalar));
 
-  EXTENSION(INLINE_LINMATH PyObject *__pow__(PyObject *self, FLOATTYPE exponent) const);
-  EXTENSION(INLINE_LINMATH PyObject *__ipow__(PyObject *self, FLOATTYPE exponent));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__pow__(PyObject *self, FLOATTYPE exponent) const);
+  PY_EXTENSION(INLINE_LINMATH PyObject *__ipow__(PyObject *self, FLOATTYPE exponent));
 
-  EXTENSION(INLINE_LINMATH PyObject *__round__(PyObject *self));
-  EXTENSION(INLINE_LINMATH PyObject *__floor__(PyObject *self));
-  EXTENSION(INLINE_LINMATH PyObject *__ceil__(PyObject *self));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__round__(PyObject *self));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__floor__(PyObject *self));
+  PY_EXTENSION(INLINE_LINMATH PyObject *__ceil__(PyObject *self));
 
   INLINE_LINMATH FLOATNAME(LVecBase4) fmax(const FLOATNAME(LVecBase4) &other) const;
   INLINE_LINMATH FLOATNAME(LVecBase4) fmin(const FLOATNAME(LVecBase4) &other) const;
@@ -191,9 +187,7 @@ PUBLISHED:
   INLINE_LINMATH void write_datagram(Datagram &destination) const;
   INLINE_LINMATH void read_datagram(DatagramIterator &source);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
 
 public:
   // The underlying implementation is via the Eigen library, if available.

--- a/panda/src/linmath/lvector2_src.h
+++ b/panda/src/linmath/lvector2_src.h
@@ -22,10 +22,8 @@ PUBLISHED:
   INLINE_LINMATH FLOATNAME(LVector2)(FLOATTYPE fill_value);
   INLINE_LINMATH FLOATNAME(LVector2)(FLOATTYPE x, FLOATTYPE y);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
-  EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
+  PY_EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
 
   INLINE_LINMATH static const FLOATNAME(LVector2) &zero();
   INLINE_LINMATH static const FLOATNAME(LVector2) &unit_x();

--- a/panda/src/linmath/lvector3_src.h
+++ b/panda/src/linmath/lvector3_src.h
@@ -26,10 +26,8 @@ PUBLISHED:
   INLINE_LINMATH FLOATNAME(LVector3)(FLOATTYPE x, FLOATTYPE y, FLOATTYPE z);
   INLINE_LINMATH FLOATNAME(LVector3)(const FLOATNAME(LVecBase2) &copy, FLOATTYPE z);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
-  EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
+  PY_EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
 
   INLINE_LINMATH static const FLOATNAME(LVector3) &zero();
   INLINE_LINMATH static const FLOATNAME(LVector3) &unit_x();

--- a/panda/src/linmath/lvector4_src.h
+++ b/panda/src/linmath/lvector4_src.h
@@ -22,10 +22,8 @@ PUBLISHED:
   INLINE_LINMATH FLOATNAME(LVector4)(FLOATTYPE x, FLOATTYPE y, FLOATTYPE z, FLOATTYPE w);
   INLINE_LINMATH FLOATNAME(LVector4)(const FLOATNAME(LVecBase3) &copy, FLOATTYPE w);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
-  EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(INLINE_LINMATH PyObject *__getattr__(PyObject *self, const std::string &attr_name) const);
+  PY_EXTENSION(INLINE_LINMATH int __setattr__(PyObject *self, const std::string &attr_name, PyObject *assign));
 
   INLINE_LINMATH static const FLOATNAME(LVector4) &zero();
   INLINE_LINMATH static const FLOATNAME(LVector4) &unit_x();

--- a/panda/src/ode/odeBody.h
+++ b/panda/src/ode/odeBody.h
@@ -51,7 +51,7 @@ PUBLISHED:
   INLINE void set_auto_disable_flag(int do_auto_disable);
   INLINE void set_auto_disable_defaults();
   INLINE void set_data(void *data);
-  EXTENSION(void set_data(PyObject *data));
+  PY_EXTENSION(void set_data(PyObject *data));
 
   INLINE void set_position(dReal x, dReal y, dReal z);
   INLINE void set_position(const LVecBase3f &pos);
@@ -71,8 +71,8 @@ PUBLISHED:
   INLINE int   get_auto_disable_flag() const;
 #ifndef CPPPARSER
   INLINE void *get_data() const;
-#endif
-  EXTENSION(PyObject *get_data() const);
+#endif // CPPPARSER
+  PY_EXTENSION(PyObject *get_data() const);
 
   INLINE LVecBase3f  get_position() const;
   INLINE LMatrix3f  get_rotation() const;
@@ -132,8 +132,8 @@ PUBLISHED:
   INLINE int get_num_joints() const;
   OdeJoint get_joint(int index) const;
   MAKE_SEQ(get_joints, get_num_joints, get_joint);
-  EXTENSION(INLINE PyObject *get_converted_joint(int i) const);
-  MAKE_SEQ_PROPERTY(joints, get_num_joints, get_converted_joint);
+  PY_EXTENSION(INLINE PyObject *get_converted_joint(int i) const);
+  PY_MAKE_SEQ_PROPERTY(joints, get_num_joints, get_converted_joint);
 
   INLINE void enable();
   INLINE void disable();

--- a/panda/src/ode/odeGeom.h
+++ b/panda/src/ode/odeGeom.h
@@ -84,7 +84,7 @@ PUBLISHED:
   INLINE LMatrix3f get_rotation() const;
   INLINE LQuaternionf get_quaternion() const;
   INLINE void get_AABB(LVecBase3f &min, LVecBase3f &max) const;
-  EXTENSION(INLINE PyObject *get_AA_bounds() const);
+  PY_EXTENSION(INLINE PyObject *get_AA_bounds() const);
   INLINE int is_space();
   INLINE int get_class() const;
   INLINE void set_category_bits(const BitMask32 &bits);
@@ -114,13 +114,13 @@ PUBLISHED:
   // int test_collide_id( int collide_id);
 
   OdeSpace get_space() const;
-  EXTENSION(INLINE PyObject *get_converted_space() const);
+  PY_EXTENSION(INLINE PyObject *get_converted_space() const);
 
   virtual void write(std::ostream &out = std::cout, unsigned int indent=0) const;
   operator bool () const;
   INLINE int compare_to(const OdeGeom &other) const;
 
-  EXTENSION(PyObject *convert() const);
+  PY_EXTENSION(PyObject *convert() const);
   OdeBoxGeom convert_to_box() const;
   OdeCappedCylinderGeom convert_to_capped_cylinder() const;
   // OdeConvexGeom convert_to_convex() const;

--- a/panda/src/ode/odeJoint.h
+++ b/panda/src/ode/odeJoint.h
@@ -83,7 +83,7 @@ PUBLISHED:
   INLINE void set_feedback(bool flag = true);
   INLINE OdeJointFeedback *get_feedback();
 
-  EXTENSION(void attach(PyObject *body1, PyObject *body2));
+  PY_EXTENSION(void attach(PyObject *body1, PyObject *body2));
   void attach_bodies(const OdeBody &body1, const OdeBody &body2);
   void attach_body(const OdeBody &body, int index);
   void detach();
@@ -93,7 +93,7 @@ PUBLISHED:
   INLINE bool operator == (const OdeJoint &other) const;
   operator bool () const;
 
-  EXTENSION(PyObject *convert() const);
+  PY_EXTENSION(PyObject *convert() const);
   OdeBallJoint convert_to_ball() const;
   OdeHingeJoint convert_to_hinge() const;
   OdeSliderJoint convert_to_slider() const;

--- a/panda/src/ode/odeSpace.h
+++ b/panda/src/ode/odeSpace.h
@@ -52,7 +52,7 @@ PUBLISHED:
   int query(const OdeSpace& space) const;
   INLINE int get_num_geoms() const;
   INLINE void get_AABB(LVecBase3f &min, LVecBase3f &max) const;
-  EXTENSION(INLINE PyObject *get_AA_bounds() const);
+  PY_EXTENSION(INLINE PyObject *get_AA_bounds() const);
   INLINE int is_space();
   INLINE int get_class() const;
   INLINE void set_category_bits(const BitMask32 &bits);
@@ -82,12 +82,12 @@ PUBLISHED:
   OdeHashSpace convert_to_hash_space() const;
   OdeQuadTreeSpace convert_to_quad_tree_space() const;
 
-  EXTENSION(PyObject *convert() const);
-  EXTENSION(INLINE PyObject *get_converted_geom(int i) const);
-  EXTENSION(INLINE PyObject *get_converted_space() const);
+  PY_EXTENSION(PyObject *convert() const);
+  PY_EXTENSION(INLINE PyObject *get_converted_geom(int i) const);
+  PY_EXTENSION(INLINE PyObject *get_converted_space() const);
 
   void auto_collide();
-  EXTENSION(int collide(PyObject* arg, PyObject* near_callback));
+  PY_EXTENSION(int collide(PyObject* arg, PyObject* near_callback));
   int set_collide_id(int collide_id, dGeomID id);
   int set_collide_id(OdeGeom& geom, int collide_id);
   void set_surface_type( int surface_type, dGeomID id);

--- a/panda/src/ode/odeUtil.h
+++ b/panda/src/ode/odeUtil.h
@@ -41,10 +41,10 @@ PUBLISHED:
                                      const OdeBody &body2,
                                      const int joint_type);
   static PT(OdeCollisionEntry) collide(const OdeGeom &geom1, const OdeGeom &geom2,
-                                      const short int max_contacts = 150);
+                                       const short int max_contacts = 150);
 
   PY_EXTENSION(static int collide2(const OdeGeom &geom1, const OdeGeom &geom2,
-                                PyObject* arg, PyObject* callback));
+                                   PyObject* arg, PyObject* callback));
 
   static OdeGeom space_to_geom(const OdeSpace &space);
 

--- a/panda/src/ode/odeUtil.h
+++ b/panda/src/ode/odeUtil.h
@@ -43,7 +43,7 @@ PUBLISHED:
   static PT(OdeCollisionEntry) collide(const OdeGeom &geom1, const OdeGeom &geom2,
                                       const short int max_contacts = 150);
 
-  EXTENSION(static int collide2(const OdeGeom &geom1, const OdeGeom &geom2,
+  PY_EXTENSION(static int collide2(const OdeGeom &geom1, const OdeGeom &geom2,
                                 PyObject* arg, PyObject* callback));
 
   static OdeGeom space_to_geom(const OdeSpace &space);

--- a/panda/src/pgraph/loaderFileTypeRegistry.h
+++ b/panda/src/pgraph/loaderFileTypeRegistry.h
@@ -38,12 +38,10 @@ public:
   void unregister_type(LoaderFileType *type);
 
 PUBLISHED:
-#ifdef HAVE_PYTHON
-  EXTENSION(void register_type(PyObject *type));
-  EXTENSION(void register_deferred_type(PyObject *entry_point));
+  PY_EXTENSION(void register_type(PyObject *type));
+  PY_EXTENSION(void register_deferred_type(PyObject *entry_point));
 
-  EXTENSION(void unregister_type(PyObject *type));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(void unregister_type(PyObject *type));
 
   int get_num_types() const;
   LoaderFileType *get_type(int n) const;
@@ -55,9 +53,7 @@ PUBLISHED:
 
   static LoaderFileTypeRegistry *get_global_ptr();
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__reduce__() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__reduce__() const);
 
 private:
   void record_extension(const std::string &extension, LoaderFileType *type);

--- a/panda/src/pgraph/nodePath.h
+++ b/panda/src/pgraph/nodePath.h
@@ -183,11 +183,9 @@ PUBLISHED:
   INLINE void clear();
 
   EXTENSION(NodePath __copy__() const);
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__deepcopy__(PyObject *self, PyObject *memo) const);
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-  EXTENSION(PyObject *__reduce_persist__(PyObject *self, PyObject *pickler) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__deepcopy__(PyObject *self, PyObject *memo) const);
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(PyObject *__reduce_persist__(PyObject *self, PyObject *pickler) const);
 
   INLINE static NodePath not_found();
   INLINE static NodePath removed();
@@ -668,10 +666,8 @@ PUBLISHED:
   INLINE void set_shader_input(CPT_InternalName id, PN_stdfloat n1, PN_stdfloat n2,
                                PN_stdfloat n3=0, PN_stdfloat n4=0, int priority=0);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(void set_shader_input(CPT_InternalName, PyObject *, int priority=0));
-  EXTENSION(void set_shader_inputs(PyObject *args, PyObject *kwargs));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(void set_shader_input(CPT_InternalName, PyObject *, int priority=0));
+  PY_EXTENSION(void set_shader_inputs(PyObject *args, PyObject *kwargs));
 
   void clear_shader_input(CPT_InternalName id);
   void set_instance_count(int instance_count);
@@ -915,9 +911,7 @@ PUBLISHED:
                          const NodePath &other = NodePath(),
                          Thread *current_thread = Thread::get_current_thread()) const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_tight_bounds(const NodePath &other = NodePath()) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *get_tight_bounds(const NodePath &other = NodePath()) const);
 
   // void analyze() const;
 
@@ -938,24 +932,22 @@ PUBLISHED:
 
   MAKE_MAP_PROPERTY(net_tags, has_net_tag, get_net_tag);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(INLINE PyObject *get_tags() const);
-  EXTENSION(INLINE PyObject *get_tag_keys() const);
-  MAKE_PROPERTY(tags, get_tags);
+  PY_EXTENSION(INLINE PyObject *get_tags() const);
+  PY_EXTENSION(INLINE PyObject *get_tag_keys() const);
+  PY_MAKE_PROPERTY(tags, get_tags);
 
-  EXTENSION(PyObject *get_python_tags());
-  EXTENSION(INLINE void set_python_tag(PyObject *keys, PyObject *value));
-  EXTENSION(INLINE PyObject *get_python_tag(PyObject *keys) const);
-  EXTENSION(INLINE PyObject *get_python_tag_keys() const);
-  EXTENSION(INLINE bool has_python_tag(PyObject *keys) const);
-  EXTENSION(INLINE void clear_python_tag(PyObject *keys));
-  EXTENSION(INLINE PyObject *get_net_python_tag(PyObject *keys) const);
-  EXTENSION(INLINE bool has_net_python_tag(PyObject *keys) const);
-  EXTENSION(NodePath find_net_python_tag(PyObject *keys) const);
-  MAKE_PROPERTY(python_tags, get_python_tags);
+  PY_EXTENSION(PyObject *get_python_tags());
+  PY_EXTENSION(INLINE void set_python_tag(PyObject *keys, PyObject *value));
+  PY_EXTENSION(INLINE PyObject *get_python_tag(PyObject *keys) const);
+  PY_EXTENSION(INLINE PyObject *get_python_tag_keys() const);
+  PY_EXTENSION(INLINE bool has_python_tag(PyObject *keys) const);
+  PY_EXTENSION(INLINE void clear_python_tag(PyObject *keys));
+  PY_EXTENSION(INLINE PyObject *get_net_python_tag(PyObject *keys) const);
+  PY_EXTENSION(INLINE bool has_net_python_tag(PyObject *keys) const);
+  PY_EXTENSION(NodePath find_net_python_tag(PyObject *keys) const);
+  PY_MAKE_PROPERTY(python_tags, get_python_tags);
 
-  EXTENSION(int __traverse__(visitproc visit, void *arg));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(int __traverse__(visitproc visit, void *arg));
 
   INLINE void list_tags() const;
 

--- a/panda/src/pgraph/nodePathCollection.h
+++ b/panda/src/pgraph/nodePathCollection.h
@@ -27,10 +27,8 @@ class EXPCL_PANDA_PGRAPH NodePathCollection {
 PUBLISHED:
   NodePathCollection() = default;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(NodePathCollection(PyObject *self, PyObject *sequence));
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(NodePathCollection(PyObject *self, PyObject *sequence));
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
 
   void add_path(const NodePath &node_path);
   bool remove_path(const NodePath &node_path);
@@ -74,9 +72,7 @@ PUBLISHED:
 
   bool calc_tight_bounds(LPoint3 &min_point, LPoint3 &max_point) const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_tight_bounds() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *get_tight_bounds() const);
 
   void set_texture(Texture *tex, int priority = 0);
   void set_texture(TextureStage *stage, Texture *tex, int priority = 0);

--- a/panda/src/pgraph/pandaNode.h
+++ b/panda/src/pgraph/pandaNode.h
@@ -106,10 +106,8 @@ PUBLISHED:
   virtual PandaNode *make_copy() const;
   PT(PandaNode) copy_subgraph(Thread *current_thread = Thread::get_current_thread()) const;
 
-#ifdef HAVE_PYTHON
   EXTENSION(PT(PandaNode) __copy__() const);
-  EXTENSION(PyObject *__deepcopy__(PyObject *self, PyObject *memo) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__deepcopy__(PyObject *self, PyObject *memo) const);
 
   INLINE int get_num_parents(Thread *current_thread = Thread::get_current_thread()) const;
   INLINE PandaNode *get_parent(int n, Thread *current_thread = Thread::get_current_thread()) const;
@@ -206,19 +204,17 @@ PUBLISHED:
   MAKE_MAP_PROPERTY(tags, has_tag, get_tag, set_tag, clear_tag);
   MAKE_MAP_KEYS_SEQ(tags, get_num_tags, get_tag_key);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_tag_keys() const);
+  PY_EXTENSION(PyObject *get_tag_keys() const);
 
-  EXTENSION(PyObject *get_python_tags());
-  EXTENSION(void set_python_tag(PyObject *key, PyObject *value));
-  EXTENSION(PyObject *get_python_tag(PyObject *key) const);
-  EXTENSION(bool has_python_tag(PyObject *key) const);
-  EXTENSION(void clear_python_tag(PyObject *key));
-  EXTENSION(PyObject *get_python_tag_keys() const);
-  MAKE_PROPERTY(python_tags, get_python_tags);
+  PY_EXTENSION(PyObject *get_python_tags());
+  PY_EXTENSION(void set_python_tag(PyObject *key, PyObject *value));
+  PY_EXTENSION(PyObject *get_python_tag(PyObject *key) const);
+  PY_EXTENSION(bool has_python_tag(PyObject *key) const);
+  PY_EXTENSION(void clear_python_tag(PyObject *key));
+  PY_EXTENSION(PyObject *get_python_tag_keys() const);
+  PY_MAKE_PROPERTY(python_tags, get_python_tags);
 
-  EXTENSION(int __traverse__(visitproc visit, void *arg));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(int __traverse__(visitproc visit, void *arg));
 
   INLINE bool has_tags() const;
   void copy_tags(PandaNode *other);

--- a/panda/src/pgraph/renderState.h
+++ b/panda/src/pgraph/renderState.h
@@ -71,7 +71,7 @@ PUBLISHED:
   bool cull_callback(CullTraverser *trav, const CullTraverserData &data) const;
 
   INLINE static CPT(RenderState) make_empty();
-  EXTENSION(static explicit CPT(RenderState) make(PyObject *args, PyObject *kwargs));
+  PY_EXTENSION(static explicit CPT(RenderState) make(PyObject *args, PyObject *kwargs));
 
 public:
   static CPT(RenderState) make(const RenderAttrib *attrib, int override = 0);
@@ -132,10 +132,8 @@ PUBLISHED:
   INLINE size_t get_invert_composition_cache_size() const;
   INLINE const RenderState *get_invert_composition_cache_source(size_t n) const;
   INLINE const RenderState *get_invert_composition_cache_result(size_t n) const;
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_composition_cache() const);
-  EXTENSION(PyObject *get_invert_composition_cache() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *get_composition_cache() const);
+  PY_EXTENSION(PyObject *get_invert_composition_cache() const);
 
   void output(std::ostream &out) const;
   void write(std::ostream &out, int indent_level) const;
@@ -150,10 +148,8 @@ PUBLISHED:
   static void list_cycles(std::ostream &out);
   static void list_states(std::ostream &out);
   static bool validate_states();
-#ifdef HAVE_PYTHON
-  EXTENSION(static PyObject *get_states());
-  EXTENSION(static PyObject *get_unused_states());
-#endif // HAVE_PYTHON
+  PY_EXTENSION(static PyObject *get_states());
+  PY_EXTENSION(static PyObject *get_unused_states());
 
 PUBLISHED:
   // These methods are intended for use by low-level code, but they're also

--- a/panda/src/pgraph/shaderAttrib.h
+++ b/panda/src/pgraph/shaderAttrib.h
@@ -96,10 +96,8 @@ public:
   CPT(RenderAttrib) set_shader_inputs(const pvector<ShaderInput> &inputs) const;
 
 PUBLISHED:
-#ifdef HAVE_PYTHON
-  EXTENSION(CPT(RenderAttrib) set_shader_input(CPT_InternalName, PyObject *, int priority=0) const);
-  EXTENSION(CPT(RenderAttrib) set_shader_inputs(PyObject *args, PyObject *kwargs) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(CPT(RenderAttrib) set_shader_input(CPT_InternalName, PyObject *, int priority=0) const);
+  PY_EXTENSION(CPT(RenderAttrib) set_shader_inputs(PyObject *args, PyObject *kwargs) const);
 
   CPT(RenderAttrib) set_instance_count(int instance_count) const;
 

--- a/panda/src/pgraph/shaderInput.h
+++ b/panda/src/pgraph/shaderInput.h
@@ -49,9 +49,7 @@ PUBLISHED:
   static const ShaderInput &get_blank();
   INLINE explicit ShaderInput(CPT_InternalName name, int priority=0);
 
-#ifdef HAVE_PYTHON
-  EXTENSION(explicit ShaderInput(CPT_InternalName name, PyObject *value, int priority=0));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(explicit ShaderInput(CPT_InternalName name, PyObject *value, int priority=0));
 
 public:
   INLINE ShaderInput(CPT_InternalName name, Texture *tex, int priority=0);

--- a/panda/src/pgraph/transformState.h
+++ b/panda/src/pgraph/transformState.h
@@ -194,10 +194,8 @@ PUBLISHED:
   INLINE const TransformState *get_invert_composition_cache_source(size_t n) const;
   INLINE const TransformState *get_invert_composition_cache_result(size_t n) const;
   bool validate_composition_cache() const;
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_composition_cache() const);
-  EXTENSION(PyObject *get_invert_composition_cache() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *get_composition_cache() const);
+  PY_EXTENSION(PyObject *get_invert_composition_cache() const);
 
   void output(std::ostream &out) const;
   void write(std::ostream &out, int indent_level) const;
@@ -210,10 +208,8 @@ PUBLISHED:
   static void list_cycles(std::ostream &out);
   static void list_states(std::ostream &out);
   static bool validate_states();
-#ifdef HAVE_PYTHON
-  EXTENSION(static PyObject *get_states());
-  EXTENSION(static PyObject *get_unused_states());
-#endif // HAVE_PYTHON
+  PY_EXTENSION(static PyObject *get_states());
+  PY_EXTENSION(static PyObject *get_unused_states());
 
 public:
   static void init_states();

--- a/panda/src/pipeline/pmutex.h
+++ b/panda/src/pipeline/pmutex.h
@@ -49,11 +49,9 @@ PUBLISHED:
 
   void operator = (const Mutex &copy) = delete;
 
-#ifdef HAVE_PYTHON
   EXTENSION(bool acquire(bool blocking=true) const);
-  EXTENSION(bool __enter__());
-  EXTENSION(void __exit__(PyObject *, PyObject *, PyObject *));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(bool __enter__());
+  PY_EXTENSION(void __exit__(PyObject *, PyObject *, PyObject *));
 public:
   // This is a global mutex set aside for the purpose of protecting Notify
   // messages from being interleaved between threads.

--- a/panda/src/pipeline/reMutex.h
+++ b/panda/src/pipeline/reMutex.h
@@ -43,11 +43,9 @@ PUBLISHED:
 
   void operator = (const ReMutex &copy) = delete;
 
-#ifdef HAVE_PYTHON
   EXTENSION(bool acquire(bool blocking=true) const);
-  EXTENSION(bool __enter__());
-  EXTENSION(void __exit__(PyObject *, PyObject *, PyObject *));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(bool __enter__());
+  PY_EXTENSION(void __exit__(PyObject *, PyObject *, PyObject *));
 };
 
 #include "reMutex.I"

--- a/panda/src/pnmimage/pfmFile.h
+++ b/panda/src/pnmimage/pfmFile.h
@@ -170,11 +170,9 @@ PUBLISHED:
 
   void output(std::ostream &out) const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_points() const);
+  PY_EXTENSION(PyObject *get_points() const);
 
-  EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
-#endif
+  PY_EXTENSION(int __getbuffer__(PyObject *self, Py_buffer *view, int flags) const);
 
 public:
   INLINE const vector_float &get_table() const;

--- a/panda/src/putil/bamReader.h
+++ b/panda/src/putil/bamReader.h
@@ -148,18 +148,14 @@ PUBLISHED:
   INLINE int get_current_major_ver() const;
   INLINE int get_current_minor_ver() const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *get_file_version() const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *get_file_version() const);
 
 PUBLISHED:
   MAKE_PROPERTY(source, get_source, set_source);
   MAKE_PROPERTY(filename, get_filename);
   MAKE_PROPERTY(loader_options, get_loader_options, set_loader_options);
 
-#ifdef HAVE_PYTHON
-  MAKE_PROPERTY(file_version, get_file_version);
-#endif // HAVE_PYTHON
+  PY_MAKE_PROPERTY(file_version, get_file_version);
   MAKE_PROPERTY(file_endian, get_file_endian);
   MAKE_PROPERTY(file_stdfloat_double, get_file_stdfloat_double);
 
@@ -205,10 +201,8 @@ public:
                                       void *user_data = nullptr);
   INLINE static WritableFactory *get_factory();
 
-#ifdef HAVE_PYTHON
 PUBLISHED:
-  EXTENSION(static void register_factory(TypeHandle handle, PyObject *func));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(static void register_factory(TypeHandle handle, PyObject *func));
 
 private:
   INLINE static void create_factory();

--- a/panda/src/putil/bitArray.h
+++ b/panda/src/putil/bitArray.h
@@ -49,9 +49,7 @@ PUBLISHED:
 
   INLINE BitArray();
   BitArray(const SparseArray &from);
-#ifdef HAVE_PYTHON
-  EXTENSION(BitArray(PyObject *init_value));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(BitArray(PyObject *init_value));
 
   INLINE static BitArray all_on();
   INLINE static BitArray all_off();
@@ -131,10 +129,8 @@ PUBLISHED:
   void operator >>= (int shift);
 
   EXTENSION(bool __bool__() const);
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__getstate__() const);
-  EXTENSION(void __setstate__(PyObject *state));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__getstate__() const);
+  PY_EXTENSION(void __setstate__(PyObject *state));
 
 public:
   void generate_hash(ChecksumHashGenerator &hashgen) const;

--- a/panda/src/putil/bitMask.h
+++ b/panda/src/putil/bitMask.h
@@ -126,10 +126,8 @@ PUBLISHED:
   INLINE int get_key() const;
 
   EXTENSION(bool __bool__() const);
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__int__() const);
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__int__() const);
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
 
 public:
   INLINE void generate_hash(ChecksumHashGenerator &hashgen) const;

--- a/panda/src/putil/callbackObject.h
+++ b/panda/src/putil/callbackObject.h
@@ -34,9 +34,7 @@ public:
 PUBLISHED:
   virtual void output(std::ostream &out) const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(static PT(CallbackObject) make(PyObject *function));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(static PT(CallbackObject) make(PyObject *function));
 
 public:
   virtual void do_callback(CallbackData *cbdata);

--- a/panda/src/putil/doubleBitMask.h
+++ b/panda/src/putil/doubleBitMask.h
@@ -39,9 +39,7 @@ PUBLISHED:
   };
 
   constexpr DoubleBitMask() = default;
-#ifdef HAVE_PYTHON
-  EXTENSION(DoubleBitMask(PyObject *init_value));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(DoubleBitMask(PyObject *init_value));
 
   INLINE static DoubleBitMask<BMType> all_on();
   INLINE static DoubleBitMask<BMType> all_off();
@@ -115,10 +113,8 @@ PUBLISHED:
   INLINE void operator >>= (int shift);
 
   EXTENSION(bool __bool__() const);
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__int__() const);
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__int__() const);
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
 
 public:
   INLINE void generate_hash(ChecksumHashGenerator &hashgen) const;

--- a/panda/src/putil/sparseArray.h
+++ b/panda/src/putil/sparseArray.h
@@ -118,10 +118,8 @@ PUBLISHED:
   INLINE int get_subrange_end(size_t n) const;
 
   EXTENSION(bool __bool__() const);
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__getstate__() const);
-  EXTENSION(void __setstate__(PyObject *state));
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__getstate__() const);
+  PY_EXTENSION(void __setstate__(PyObject *state));
 
 private:
   void do_add_range(int begin, int end);

--- a/panda/src/putil/typedWritable.h
+++ b/panda/src/putil/typedWritable.h
@@ -60,10 +60,8 @@ PUBLISHED:
   INLINE void mark_bam_modified();
   INLINE UpdateSeq get_bam_modified() const;
 
-#ifdef HAVE_PYTHON
-  EXTENSION(PyObject *__reduce__(PyObject *self) const);
-  EXTENSION(PyObject *__reduce_persist__(PyObject *self, PyObject *pickler) const);
-#endif // HAVE_PYTHON
+  PY_EXTENSION(PyObject *__reduce__(PyObject *self) const);
+  PY_EXTENSION(PyObject *__reduce_persist__(PyObject *self, PyObject *pickler) const);
 
   INLINE vector_uchar encode_to_bam_stream() const;
   bool encode_to_bam_stream(vector_uchar &data, BamWriter *writer = nullptr) const;


### PR DESCRIPTION
## Issue description
Reduce some `ifdef` chaff and make the scripting target for a Python extension clearer. See [Issue #1414](https://github.com/panda3d/panda3d/issues/1414)

## Solution description
Created `PY_EXTENSION`, `PY_EXTEND`, `PY_MAKE_PROPERTY`, and `PY_MAKE_SEQ_PROPERTY` (for these last two, they were the only ones currently needed). These mimic the behavior of the non-PY versions with the added condition that if HAVE_PYTHON is not defined, they drop the contents as would normally happen with CPPPARSER undefined. Further, the `PY_EXTEND` macro is expressed as variadic (unlike `EXTEND`) so that it can consume its contents properly. (It may be worth considering doing this with `EXTEND` as well.)

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
