### PR TITLE
move Set API out of published interface

### DIFF
--- a/dtool/src/dtoolbase/typeHandle.h
+++ b/dtool/src/dtoolbase/typeHandle.h
@@ -123,8 +123,6 @@ PUBLISHED:
   INLINE TypeHandle get_parent_towards(TypeHandle ancestor,
                                        TypedObject *object = nullptr) const;
 
-  int get_best_parent_from_Set(const std::set< int > &legal_vals) const;
-
   size_t get_memory_usage(MemoryClass memory_class) const;
   void inc_memory_usage(MemoryClass memory_class, size_t size);
   void dec_memory_usage(MemoryClass memory_class, size_t size);
@@ -145,6 +143,8 @@ PUBLISHED:
 #endif // HAVE_PYTHON
 
 public:
+  int get_best_parent_from_Set(const std::set< int > &legal_vals) const;
+
 #ifdef HAVE_PYTHON
   PyObject *get_python_type() const;
 #endif // HAVE_PYTHON


### PR DESCRIPTION
## Issue description
Integrating `set<...>` across a language barrier is very challenging in the best of cases. See [Issue #1421](https://github.com/panda3d/panda3d/issues/1421).

## Solution description
This moves the function `get_best_parent_from_Set` from the `PUBLISHED` block, to `public`.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
