### PR TITLE
additions to .N files

### DIFF
--- a/dtool/src/dtoolutil/config_dtoolutil.N
+++ b/dtool/src/dtoolutil/config_dtoolutil.N
@@ -8,3 +8,5 @@ forcetype std::ios
 forcetype std::istream
 forcetype std::ostream
 forcetype std::iostream
+
+forcetype FILE

--- a/panda/src/dgraph/dataNodeTransmit.N
+++ b/panda/src/dgraph/dataNodeTransmit.N
@@ -1,0 +1,1 @@
+forcetype DataNodeTransmit

--- a/panda/src/downloader/downloadDb.N
+++ b/panda/src/downloader/downloadDb.N
@@ -1,0 +1,1 @@
+forcetype DownloadDb::Db

--- a/panda/src/event/eventReceiver.N
+++ b/panda/src/event/eventReceiver.N
@@ -1,0 +1,1 @@
+forcetype EventReceiver

--- a/panda/src/express/config_express.N
+++ b/panda/src/express/config_express.N
@@ -6,3 +6,5 @@ forcetype PTA_double
 forcetype CPTA_double
 forcetype PTA_int
 forcetype CPTA_int
+forcetype HashGeneratorBase
+forcetype ChecksumHashGenerator

--- a/panda/src/gobj/geomPrimitive.N
+++ b/panda/src/gobj/geomPrimitive.N
@@ -1,0 +1,1 @@
+forcetype GeomPrimitivePipelineReader

--- a/panda/src/gobj/geomVertexData.N
+++ b/panda/src/gobj/geomVertexData.N
@@ -1,0 +1,1 @@
+forcetype GeomVertexDataPipelineReader

--- a/panda/src/gobj/samplerContext.N
+++ b/panda/src/gobj/samplerContext.N
@@ -1,0 +1,1 @@
+forcetype SamplerContext

--- a/panda/src/gobj/shader.N
+++ b/panda/src/gobj/shader.N
@@ -1,0 +1,1 @@
+forcetype Shader::ShaderPtrData

--- a/panda/src/nativenet/config_nativenet.N
+++ b/panda/src/nativenet/config_nativenet.N
@@ -1,0 +1,1 @@
+forcetype Time_Span

--- a/panda/src/pgraph/accumulatedAttribs.N
+++ b/panda/src/pgraph/accumulatedAttribs.N
@@ -1,0 +1,1 @@
+forcetype AccumulatedAttribs

--- a/panda/src/pgraph/cullBin.N
+++ b/panda/src/pgraph/cullBin.N
@@ -1,0 +1,1 @@
+forcetype CullBin

--- a/panda/src/pgraph/cullHandler.N
+++ b/panda/src/pgraph/cullHandler.N
@@ -1,0 +1,1 @@
+forcetype CullHandler

--- a/panda/src/pgraph/cullPlanes.N
+++ b/panda/src/pgraph/cullPlanes.N
@@ -1,0 +1,1 @@
+forcetype CullPlanes

--- a/panda/src/pgraph/cullableObject.N
+++ b/panda/src/pgraph/cullableObject.N
@@ -1,0 +1,1 @@
+forcetype CullableObject

--- a/panda/src/pgraph/geomTransformer.N
+++ b/panda/src/pgraph/geomTransformer.N
@@ -1,0 +1,1 @@
+forcetype GeomTransformer

--- a/panda/src/pgraph/portalClipper.N
+++ b/panda/src/pgraph/portalClipper.N
@@ -1,0 +1,1 @@
+forcetype PortalClipper

--- a/panda/src/pipeline/pipeline.N
+++ b/panda/src/pipeline/pipeline.N
@@ -1,0 +1,1 @@
+forcetype Pipeline

--- a/panda/src/pipeline/thread.N
+++ b/panda/src/pipeline/thread.N
@@ -1,0 +1,1 @@
+forcetype Thread::PStatsCallback

--- a/panda/src/pnmimage/config_pnmimage.N
+++ b/panda/src/pnmimage/config_pnmimage.N
@@ -1,0 +1,2 @@
+forcetype PNMReader
+forcetype PNMWriter

--- a/panda/src/pstatclient/pStatCollectorDef.N
+++ b/panda/src/pstatclient/pStatCollectorDef.N
@@ -1,0 +1,1 @@
+forcetype PStatCollectorDef

--- a/panda/src/pstatclient/pStatFrameData.N
+++ b/panda/src/pstatclient/pStatFrameData.N
@@ -1,0 +1,1 @@
+forcetype PStatFrameData

--- a/panda/src/putil/bamReader.N
+++ b/panda/src/putil/bamReader.N
@@ -1,0 +1,1 @@
+forcetype BamReader::AuxData


### PR DESCRIPTION
## Issue description
Note some types referenced in published API that do not appear in the interrogate DB. See [Issue #1416](https://github.com/panda3d/panda3d/issues/1416)

## Solution description
Add required `forcetype` directives to various .N files to cause `interrogate` to emit these types as published into the interrogate DB. In cases where there was already a convenient `config_foo.N` file, I have added these directives to that. Otherwise I have created new .N files that track the name of the header that declares the type.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
