### PR TITLE
respect textures-header-only for embedded textures

### DIFF
--- a/panda/src/gobj/texture.cxx
+++ b/panda/src/gobj/texture.cxx
@@ -10693,10 +10693,15 @@ do_fillin_rawdata(CData *cdata, DatagramIterator &scan, BamReader *manager) {
       return;
     }
 
-    PTA_uchar image = PTA_uchar::empty_array(u_size, get_class_type());
-    scan.extract_bytes(image.p(), u_size);
+    if (!textures_header_only) {
+      PTA_uchar image = PTA_uchar::empty_array(u_size, get_class_type());
+      scan.extract_bytes(image.p(), u_size);
+      cdata->_ram_images[n]._image = image;
 
-    cdata->_ram_images[n]._image = image;
+    } else {
+      // Skip over actual image data if we're only reading in dummy textures.
+      scan.skip_bytes(u_size);
+    }
   }
   cdata->_loaded_from_image = true;
   cdata->inc_image_modified();


### PR DESCRIPTION
## Issue description
The `textures-header-only` config option is not respected for textures that have been embedded in a bam file.  This is likely an oversight, as the common use case for textures-header-only is to reduce memory usage for processes that don't need the texture data, like servers.

## Solution description
Simply skip over the bytes containing the image data if textures-header-only is set.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
