### PR TITLE
MetaInterval: Prevent restarting an interval if it has already finished and we don't specify a start time

### DIFF
--- a/direct/src/interval/FunctionInterval.py
+++ b/direct/src/interval/FunctionInterval.py
@@ -86,11 +86,18 @@ class FunctionInterval(Interval.Interval):
         return name
 
     def privInstant(self):
+        """
+        In versions previous to 1.11, this function did not set the state of the Interval
+        In 1.11 this has been changed to be consistent with MetaInterval
+        """
+        self.state = CInterval.SStarted
         # Evaluate the function
         self.function(*self.extraArgs, **self.kw)
         # Print debug information
         self.notify.debug(
             'updateFunc() - %s: executing Function' % self.name)
+        self.state = CInterval.SFinal
+        self.intervalDone()
 
 
 ### FunctionInterval subclass for throwing events ###

--- a/direct/src/interval/Interval.py
+++ b/direct/src/interval/Interval.py
@@ -134,6 +134,12 @@ class Interval(DirectObject):
         return self.getT()
 
     def resume(self, startT = None):
+        """
+        In versions previous to 1.11, this would resume an interval even if it had ended
+        As of 1.11 we now check if the interval has ended, and only resume it if startT has been passed
+        """
+        if self.getState() == CInterval.SFinal and startT is None:
+            return
         if startT is not None:
             self.setT(startT)
         self.setupResume()

--- a/direct/src/interval/MetaInterval.py
+++ b/direct/src/interval/MetaInterval.py
@@ -374,6 +374,10 @@ class MetaInterval(CMetaInterval):
         return self.getT()
 
     def resume(self, startT = None):
+        """
+        In versions previous to 1.11, this would resume an interval even if it had ended
+        As of 1.11 we now check if the interval has ended, and only resume it if startT has been passed
+        """
         if self.getState() == CInterval.SFinal and startT is None:
             return
         self.__updateIvals()

--- a/direct/src/interval/MetaInterval.py
+++ b/direct/src/interval/MetaInterval.py
@@ -374,6 +374,8 @@ class MetaInterval(CMetaInterval):
         return self.getT()
 
     def resume(self, startT = None):
+        if self.getState() == CInterval.SFinal and startT is None:
+            return
         self.__updateIvals()
         if startT is not None:
             self.setT(startT)

--- a/direct/src/interval/cInterval.cxx
+++ b/direct/src/interval/cInterval.cxx
@@ -175,9 +175,14 @@ pause() {
 /**
  * Restarts the interval from its current point after a previous call to
  * pause().
+ * In versions previous to 1.11, this would resume an interval even if it had ended
+ * As of 1.11 we now check if the interval has ended, and only resume it if startT has been passed
  */
 void CInterval::
 resume() {
+    if(get_state() == S_final){
+        return;
+    }
   setup_resume();
   _manager->add_c_interval(this, false);
 }

--- a/tests/interval/test_interval_controls.py
+++ b/tests/interval/test_interval_controls.py
@@ -1,0 +1,34 @@
+from direct.interval.IntervalManager import ivalMgr
+from direct.interval.IntervalGlobal import *
+from direct.task.TaskManagerGlobal import taskMgr
+import pytest
+
+
+def test_resume_sequence_no_startT():
+    test_resume_sequence_no_startT.callCount = 0
+
+    def func():
+        test_resume_sequence_no_startT.callCount += 1
+
+    sut = Sequence(Func(func))
+    sut.start()
+    ivalMgr.step()
+    sut.resume(None)
+    ivalMgr.step()
+    taskMgr.step()
+    assert test_resume_sequence_no_startT.callCount == 1
+
+def test_resume_func_no_startT():
+    test_resume_func_no_startT.callCount = 0
+
+    def func():
+        test_resume_func_no_startT.callCount += 1
+
+    sut = Func(func)
+    sut.start()
+    ivalMgr.step()
+    taskMgr.step()
+    sut.resume(None)
+    ivalMgr.step()
+    taskMgr.step()
+    assert test_resume_func_no_startT.callCount == 1


### PR DESCRIPTION
## Issue description
As per issue #1203, when a finished sequence has ```resume()``` called, ```Func()``` have their callbacks called. This PR aims to mitigate this unintuitive design decision.

## Solution description
For MetaIntervals, if you call ```.resume()``` and the interval is already in the finished state, it will return out of the function, unless you have specified a ```startT```.  For consistency, this check has been placed in MetaInterval as opposed to overriding the function for just ```Sequence()```


## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
