### PR TITLE
Interval: Assertion error when given very long external intervals

### DIFF
--- a/direct/src/interval/cMetaInterval.I
+++ b/direct/src/interval/cMetaInterval.I
@@ -127,7 +127,7 @@ get_event_type() const {
 INLINE int CMetaInterval::
 double_to_int_time(double t) const {
   // Use floor() just in case there are negative values involved.
-  return (int)floor(t * _precision + 0.5);
+  return (long long)floor(t * _precision + 0.5);
 }
 
 /**
@@ -135,7 +135,7 @@ double_to_int_time(double t) const {
  * double time value or offset in seconds.
  */
 INLINE double CMetaInterval::
-int_to_double_time(int time) const {
+int_to_double_time(long long time) const {
   return (double)time / _precision;
 }
 
@@ -143,7 +143,7 @@ int_to_double_time(int time) const {
  *
  */
 INLINE CMetaInterval::PlaybackEvent::
-PlaybackEvent(int time, int n,
+PlaybackEvent(long long time, int n,
               CMetaInterval::PlaybackEventType type) :
   _time(time),
   _n(n),
@@ -164,7 +164,7 @@ operator < (const CMetaInterval::PlaybackEvent &other) const {
  *
  */
 INLINE CMetaInterval::EventQueueEntry::
-EventQueueEntry(int n, CInterval::EventType event_type, int time) :
+EventQueueEntry(int n, CInterval::EventType event_type, long long time) :
   _n(n),
   _event_type(event_type),
   _time(time)

--- a/direct/src/interval/cMetaInterval.cxx
+++ b/direct/src/interval/cMetaInterval.cxx
@@ -331,8 +331,8 @@ priv_initialize(double t) {
   recompute();
   _next_event_index = 0;
   _active.clear();
-
-  int now = double_to_int_time(t);
+  
+  long long now = double_to_int_time(t);
 
   /*
   // One special case: if we step to t == 0.0, it really means to the very
@@ -414,7 +414,7 @@ priv_step(double t) {
   }
 
   check_started(get_class_type(), "priv_step");
-  int now = double_to_int_time(t);
+  long long now = double_to_int_time(t);
 
   /*
   // One special case: if we step to t == 0.0, it really means to the very
@@ -524,7 +524,7 @@ priv_reverse_initialize(double t) {
   _next_event_index = _events.size();
   _active.clear();
 
-  int now = double_to_int_time(t);
+  long long now = double_to_int_time(t);
 
   /*
   // One special case: if we step to t == 0.0, it really means to the very
@@ -836,7 +836,7 @@ do_event_forward(CMetaInterval::PlaybackEvent *event,
  * copying the events from new_active to active.
  */
 void CMetaInterval::
-finish_events_forward(int now, CMetaInterval::ActiveEvents &new_active) {
+finish_events_forward(long long now, CMetaInterval::ActiveEvents &new_active) {
   // Do whatever's still active.
   ActiveEvents::iterator ai;
   for (ai = _active.begin(); ai != _active.end(); ++ai) {
@@ -913,7 +913,7 @@ do_event_reverse(CMetaInterval::PlaybackEvent *event,
  * then copying the events from new_active to active.
  */
 void CMetaInterval::
-finish_events_reverse(int now, CMetaInterval::ActiveEvents &new_active) {
+finish_events_reverse(long long now, CMetaInterval::ActiveEvents &new_active) {
   // Do whatever's still active.
   ActiveEvents::iterator ai;
   for (ai = _active.begin(); ai != _active.end(); ++ai) {
@@ -942,7 +942,7 @@ finish_events_reverse(int now, CMetaInterval::ActiveEvents &new_active) {
  * ET_step.
  */
 void CMetaInterval::
-enqueue_event(int n, CInterval::EventType event_type, bool is_initial, int time) {
+enqueue_event(int n, CInterval::EventType event_type, bool is_initial, long long time) {
   nassertv(n >= 0 && n < (int)_defs.size());
   const IntervalDef &def = _defs[n];
   switch (def._type) {
@@ -1151,7 +1151,7 @@ recompute_level(int n, int level_begin, int &level_end) {
  */
 int CMetaInterval::
 get_begin_time(const CMetaInterval::IntervalDef &def, int level_begin,
-               int previous_begin, int previous_end) {
+               long long previous_begin, long long previous_end) {
   switch (def._rel_to) {
   case RS_previous_end:
     return previous_end + double_to_int_time(def._rel_time);

--- a/direct/src/interval/cMetaInterval.h
+++ b/direct/src/interval/cMetaInterval.h
@@ -114,7 +114,7 @@ private:
 
   class PlaybackEvent {
   public:
-    INLINE PlaybackEvent(int time, int n, PlaybackEventType type);
+    INLINE PlaybackEvent(long long time, int n, PlaybackEventType type);
     INLINE bool operator < (const PlaybackEvent &other) const;
     int _time;
     int _n;
@@ -124,7 +124,7 @@ private:
 
   class EventQueueEntry {
   public:
-    INLINE EventQueueEntry(int n, EventType event_type, int time);
+    INLINE EventQueueEntry(int n, EventType event_type, long long time);
     int _n;
     EventType _event_type;
     int _time;
@@ -139,25 +139,25 @@ private:
   typedef pdeque<EventQueueEntry> EventQueue;
 
   INLINE int double_to_int_time(double t) const;
-  INLINE double int_to_double_time(int time) const;
+  INLINE double int_to_double_time(long long time) const;
 
   void clear_events();
   void do_event_forward(PlaybackEvent *event, ActiveEvents &new_active,
                         bool is_initial);
-  void finish_events_forward(int now, ActiveEvents &new_active);
+  void finish_events_forward(long long now, ActiveEvents &new_active);
   void do_event_reverse(PlaybackEvent *event, ActiveEvents &new_active,
                         bool is_initial);
-  void finish_events_reverse(int now, ActiveEvents &new_active);
+  void finish_events_reverse(long long now, ActiveEvents &new_active);
 
   void enqueue_event(int n, CInterval::EventType event_type, bool is_initial,
-                     int time = 0);
+                     long long time = 0);
   void enqueue_self_event(CInterval::EventType event_type, double t = 0.0);
   void enqueue_done_event();
   bool service_event_queue();
 
   int recompute_level(int n, int level_begin, int &level_end);
   int get_begin_time(const IntervalDef &def, int level_begin,
-                     int previous_begin, int previous_end);
+                     long long previous_begin, long long previous_end);
 
   void write_event_desc(std::ostream &out, const IntervalDef &def,
                         int &extra_indent_level) const;

--- a/direct/src/showbase/Loader.py
+++ b/direct/src/showbase/Loader.py
@@ -949,7 +949,7 @@ class Loader(DirectObject):
             return None
 
     def loadSound(self, manager, soundPath, positional = False,
-                  callback = None, okMissing=None, extraArgs = []):
+                  callback = None, extraArgs = [], okMissing=None):
 
         """Loads one or more sound files, specifying the particular
         AudioManager that should be used to load them.  The soundPath
@@ -976,7 +976,7 @@ class Loader(DirectObject):
                 sound = manager.getSound(soundPath, positional)
                 result.append(sound)
 
-                if str(sound).startswith('NullAudioSound') and not okMissing:
+                if manager.getNullSound() and not okMissing:
                     message = 'Could not load audio file: %s' % (soundPath)
                     raise IOError(message)
 

--- a/direct/src/showbase/Loader.py
+++ b/direct/src/showbase/Loader.py
@@ -949,7 +949,7 @@ class Loader(DirectObject):
             return None
 
     def loadSound(self, manager, soundPath, positional = False,
-                  callback = None, extraArgs = []):
+                  callback = None, okMissing=None, extraArgs = []):
 
         """Loads one or more sound files, specifying the particular
         AudioManager that should be used to load them.  The soundPath
@@ -975,6 +975,10 @@ class Loader(DirectObject):
                 # should return a valid sound obj even if musicMgr is invalid
                 sound = manager.getSound(soundPath, positional)
                 result.append(sound)
+
+                if str(sound).startswith('NullAudioSound') and not okMissing:
+                    message = 'Could not load audio file: %s' % (soundPath)
+                    raise IOError(message)
 
             if gotList:
                 return result

--- a/panda/src/movies/movieAudioCursor.cxx
+++ b/panda/src/movies/movieAudioCursor.cxx
@@ -25,7 +25,7 @@ MovieAudioCursor(MovieAudio *src) :
   _source(src),
   _audio_rate(8000),
   _audio_channels(1),
-  _length(1.0E10),
+  _length(0),
   _can_seek(true),
   _can_seek_fast(true),
   _aborted(false),

--- a/tests/interval/test_interval_length.py
+++ b/tests/interval/test_interval_length.py
@@ -16,6 +16,8 @@ def test_invalid_sound_interval():
     seq.start()
     ivalMgr.step()
 
+    amgr.shutdown()
+
     assert seq is not None
 
 

--- a/tests/interval/test_interval_length.py
+++ b/tests/interval/test_interval_length.py
@@ -1,0 +1,31 @@
+from panda3d.core import *
+from direct.interval.IntervalGlobal import *
+import pytest
+
+
+def test_invalid_sound_interval():
+    load_prc_file_data('', 'audio-library-name p3fmod_audio')
+    amgr = AudioManager.create_AudioManager()
+
+    sound = SoundInterval(amgr.get_sound(MovieAudio('Load-Failure Stub')))
+    seq = Sequence()
+
+    seq.append(WaitInterval(1.0))
+    seq.append(sound)
+
+    seq.start()
+    ivalMgr.step()
+
+    assert seq is not None
+
+
+def test_long_interval():
+    seq = Sequence()
+
+    seq.append(WaitInterval(1.0E10))
+    seq.append(WaitInterval(1))
+
+    seq.start()
+    ivalMgr.step()
+
+    assert seq is not None


### PR DESCRIPTION
## Issue description
As per issue #488 (Interval: Assertion error when given very long external intervals), this PR deals with two issues:
1. Creating an interval with a duration longer than `int`'s maximum value, triggers an assertion error in cMetaInterval. 
2. Creating an invalid MovieAudioCursor has a default length of 3 centuries

## Solution description
The PR aims to resolve this issue in 3 different steps in order to address the multiple issues at play:
1. Durations in cMetaInterval have been changed to a `long long` type as opposed to the `int` type that was used before
2. MovieAudioCursor default length has been changed to 0 seconds, this is to match the fact that it has 0 samples/frames
3. `loader.loadSound` now follows the behaviour of `loadModel` and raises an `IOError` if a `NullAudioSound` was returned

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.

Fixes #488
