### PR TITLE
python: Use public PyErr_Occurred API instead of private macro

### DIFF
--- a/dtool/src/interrogate/interfaceMakerPythonNative.cxx
+++ b/dtool/src/interrogate/interfaceMakerPythonNative.cxx
@@ -1917,7 +1917,7 @@ write_module_class(ostream &out, Object *obj) {
           write_function_forset(out, def._remaps, 0, 0, expected_params, 2, true, true,
                                 AT_no_args, return_flags, false);
 
-          out << "  if (!_PyErr_OCCURRED()) {\n";
+          out << "  if (!PyErr_Occurred()) {\n";
           out << "    return Dtool_Raise_BadArgumentsError(\n";
           output_quoted(out, 6, expected_params);
           out << ");\n";
@@ -1957,7 +1957,7 @@ write_module_class(ostream &out, Object *obj) {
           write_function_forset(out, def._remaps, 1, 1, expected_params, 2, true, true,
                                 AT_single_arg, RF_err_null | RF_pyobject, false, !all_nonconst);
 
-          out << "  if (!_PyErr_OCCURRED()) {\n";
+          out << "  if (!PyErr_Occurred()) {\n";
           out << "    return Dtool_Raise_BadArgumentsError(\n";
           output_quoted(out, 6, expected_params);
           out << ");\n";
@@ -2075,7 +2075,7 @@ write_module_class(ostream &out, Object *obj) {
                                   true, true, AT_varargs, RF_int | RF_decref_args, true);
 
             out << "    Py_DECREF(args);\n";
-            out << "    if (!_PyErr_OCCURRED()) {\n";
+            out << "    if (!PyErr_Occurred()) {\n";
             out << "      Dtool_Raise_BadArgumentsError(\n";
             output_quoted(out, 8, expected_params);
             out << ");\n";
@@ -2094,7 +2094,7 @@ write_module_class(ostream &out, Object *obj) {
             write_function_forset(out, delattr_remaps, 1, 1, expected_params, 4,
                                   true, true, AT_single_arg, RF_int, true);
 
-            out << "    if (!_PyErr_OCCURRED()) {\n";
+            out << "    if (!PyErr_Occurred()) {\n";
             out << "      Dtool_Raise_BadArgumentsError(\n";
             output_quoted(out, 8, expected_params);
             out << ");\n";
@@ -2126,7 +2126,7 @@ write_module_class(ostream &out, Object *obj) {
           out << "  if (res != nullptr) {\n";
           out << "    return res;\n";
           out << "  }\n";
-          out << "  if (_PyErr_OCCURRED() != PyExc_AttributeError) {\n";
+          out << "  if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {\n";
           out << "    return nullptr;\n";
           out << "  }\n";
           out << "  PyErr_Clear();\n\n";
@@ -2173,7 +2173,7 @@ write_module_class(ostream &out, Object *obj) {
           write_function_forset(out, def._remaps, 1, 1, expected_params, 2, true, true,
                                 AT_no_args, RF_pyobject | RF_err_null, false, true, "index");
 
-          out << "  if (!_PyErr_OCCURRED()) {\n";
+          out << "  if (!PyErr_Occurred()) {\n";
           out << "    return Dtool_Raise_BadArgumentsError(\n";
           output_quoted(out, 6, expected_params);
           out << ");\n";
@@ -2224,7 +2224,7 @@ write_module_class(ostream &out, Object *obj) {
                                 true, true, AT_single_arg, RF_int, false, true, "index");
           out << "  }\n\n";
 
-          out << "  if (!_PyErr_OCCURRED()) {\n";
+          out << "  if (!PyErr_Occurred()) {\n";
           out << "    Dtool_Raise_BadArgumentsError(\n";
           output_quoted(out, 6, expected_params);
           out << ");\n";
@@ -2292,7 +2292,7 @@ write_module_class(ostream &out, Object *obj) {
                                 true, true, AT_single_arg, RF_int, false);
           out << "  }\n\n";
 
-          out << "  if (!_PyErr_OCCURRED()) {\n";
+          out << "  if (!PyErr_Occurred()) {\n";
           out << "    Dtool_Raise_BadArgumentsError(\n";
           output_quoted(out, 6, expected_params);
           out << ");\n";
@@ -2528,7 +2528,7 @@ write_module_class(ostream &out, Object *obj) {
                                 true, true, AT_single_arg, return_flags, true);
           out << "  }\n\n";
 
-          out << "  if (!_PyErr_OCCURRED()) {\n";
+          out << "  if (!PyErr_Occurred()) {\n";
           out << "    return Dtool_Raise_BadArgumentsError(\n";
           output_quoted(out, 6, expected_params);
           out << ");\n";
@@ -2587,7 +2587,7 @@ write_module_class(ostream &out, Object *obj) {
           write_function_forset(out, def._remaps, 1, 1, expected_params, 2, true, true,
                                 AT_single_arg, RF_compare, false, true);
 
-          out << "  if (!_PyErr_OCCURRED()) {\n";
+          out << "  if (!PyErr_Occurred()) {\n";
           out << "    Dtool_Raise_BadArgumentsError(\n";
           output_quoted(out, 6, expected_params);
           out << ");\n";
@@ -2802,7 +2802,7 @@ write_module_class(ostream &out, Object *obj) {
 
       // End of switch block
       out << "  }\n\n";
-      out << "  if (_PyErr_OCCURRED()) {\n";
+      out << "  if (PyErr_Occurred()) {\n";
       out << "    PyErr_Clear();\n";
       out << "  }\n\n";
     }
@@ -2819,7 +2819,7 @@ write_module_class(ostream &out, Object *obj) {
       // no matching comparison operator was found.
       out << "  // All is not lost; we still have the compare_to function to fall back onto.\n";
       out << "  int cmpval = " << slots["tp_compare"]._wrapper_name << "(self, arg);\n";
-      out << "  if (cmpval == -1 && _PyErr_OCCURRED()) {\n";
+      out << "  if (cmpval == -1 && PyErr_Occurred()) {\n";
       out << "    if (PyErr_ExceptionMatches(PyExc_TypeError)) {\n";
       out << "      PyErr_Clear();\n";
       out << "    } else {\n";
@@ -3961,7 +3961,7 @@ write_function_for_name(ostream &out, Object *obj,
     out << "#endif\n";
     indent(out, 2) << "}\n";
 
-    out << "  if (!_PyErr_OCCURRED()) {\n"
+    out << "  if (!PyErr_Occurred()) {\n"
         << "    ";
     if ((return_flags & ~RF_pyobject) == RF_err_null) {
       out << "return ";
@@ -4039,7 +4039,7 @@ write_function_for_name(ostream &out, Object *obj,
     // figure out a way in the future to better determine when it will be and
     // won't be necessary to write this out.
     if (args_type != AT_no_args) {
-      out << "  if (!_PyErr_OCCURRED()) {\n"
+      out << "  if (!PyErr_Occurred()) {\n"
           << "    ";
       if ((return_flags & ~RF_pyobject) == RF_err_null) {
         out << "return ";
@@ -5217,7 +5217,7 @@ write_function_instance(ostream &out, FunctionRemap *remap,
         extra_convert <<
           "size_t arg_val = PyLongOrInt_AsSize_t(arg);\n"
           "#ifndef NDEBUG\n"
-          "if (arg_val == (size_t)-1 && _PyErr_OCCURRED()) {\n";
+          "if (arg_val == (size_t)-1 && PyErr_Occurred()) {\n";
         error_return(extra_convert, 2, return_flags);
         extra_convert <<
           "}\n"
@@ -6317,7 +6317,7 @@ write_function_instance(ostream &out, FunctionRemap *remap,
       // terminate on error.
       if (!may_raise_typeerror || report_errors) {
         indent(out, indent_level)
-          << "if (_PyErr_OCCURRED()) {\n";
+          << "if (PyErr_Occurred()) {\n";
       } else {
         // If a method is some extension method that takes a PyObject*, and it
         // raised a TypeError, continue.  The documentation tells us not to
@@ -6326,7 +6326,7 @@ write_function_instance(ostream &out, FunctionRemap *remap,
         // the TypeError we want to catch here is going to be generated by a
         // PyErr_SetString call, not by user code.
         indent(out, indent_level)
-          << "PyObject *exception = _PyErr_OCCURRED();\n";
+          << "PyObject *exception = PyErr_Occurred();\n";
         indent(out, indent_level)
           << "if (exception == PyExc_TypeError) {\n";
         indent(out, indent_level)
@@ -6886,7 +6886,7 @@ write_getset(ostream &out, Object *obj, Property *property) {
     write_function_forset(out, remaps, 1, 1, expected_params, 2, true, true,
                           AT_no_args, RF_pyobject | RF_err_null, false, true, "index");
 
-    out << "  if (!_PyErr_OCCURRED()) {\n";
+    out << "  if (!PyErr_Occurred()) {\n";
     out << "    return Dtool_Raise_BadArgumentsError(\n";
     output_quoted(out, 6, expected_params);
     out << ");\n"
@@ -6952,7 +6952,7 @@ write_getset(ostream &out, Object *obj, Property *property) {
                             expected_params, 2, true, true, AT_single_arg,
                             RF_int, false, false, "index");
 
-      out << "  if (!_PyErr_OCCURRED()) {\n";
+      out << "  if (!PyErr_Occurred()) {\n";
       out << "    Dtool_Raise_BadArgumentsError(\n";
       output_quoted(out, 6, expected_params);
       out << ");\n";
@@ -6981,7 +6981,7 @@ write_getset(ostream &out, Object *obj, Property *property) {
                             expected_params, 2, true, true, AT_single_arg,
                             RF_pyobject | RF_err_null, false, false, "index");
 
-      out << "  if (!_PyErr_OCCURRED()) {\n";
+      out << "  if (!PyErr_Occurred()) {\n";
       out << "    Dtool_Raise_BadArgumentsError(\n";
       output_quoted(out, 6, expected_params);
       out << ");\n";
@@ -7049,7 +7049,7 @@ write_getset(ostream &out, Object *obj, Property *property) {
     write_function_forset(out, remaps, 1, 1, expected_params, 2, true, true,
                           AT_single_arg, RF_pyobject | RF_err_null, false, true);
 
-    out << "  if (!_PyErr_OCCURRED()) {\n";
+    out << "  if (!PyErr_Occurred()) {\n";
     out << "    return Dtool_Raise_BadArgumentsError(\n";
     output_quoted(out, 6, expected_params);
     out << ");\n"
@@ -7128,7 +7128,7 @@ write_getset(ostream &out, Object *obj, Property *property) {
                             expected_params, 2, true, true, AT_varargs,
                             RF_int | RF_decref_args, false, false);
 
-      out << "  if (!_PyErr_OCCURRED()) {\n";
+      out << "  if (!PyErr_Occurred()) {\n";
       out << "    Dtool_Raise_BadArgumentsError(\n";
       output_quoted(out, 6, expected_params);
       out << ");\n";
@@ -7178,7 +7178,7 @@ write_getset(ostream &out, Object *obj, Property *property) {
       write_function_forset(out, remaps, 1, 1, expected_params, 2, true, true,
                             AT_no_args, RF_pyobject | RF_err_null, false, true, "index");
 
-      out << "  if (!_PyErr_OCCURRED()) {\n";
+      out << "  if (!PyErr_Occurred()) {\n";
       out << "    return Dtool_Raise_BadArgumentsError(\n";
       output_quoted(out, 6, expected_params);
       out << ");\n"
@@ -7375,7 +7375,7 @@ write_getset(ostream &out, Object *obj, Property *property) {
                             expected_params, 2, true, true, AT_single_arg,
                             RF_int, false, false);
 
-      out << "  if (!_PyErr_OCCURRED()) {\n";
+      out << "  if (!PyErr_Occurred()) {\n";
       out << "    Dtool_Raise_BadArgumentsError(\n";
       output_quoted(out, 6, expected_params);
       out << ");\n";

--- a/dtool/src/interrogatedb/py_compat.h
+++ b/dtool/src/interrogatedb/py_compat.h
@@ -126,10 +126,6 @@ typedef long Py_hash_t;
 /* Python 3.3 */
 
 #if PY_MAJOR_VERSION >= 3
-// Python 3 versions before 3.3.3 defined this incorrectly.
-#  undef _PyErr_OCCURRED
-#  define _PyErr_OCCURRED() (PyThreadState_GET()->curexc_type)
-
 // Python versions before 3.3 did not define this.
 #  if PY_VERSION_HEX < 0x03030000
 #    define PyUnicode_AsUTF8 _PyUnicode_AsString
@@ -246,13 +242,6 @@ INLINE PyObject *PyObject_CallMethodOneArg(PyObject *obj, PyObject *name, PyObje
 #endif
 
 /* Other Python implementations */
-
-// _PyErr_OCCURRED is an undocumented macro version of PyErr_Occurred.
-// Some implementations of the CPython API (e.g. PyPy's cpyext) do not define
-// it, so in these cases we just silently fall back to PyErr_Occurred.
-#ifndef _PyErr_OCCURRED
-#  define _PyErr_OCCURRED() PyErr_Occurred()
-#endif
 
 #endif  // HAVE_PYTHON
 

--- a/dtool/src/interrogatedb/py_panda.cxx
+++ b/dtool/src/interrogatedb/py_panda.cxx
@@ -134,11 +134,10 @@ DTOOL_Call_GetPointerThisClass(PyObject *self, Dtool_PyTypedObject *classdef,
  *
  * Returns true if there is an active exception, false otherwise.
  *
- * In the NDEBUG case, this is simply a #define to _PyErr_OCCURRED() (which is
- * an undocumented inline version of PyErr_Occurred()).
+ * In the NDEBUG case, this is simply a #define to PyErr_Occurred().
  */
 bool _Dtool_CheckErrorOccurred() {
-  if (_PyErr_OCCURRED()) {
+  if (PyErr_Occurred()) {
     return true;
   }
   if (Notify::ptr()->has_assert_failed()) {
@@ -231,7 +230,7 @@ PyObject *_Dtool_Raise_BadArgumentsError() {
  * NULL, otherwise Py_None.
  */
 PyObject *_Dtool_Return_None() {
-  if (UNLIKELY(_PyErr_OCCURRED())) {
+  if (UNLIKELY(PyErr_Occurred())) {
     return nullptr;
   }
 #ifndef NDEBUG
@@ -248,7 +247,7 @@ PyObject *_Dtool_Return_None() {
  * NULL, otherwise the given boolean value as a PyObject *.
  */
 PyObject *Dtool_Return_Bool(bool value) {
-  if (UNLIKELY(_PyErr_OCCURRED())) {
+  if (UNLIKELY(PyErr_Occurred())) {
     return nullptr;
   }
 #ifndef NDEBUG
@@ -267,7 +266,7 @@ PyObject *Dtool_Return_Bool(bool value) {
  * increased.
  */
 PyObject *_Dtool_Return(PyObject *value) {
-  if (UNLIKELY(_PyErr_OCCURRED())) {
+  if (UNLIKELY(PyErr_Occurred())) {
     return nullptr;
   }
 #ifndef NDEBUG

--- a/dtool/src/interrogatedb/py_panda.h
+++ b/dtool/src/interrogatedb/py_panda.h
@@ -205,7 +205,7 @@ INLINE PyObject *DtoolInstance_RichComparePointers(PyObject *v1, PyObject *v2, i
 EXPCL_PYPANDA bool _Dtool_CheckErrorOccurred();
 
 #ifdef NDEBUG
-#define Dtool_CheckErrorOccurred() (UNLIKELY(_PyErr_OCCURRED() != nullptr))
+#define Dtool_CheckErrorOccurred() (UNLIKELY(PyErr_Occurred() != nullptr))
 #else
 #define Dtool_CheckErrorOccurred() (UNLIKELY(_Dtool_CheckErrorOccurred()))
 #endif
@@ -232,8 +232,8 @@ EXPCL_PYPANDA PyObject *Dtool_Return_Bool(bool value);
 EXPCL_PYPANDA PyObject *_Dtool_Return(PyObject *value);
 
 #ifdef NDEBUG
-#define Dtool_Return_None() (LIKELY(_PyErr_OCCURRED() == nullptr) ? (Py_INCREF(Py_None), Py_None) : nullptr)
-#define Dtool_Return(value) (LIKELY(_PyErr_OCCURRED() == nullptr) ? value : nullptr)
+#define Dtool_Return_None() (LIKELY(PyErr_Occurred() == nullptr) ? (Py_INCREF(Py_None), Py_None) : nullptr)
+#define Dtool_Return(value) (LIKELY(PyErr_Occurred() == nullptr) ? value : nullptr)
 #else
 #define Dtool_Return_None() _Dtool_Return_None()
 #define Dtool_Return(value) _Dtool_Return(value)

--- a/dtool/src/interrogatedb/py_wrappers.cxx
+++ b/dtool/src/interrogatedb/py_wrappers.cxx
@@ -308,7 +308,7 @@ static PyObject *Dtool_MutableSequenceWrapper_pop(PyObject *self, PyObject *args
     break;
   case 1:
     index = PyNumber_AsSsize_t(PyTuple_GET_ITEM(args, 0), PyExc_IndexError);
-    if (index == -1 && _PyErr_OCCURRED()) {
+    if (index == -1 && PyErr_Occurred()) {
       return nullptr;
     }
     if (index < 0) {
@@ -361,7 +361,7 @@ static PyObject *Dtool_MutableSequenceWrapper_insert(PyObject *self, PyObject *a
     return Dtool_Raise_TypeError("insert() takes exactly 2 arguments");
   }
   Py_ssize_t index = PyNumber_AsSsize_t(PyTuple_GET_ITEM(args, 0), PyExc_IndexError);
-  if (index == -1 && _PyErr_OCCURRED()) {
+  if (index == -1 && PyErr_Occurred()) {
     return nullptr;
   }
   if (index < 0) {
@@ -420,8 +420,8 @@ static int Dtool_MappingWrapper_contains(PyObject *self, PyObject *key) {
   if (value != nullptr) {
     Py_DECREF(value);
     return 1;
-  } else if (_PyErr_OCCURRED() == PyExc_KeyError ||
-             _PyErr_OCCURRED() == PyExc_TypeError) {
+  } else if (PyErr_ExceptionMatches(PyExc_KeyError) ||
+             PyErr_ExceptionMatches(PyExc_TypeError)) {
     PyErr_Clear();
     return 0;
   } else {
@@ -479,7 +479,7 @@ static PyObject *Dtool_MappingWrapper_get(PyObject *self, PyObject *args) {
   PyObject *value = wrap->_getitem_func(wrap->_base._self, key);
   if (value != nullptr) {
     return value;
-  } else if (_PyErr_OCCURRED() == PyExc_KeyError) {
+  } else if (PyErr_ExceptionMatches(PyExc_KeyError)) {
     PyErr_Clear();
     Py_INCREF(defvalue);
     return defvalue;
@@ -943,7 +943,7 @@ static PyObject *Dtool_MutableMappingWrapper_pop(PyObject *self, PyObject *args)
       Py_DECREF(value);
       return nullptr;
     }
-  } else if (_PyErr_OCCURRED() == PyExc_KeyError) {
+  } else if (PyErr_ExceptionMatches(PyExc_KeyError)) {
     PyErr_Clear();
     Py_INCREF(defvalue);
     return defvalue;
@@ -1043,7 +1043,7 @@ static PyObject *Dtool_MutableMappingWrapper_setdefault(PyObject *self, PyObject
   PyObject *value = wrap->_getitem_func(wrap->_base._self, key);
   if (value != nullptr) {
     return value;
-  } else if (_PyErr_OCCURRED() == PyExc_KeyError) {
+  } else if (PyErr_ExceptionMatches(PyExc_KeyError)) {
     PyErr_Clear();
     if (wrap->_setitem_func(wrap->_base._self, key, defvalue) == 0) {
       Py_INCREF(defvalue);

--- a/panda/src/event/asyncFuture_ext.cxx
+++ b/panda/src/event/asyncFuture_ext.cxx
@@ -226,7 +226,7 @@ result(PyObject *self, PyObject *timeout) const {
   double timeout_val;
   if (timeout != Py_None) {
     timeout_val = PyFloat_AsDouble(timeout);
-    if (timeout_val == -1.0 && _PyErr_OCCURRED()) {
+    if (timeout_val == -1.0 && PyErr_Occurred()) {
       return nullptr;
     }
   }

--- a/panda/src/gobj/pythonTexturePoolFilter.cxx
+++ b/panda/src/gobj/pythonTexturePoolFilter.cxx
@@ -131,7 +131,7 @@ pre_load(const Filename &orig_filename, const Filename &orig_alpha_filename,
 
     Py_DECREF(result);
   } else {
-    PyObject *exc_type = _PyErr_OCCURRED();
+    PyObject *exc_type = PyErr_Occurred();
     nassertr(exc_type != nullptr, nullptr);
 
     gobj_cat.error()
@@ -186,7 +186,7 @@ post_load(Texture *tex) {
       }
     }
   } else {
-    PyObject *exc_type = _PyErr_OCCURRED();
+    PyObject *exc_type = PyErr_Occurred();
     nassertr(exc_type != nullptr, result_tex);
 
     gobj_cat.error()

--- a/panda/src/pgraph/nodePath_ext.cxx
+++ b/panda/src/pgraph/nodePath_ext.cxx
@@ -253,7 +253,7 @@ set_shader_input(CPT_InternalName name, PyObject *value, int priority) {
   ShaderInput &input = attrib->_inputs[name];
   invoke_extension(&input).__init__(std::move(name), value, priority);
 
-  if (!_PyErr_OCCURRED()) {
+  if (!PyErr_Occurred()) {
     node->set_attrib(ShaderAttrib::return_new(attrib));
   }
 }
@@ -295,7 +295,7 @@ set_shader_inputs(PyObject *args, PyObject *kwargs) {
     invoke_extension(&input).__init__(std::move(name), value);
   }
 
-  if (!_PyErr_OCCURRED()) {
+  if (!PyErr_Occurred()) {
     node->set_attrib(ShaderAttrib::return_new(attrib));
   }
 }

--- a/panda/src/pgraph/pythonLoaderFileType.cxx
+++ b/panda/src/pgraph/pythonLoaderFileType.cxx
@@ -331,7 +331,7 @@ load_file(const Filename &path, const LoaderOptions &options,
   Py_DECREF(args);
 
   if (node == nullptr) {
-    PyObject *exc_type = _PyErr_OCCURRED();
+    PyObject *exc_type = PyErr_Occurred();
     if (!exc_type) {
       loader_cat.error()
         << "load_file must return valid PandaNode or raise exception\n";

--- a/panda/src/pgraph/renderState_ext.cxx
+++ b/panda/src/pgraph/renderState_ext.cxx
@@ -57,7 +57,7 @@ make(PyObject *args, PyObject *kwds) {
   int override = 0;
   if (py_override != nullptr) {
     override = _PyLong_AsInt(py_override);
-    if (override == -1 && _PyErr_OCCURRED()) {
+    if (override == -1 && PyErr_Occurred()) {
       return nullptr;
     }
   }

--- a/pandatool/src/deploy-stub/android_main.cxx
+++ b/pandatool/src/deploy-stub/android_main.cxx
@@ -279,7 +279,7 @@ void android_main(struct android_app *app) {
       break;
     }
     if (n < 0) {
-      if (_PyErr_OCCURRED() != PyExc_SystemExit) {
+      if (!PyErr_ExceptionMatches(PyExc_SystemExit)) {
         PyErr_Print();
       } else {
         PyErr_Clear();


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
The private `_PyErr_OCCURRED` macro was removed in Python 3.10.0 alpha 5: https://bugs.python.org/issue43270

While building Panda3D for Python 3.12.0 alpha 5, I noticed that Panda3D's `py_compat.h` header was erroneously defining `_PyErr_OCCURRED` as:

```cpp
PyThreadState_GET()->curexc_type
```

However, Python 3.12.0 alpha 5 no longer has a  `curexc_type` field as part of the `PyThreadState` struct. This causes the build to fail.

Problem 1: `py_compat.h` should not be redefining the `_PyErr_OCCURRED` macro for all Python versions. The invalid macro definition only exists prior to Python 3.3.3. It comes as a surprise that it is being redefined in all subsequent Python versions also. This can lead to issues if newer Python versions have a different implementation of the macro.

Problem 2: `_PyErr_OCCURRED` no longer exists in versions after Python 3.10.0 alpha 5. Therefore, I believe that we should switch to using the public `PyErr_Occurred` method instead, which does not require any compatibility headers as it is available in all Python 3 versions.

Problem 3: `_PyErr_OCCURRED` is being used to compare exception types in multiple locations. This may not work in all cases according to the Python manual:

> Do not compare the return value to a specific exception; use [PyErr_ExceptionMatches()](https://docs.python.org/3/c-api/exceptions.html#c.PyErr_ExceptionMatches) instead, shown below. (The comparison could easily fail since the exception may be an instance instead of a class, in the case of a class exception, or it may be a subclass of the expected exception.)

## Solution description
Problem 1 is solved by removing the compatibility headers, which are no longer required.

Problem 2 is solved by switching all `_PyErr_OCCURRED` references to `PyErr_Occurred` calls.

Problem 3 is solved by replacing the relevant `PyErr_Occurred` calls to `PyErr_ExceptionMatches` calls.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X]  …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
