### PR TITLE
Actor: Allow Actor to store a reference of instantiated Actors

### DIFF
--- a/direct/src/actor/Actor.py
+++ b/direct/src/actor/Actor.py
@@ -18,6 +18,8 @@ class Actor(DirectObject, NodePath):
     Actor class: Contains methods for creating, manipulating
     and playing animations on characters
     """
+    activeActors = []
+
     notify = DirectNotifyGlobal.directNotify.newCategory("Actor")
     partPrefix = "__Actor_"
 
@@ -31,6 +33,7 @@ class Actor(DirectObject, NodePath):
     validateSubparts = ConfigVariableBool('validate-subparts', True)
     mergeLODBundles = ConfigVariableBool('merge-lod-bundles', True)
     allowAsyncBind = ConfigVariableBool('allow-async-bind', True)
+    storeReference = ConfigVariableBool('store-actor-reference', True)
 
     class PartDef:
 
@@ -170,6 +173,10 @@ class Actor(DirectObject, NodePath):
 
         # initialize our NodePath essence
         NodePath.__init__(self)
+
+        # Add this Actor to our activeActors - this prevents GC from picking it up
+        if Actor.storeReference:
+            Actor.activeActors.append(self)
 
         self.loader = PandaLoader.getGlobalPtr()
 
@@ -506,6 +513,8 @@ class Actor(DirectObject, NodePath):
         Note that `removeNode()` itself is not sufficient to destroy actors,
         which is why this method exists.
         """
+        if Actor.storeReference and self in Actor.activeActors:
+            Actor.activeActors.remove(self)
         self.stop(None)
         self.clearPythonData()
         self.flush()
@@ -2647,3 +2656,4 @@ class Actor(DirectObject, NodePath):
     get_base_frame_rate = getBaseFrameRate
     remove_anim_control_dict = removeAnimControlDict
     load_anims_on_all_lods = loadAnimsOnAllLODs
+


### PR DESCRIPTION
## Issue description
Feel free to delete/close if unhelpful/out-of-scope

An issue that comes up now and again, is that Actors become static as soon as it becomes out-of-scope. This is because as soon as the Actor becomes out of scope, Python's GC cleans up the Python class, which leaves the C++ NodePath still active. 

Related issue: #922 

## Solution description
My solution is to have Actor store a reference to instantiated Actors. This behaviour is toggled by a `ConfigVariableBool` as some developers may have leveraged this behaviour in their games. The config variable allows them to switch back to the old behaviour, where the model becomes static when the Actor becomes out-of-scope. 

This makes Actor easier to use and more intuitive for newbies, although at the cost of having to store a reference to each actor.  

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
