### PR TITLE
patch around non-exported return type

### DIFF
--- a/panda/src/putil/bitArray.I
+++ b/panda/src/putil/bitArray.I
@@ -177,15 +177,15 @@ extract(int low_bit, int size) const {
 
   if (b + size < num_bits_per_word) {
     // The whole thing fits within one word of the array.
-    return get_word(w).extract(b, size);
+    return get_word_internal(w).extract(b, size);
 
   } else {
     // We have to split it across two words.
     int num_lower_bits = num_bits_per_word - b;
     int num_higher_bits = size - num_lower_bits;
 
-    return get_word(w).extract(b, num_lower_bits) |
-      (get_word(w + 1).extract(0, num_higher_bits) << num_lower_bits);
+    return get_word_internal(w).extract(b, num_lower_bits) |
+      (get_word_internal(w + 1).extract(0, num_higher_bits) << num_lower_bits);
   }
 }
 
@@ -241,17 +241,24 @@ get_num_words() const {
  * get_num_words(), but the return value beyond get_num_words() will always be
  * the same.
  */
-INLINE BitArray::MaskType BitArray::
+INLINE BitArray::WordType BitArray::
 get_word(size_t n) const {
+  return get_word_internal(n).get_word();
+}
+
+/**
+ * Internal implementation of get_word that returns MaskType.
+ */
+INLINE BitArray::MaskType BitArray::
+get_word_internal(size_t n) const {
   nassertr(n >= 0, MaskType::all_off());
   if (n < get_num_words()) {
     return _array[n];
   }
   if (_highest_bits) {
     return MaskType::all_on();
-  } else {
-    return MaskType::all_off();
   }
+  return MaskType::all_off();
 }
 
 /**

--- a/panda/src/putil/bitArray.cxx
+++ b/panda/src/putil/bitArray.cxx
@@ -103,7 +103,7 @@ has_any_of(int low_bit, int size) const {
   }
   if (b + size <= num_bits_per_word) {
     // The whole thing fits within one word of the array.
-    return get_word(w).has_any_of(b, size);
+    return get_word_internal(w).has_any_of(b, size);
   }
 
   int num_high_bits = num_bits_per_word - b;
@@ -156,7 +156,7 @@ has_all_of(int low_bit, int size) const {
   }
   if (b + size <= num_bits_per_word) {
     // The whole thing fits within one word of the array.
-    return get_word(w).has_all_of(b, size);
+    return get_word_internal(w).has_all_of(b, size);
   }
 
   int num_high_bits = num_bits_per_word - b;
@@ -588,7 +588,7 @@ compare_to(const BitArray &other) const {
 
   // Compare from highest-order to lowest-order word.
   for (int i = num_words - 1; i >= 0; --i) {
-    int compare = get_word(i).compare_to(other.get_word(i));
+    int compare = get_word_internal(i).compare_to(other.get_word_internal(i));
     if (compare != 0) {
       return compare;
     }

--- a/panda/src/putil/bitArray.h
+++ b/panda/src/putil/bitArray.h
@@ -89,7 +89,7 @@ PUBLISHED:
   int get_next_higher_different_bit(int low_bit) const;
 
   INLINE size_t get_num_words() const;
-  INLINE MaskType get_word(size_t n) const;
+  INLINE WordType get_word(size_t n) const;
   INLINE void set_word(size_t n, WordType value);
 
   void invert_in_place();
@@ -140,6 +140,7 @@ public:
   void generate_hash(ChecksumHashGenerator &hashgen) const;
 
 private:
+  INLINE MaskType get_word_internal(size_t n) const;
   INLINE void copy_on_write();
   void ensure_has_word(int n);
   void normalize();


### PR DESCRIPTION
## Issue description
Fixes #1425 

## Solution description
One solution path. I changed the return type of `get_word()` to be the "word type". This is symmetric with the `set_word(...)` method. For internal computations that want some of the `BitMask<....>` functionality, the former implementation of `get_word()` is moved into a private `get_word_internal()` method that continues to return the `MaskType`. Internal calculation can continue to operate on that. The new `get_word()` implementation calls `get_word_internal()` and extracts the actual word to return.

An alternative may be to not export `get_word()`, but that seems overly constrained.

@rdb has also suggested making `set_word(...)` take `MaskType`. For myself this feels like exposing implementation detail. But I'm not especially passionate about either direction.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
