### PR TITLE
bdist_apps: Fix assertion error from calling finalize_options twice

### DIFF
--- a/direct/src/dist/commands.py
+++ b/direct/src/dist/commands.py
@@ -1720,9 +1720,10 @@ class bdist_apps(setuptools.Command):
             optval = getattr(self, opt)
             if optval is not None:
                 setattr(build_cmd, opt, optval)
-        build_cmd.finalize_options()
         if not self.skip_build:
             self.run_command('build_apps')
+        else:
+            build_cmd.finalize_options()
 
         platforms = build_cmd.platforms
         build_base = os.path.abspath(build_cmd.build_base)


### PR DESCRIPTION
## Issue description
When `bdist_apps` is ran with `skip_build` set to `False`, we call `build_apps.finalize_options` twice. As  https://github.com/panda3d/panda3d/commit/3f3fd74f869b21b249e76d3068cb1735afa807ae we trigger an AssertionError if a `bam_model_extension` already exists in `file_handlers`. 

## Solution description
This PR moves the `build_cmd.finalize_options()` call to an `else` block, so that we don't call `finalize_options` twice.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
