### PR TITLE
direct: fix missing import in Loader

### DIFF
--- a/direct/src/showbase/Loader.py
+++ b/direct/src/showbase/Loader.py
@@ -16,6 +16,7 @@ from panda3d.core import (
     ModelPool,
     NodePath,
     PandaNode,
+    SamplerState,
     ShaderPool,
     StaticTextFont,
     TexturePool,


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
Fixes `NameError: name 'SamplerState' is not defined` after c7c70bc32a298557684c58065bae5a02c1cb72ba . 

This was the only issue I've encountered in some simple testing of my application.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
Added missing import

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
