### PR TITLE
dtoolutil: Fix _MSC_VER macros that should be _WIN32

### DIFF
--- a/dtool/src/dtoolutil/executionEnvironment.cxx
+++ b/dtool/src/dtoolutil/executionEnvironment.cxx
@@ -261,7 +261,7 @@ ns_has_environment_variable(const string &var) const {
 
 #ifdef PREREAD_ENVIRONMENT
   return false;
-#elif defined(_MSC_VER)
+#elif defined(_WIN32)
   size_t size = 0;
   getenv_s(&size, nullptr, 0, var.c_str());
   return size != 0;
@@ -305,7 +305,7 @@ ns_get_environment_variable(const string &var) const {
   }
 
 #ifndef PREREAD_ENVIRONMENT
-#ifdef _MSC_VER
+#ifdef _WIN32
   std::string value(128, '\0');
   size_t size = value.size();
   while (getenv_s(&size, &value[0], size, var.c_str()) == ERANGE) {
@@ -436,7 +436,7 @@ void ExecutionEnvironment::
 ns_set_environment_variable(const string &var, const string &value) {
   _variables[var] = value;
 
-#ifdef _MSC_VER
+#ifdef _WIN32
   _putenv_s(var.c_str(), value.c_str());
 #else
   setenv(var.c_str(), value.c_str(), 1);
@@ -464,7 +464,7 @@ ns_clear_shadow(const string &var) {
 
 #ifdef PREREAD_ENVIRONMENT
   // Now we have to replace the value in the table.
-#ifdef _MSC_VER
+#ifdef _WIN32
   std::string value(128, '\0');
   size_t size = value.size();
   while (getenv_s(&size, &value[0], size, var.c_str()) == ERANGE) {


### PR DESCRIPTION
## Issue description
When compiling Panda3D with Mingw64, Panda3D attempts to call the `setenv` function which is not available on Mingw64. However, `_putenv_s` and friends are available on Mingw64 just fine.

## Solution description
I've replaced the `_MSC_VER` macros in `ExecutionEnvironment` with `_WIN32` macros which should apply to both MSVC and Mingw64.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
