### PR TITLE
fix SocketStream::flush() covariant

### DIFF
--- a/direct/src/distributed/cConnectionRepository.cxx
+++ b/direct/src/distributed/cConnectionRepository.cxx
@@ -580,7 +580,8 @@ flush() {
 
   #ifdef HAVE_OPENSSL
   if (_http_conn) {
-    return _http_conn->flush();
+    _http_conn->flush();
+    return !_http_conn->is_closed();
   }
   #endif  // HAVE_OPENSSL
 

--- a/panda/src/downloader/socketStream.I
+++ b/panda/src/downloader/socketStream.I
@@ -131,15 +131,16 @@ get_tcp_header_size() const {
 INLINE bool SSWriter::
 consider_flush() {
   if (!_collect_tcp) {
-    return flush();
-
+    flush();
+    return !is_closed();
   } else {
     double elapsed =
       TrueClock::get_global_ptr()->get_short_time() - _queued_data_start;
     // If the elapsed time is negative, someone must have reset the clock
     // back, so just go ahead and flush.
     if (elapsed < 0.0 || elapsed >= _collect_tcp_interval) {
-      return flush();
+      flush();
+      return !is_closed();
     }
   }
 
@@ -150,11 +151,10 @@ consider_flush() {
  * Sends the most recently queued data now.  This only has meaning if
  * set_collect_tcp() has been set to true.
  */
-INLINE bool SSWriter::
+INLINE void SSWriter::
 flush() {
   _ostream->flush();
   _queued_data_start = TrueClock::get_global_ptr()->get_short_time();
-  return !is_closed();
 }
 
 /**
@@ -176,9 +176,9 @@ OSocketStream(std::streambuf *buf) : std::ostream(buf), SSWriter(this) {
  * Sends the most recently queued data now.  This only has meaning if
  * set_collect_tcp() has been set to true.
  */
-INLINE bool OSocketStream::
+INLINE void OSocketStream::
 flush() {
-  return SSWriter::flush();
+  SSWriter::flush();
 }
 
 /**
@@ -212,7 +212,7 @@ get_tcp_header_size() const {
  * Sends the most recently queued data now.  This only has meaning if
  * set_collect_tcp() has been set to true.
  */
-INLINE bool SocketStream::
+INLINE void SocketStream::
 flush() {
-  return SSWriter::flush();
+  SSWriter::flush();
 }

--- a/panda/src/downloader/socketStream.h
+++ b/panda/src/downloader/socketStream.h
@@ -106,7 +106,7 @@ PUBLISHED:
   INLINE int get_tcp_header_size() const;
 
   INLINE bool consider_flush();
-  INLINE bool flush();
+  INLINE void flush();
 
 private:
   std::ostream *_ostream;
@@ -168,7 +168,7 @@ PUBLISHED:
   virtual bool is_closed() = 0;
   virtual void close() = 0;
 
-  INLINE bool flush();
+  INLINE void flush();
 };
 
 /**
@@ -190,7 +190,7 @@ PUBLISHED:
   INLINE void set_tcp_header_size(int tcp_header_size);
   INLINE int get_tcp_header_size() const;
 
-  INLINE bool flush();
+  INLINE void flush();
 };
 
 

--- a/panda/src/recorder/socketStreamRecorder.I
+++ b/panda/src/recorder/socketStreamRecorder.I
@@ -135,7 +135,8 @@ consider_flush() {
 INLINE bool SocketStreamRecorder::
 flush() {
   if (_stream != nullptr) {
-    return _stream->flush();
+    _stream->flush();
+    return !_stream->is_closed();
   }
   return true;
 }


### PR DESCRIPTION
## Issue description
This corrects an instance of covariant overload on return type. Such functionality is generally a dangerous pattern in C++. See [Issue #1418](https://github.com/panda3d/panda3d/issues/1418)

## Solution description
I changed `SSWriter::flush()` (and derived types) to return `void` rather than `bool`, then adjusted call sites to call `is_closed()` if they needed that information.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
