### PR TITLE
openal: fix potential iterator invalidation in OpenALAudioManager::update

### DIFF
--- a/panda/src/audiotraits/openalAudioManager.cxx
+++ b/panda/src/audiotraits/openalAudioManager.cxx
@@ -959,32 +959,32 @@ stop_all_sounds() {
  */
 void OpenALAudioManager::
 update() {
-  ReMutexHolder holder(_lock);
+  ReMutexHolder const holder(_lock);
 
-  // See if any of our playing sounds have ended we must first collect a
-  // seperate list of finished sounds and then iterated over those again
-  // calling their finished method.  We can't call finished() within a loop
-  // iterating over _sounds_playing since finished() modifies _sounds_playing
-  SoundsPlaying sounds_finished;
-
-  double rtc = TrueClock::get_global_ptr()->get_short_time();
+  // See if any of our playing sounds have ended.
+  double const rtc = TrueClock::get_global_ptr()->get_short_time();
   SoundsPlaying::iterator i=_sounds_playing.begin();
-  for (; i!=_sounds_playing.end(); ++i) {
-    OpenALAudioSound *sound = (*i);
+  while (i!=_sounds_playing.end()) {
+    // The post-increment syntax is *very* important here.
+    // As both OpenALAudioSound::pull_used_buffers and OpenALAudioSound::finished can modify the list of sounds playing
+    // by erasing 'sound' from the list, thus invaliding the iterator.
+    PT(OpenALAudioSound) sound = *(i++);
     sound->pull_used_buffers();
+
+    // If pull_used_buffers() encountered an error, the sound was cleaned up.
+    // No need to do anymore work.
+    if (!sound->is_valid()) {
+      continue;
+    }
+
     sound->push_fresh_buffers();
     sound->restart_stalled_audio();
     sound->cache_time(rtc);
     if ((sound->_source == 0)||
         ((sound->_stream_queued.size() == 0)&&
          (sound->_loops_completed >= sound->_playing_loops))) {
-      sounds_finished.insert(*i);
+      sound->finished();
     }
-  }
-
-  i=sounds_finished.begin();
-  for (; i!=sounds_finished.end(); ++i) {
-    (**i).finished();
   }
 }
 

--- a/panda/src/audiotraits/openalAudioSound.cxx
+++ b/panda/src/audiotraits/openalAudioSound.cxx
@@ -529,7 +529,7 @@ pull_used_buffers() {
           }
         }
         if (!found_culprit) {
-          audio_error("corruption in stream queue");
+          audio_error(get_name() << ": corruption in stream queue");
           cleanup();
           return;
         }


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
OpenALAudioManager::update iterates through all currently playing sounds via a std::set / phash_set object, _sounds_playing.

If a stream queue corruption was detected during OpenALAudioSound::pull_used_buffers, the logic added in a895890 would call cleanup() on the sound if we could not successfully locate the target buffer and log an error.

However, the act of calling OpenALAudioSound::cleanup would lead to calling stop() (since the sound was actively playing). In OpenALAudioSound::stop(), we would then proceed to call _manager->stopping_sound which would erase the current sound from _sounds_playing (while we still held an iterator to it). Per STL standard and real-world observation, std::set::erase will invalidate the current iterator held in update (https://en.cppreference.com/w/cpp/container/set/erase). This leads to a segmentation fault when we attempt the next iteration on the loop.

To easily reproduce this failure, simply apply the following patch that forces the cleanup inside pull_used_buffers().
```
--- a/panda/src/audiotraits/openalAudioSound.cxx
+++ b/panda/src/audiotraits/openalAudioSound.cxx
@@ -514,6 +514,12 @@ pull_used_buffers() {
     alSourceUnqueueBuffers(_source, 1, &buffer);
     int err = alGetError();
     if (err == AL_NO_ERROR) {
+      if (rand() % 5 == 0)
+      {
+        audio_error("corruption in stream queue");
+        cleanup();
+        return;
+      }
       if (_stream_queued[0]._buffer != buffer) {
         // This is certainly atypical: most implementations of OpenAL unqueue
         // buffers in FIFO order. However, some (e.g. Apple's) can unqueue
@@ -630,6 +636,10 @@ void OpenALAudioSound::
 cache_time(double rtc) {
   ReMutexHolder holder(OpenALAudioManager::_lock);
 
+  if (!is_playing())
+  {
+    return;
+  }
   nassertv(is_playing());
 
   double t=get_calibrated_clock(rtc);
```

With the commit in the PR + the above patch, the iterator invalidation is no longer observed.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

To resolve this, let's ensure we don't hold onto invalid iterators during the updating of playing sounds. We'll now use the post-increment operator to safely move the iterator 'i' past the sound potentially being erased. This also lets us get away with finishing sounds without having a separate _sounds_finish set being constructed each frame as an added bonus.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
