### PR TITLE
distributed: Fix segmentation fault when ConnectionRepository is verbose by holding GIL

### DIFF
--- a/direct/src/distributed/cConnectionRepository.cxx
+++ b/direct/src/distributed/cConnectionRepository.cxx
@@ -687,11 +687,7 @@ handle_update_field() {
       PyObject_GetAttrString(_python_repository, "doId2do");
     nassertr(doId2do != nullptr, false);
 
-    #ifdef USE_PYTHON_2_2_OR_EARLIER
-    PyObject *doId = PyInt_FromLong(do_id);
-    #else
     PyObject *doId = PyLong_FromUnsignedLong(do_id);
-    #endif
     PyObject *distobj = PyDict_GetItem(doId2do, doId);
     Py_DECREF(doId);
     Py_DECREF(doId2do);
@@ -778,11 +774,7 @@ handle_update_field_owner() {
       PyObject_GetAttrString(_python_repository, "doId2ownerView");
     nassertr(doId2ownerView != nullptr, false);
 
-    #ifdef USE_PYTHON_2_2_OR_EARLIER
-    PyObject *doId = PyInt_FromLong(do_id);
-    #else
     PyObject *doId = PyLong_FromUnsignedLong(do_id);
-    #endif
 
     // pass the update to the owner view first
     PyObject *distobjOV = PyDict_GetItem(doId2ownerView, doId);
@@ -887,7 +879,7 @@ describe_message(std::ostream &out, const string &prefix,
 
   packer.set_unpack_data((const char *)dg.get_data(), dg.get_length(), false);
   CHANNEL_TYPE do_id;
-  int msg_type;
+  unsigned int msg_type;
   bool is_update = false;
   string full_prefix = "CR::" + prefix;
 
@@ -913,7 +905,12 @@ describe_message(std::ostream &out, const string &prefix,
 
     #ifdef HAVE_PYTHON
     if (_python_repository != nullptr) {
-      PyObject *msgId = PyLong_FromLong(msg_type);
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+      PyGILState_STATE gstate;
+      gstate = PyGILState_Ensure();
+#endif
+
+      PyObject *msgId = PyLong_FromUnsignedLong(msg_type);
       nassertv(msgId != nullptr);
       PyObject *methodName = PyUnicode_FromString("_getMsgName");
       nassertv(methodName != nullptr);
@@ -927,6 +924,10 @@ describe_message(std::ostream &out, const string &prefix,
       Py_DECREF(methodName);
       Py_DECREF(msgId);
       Py_DECREF(result);
+
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+      PyGILState_Release(gstate);
+#endif
     }
     #endif
     if (msgName.length() == 0) {
@@ -945,15 +946,16 @@ describe_message(std::ostream &out, const string &prefix,
 
     #ifdef HAVE_PYTHON
     if (_python_repository != nullptr) {
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+      PyGILState_STATE gstate;
+      gstate = PyGILState_Ensure();
+#endif
+
       PyObject *doId2do =
         PyObject_GetAttrString(_python_repository, "doId2do");
       nassertv(doId2do != nullptr);
 
-      #ifdef USE_PYTHON_2_2_OR_EARLIER
-      PyObject *doId = PyInt_FromLong(do_id);
-      #else
       PyObject *doId = PyLong_FromUnsignedLong(do_id);
-      #endif
       PyObject *distobj = PyDict_GetItem(doId2do, doId);
       Py_DECREF(doId);
       Py_DECREF(doId2do);
@@ -969,6 +971,10 @@ describe_message(std::ostream &out, const string &prefix,
         dclass = (DCClass *)PyLong_AsVoidPtr(dclass_this);
         Py_DECREF(dclass_this);
       }
+
+#if defined(HAVE_THREADS) && !defined(SIMPLE_THREADS)
+      PyGILState_Release(gstate);
+#endif
     }
     #endif  // HAVE_PYTHON
 


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
A segmentation fault occurs when `CConnectionRepository` is set to verbose mode, and a message is to be printed to the debug console.

This occurs because `CConnectionRepository` is running on a separate thread when threading is enabled, and Python might be running code on another thread while `describe_message` is running. As such, we need to hold the GIL before calling into any Python functions from the `describe_message` function.

## Solution description
I solved the problem by holding the GIL before calling into any Python functions in the `describe_message` function.

I've also changed `msg_type` to be an unsigned int, as it's read from the stream as an `uint16` (not an `int16`), and removed an unused Python 2.2 macro.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
