### PR TITLE
ShowBase: Add a check for Destroy() being called from a non-main thread

### DIFF
--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -584,11 +584,14 @@ class ShowBase(DirectObject.DirectObject):
         exitfunc and will be called at application exit time
         automatically.
 
-        This function is designed to be safe to call multiple times."""
+        This function is designed to be safe to call multiple times.
+
+        When called from a Thread, a Task is created to run it on the main thread
+        """
 
         if threading.current_thread() is not threading.main_thread():
-            self.notify.warning("destory() was called on a thread other than the main thread.")
-            taskMgr.doMethodLater(0.1, self.destroy, "ShowBaseDestroyTask", extraArgs=[])
+            task = taskMgr.add(self.destroy, extraArgs=[])
+            task.wait()
             return
 
         for cb in self.finalExitCallbacks[:]:
@@ -3342,7 +3345,12 @@ class ShowBase(DirectObject.DirectObject):
         not running from within a p3d file.  When we *are* within a p3d
         file, the Panda3D runtime has to be responsible for running the
         main loop, so we can't allow the application to do it.
+
+        This method must be called from the main thread, otherwise an error is thrown
         """
+        if threading.current_thread() is not threading.main_thread():
+            self.notify.error("run() must be called from the main thread.")
+            return
 
         if self.appRunner is None or self.appRunner.dummy or \
            (self.appRunner.interactiveConsole and not self.appRunner.initialAppImport):

--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -68,6 +68,7 @@ import time
 import atexit
 import importlib
 from direct.showbase import ExceptionVarDump
+from direct.stdpy import threading
 from . import DirectObject
 from . import SfxPlayer
 if __debug__:
@@ -584,6 +585,11 @@ class ShowBase(DirectObject.DirectObject):
         automatically.
 
         This function is designed to be safe to call multiple times."""
+
+        if threading.current_thread() is not threading.main_thread():
+            self.notify.warning("destory() was called on a thread other than the main thread.")
+            taskMgr.doMethodLater(0.1, self.destroy, "ShowBaseDestroyTask", extraArgs=[])
+            return
 
         for cb in self.finalExitCallbacks[:]:
             cb()


### PR DESCRIPTION
## Issue description
On certain platforms (MacOS in this case), closing a graphics window must be done from the main thread. Failing to do so on MacOS triggers an NSInternalInconsistencyException. 
Issue: #1269 

## Solution description
This PR solves the problem by checking if Destroy is being called from the main thread. Issuing a warning via DirectNotify if it hasn't been called from the main thread. Then posts a task in TaskMgr to call Destroy. 

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
