### PR TITLE
Notifier: Add custom exception type for Notifier.error

### DIFF
--- a/direct/src/directnotify/Notifier.py
+++ b/direct/src/directnotify/Notifier.py
@@ -9,6 +9,10 @@ import time
 import sys
 
 
+class NotifierException(Exception):
+    pass
+
+
 class Notifier:
     serverDelta = 0
 
@@ -116,7 +120,7 @@ class Notifier:
             return NSError
 
     # error funcs
-    def error(self, errorString, exception=Exception):
+    def error(self, errorString, exception=NotifierException):
         """
         Raise an exception with given string and optional type:
         Exception: error


### PR DESCRIPTION
## Issue description
This PR solves issue #1247  where it was requested that Notifier should have a custom exception type.

## Solution description
This PR solves this by defining NotifierException at the top of the file, and setting that as the default parameter for exception in the error method.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
