### PR TITLE
dcparser: Updated out-of-panda dc_sort_inheritance_by_file variable to match PRC default

### DIFF
--- a/direct/src/dcparser/dcClass.h
+++ b/direct/src/dcparser/dcClass.h
@@ -32,7 +32,7 @@ extern ConfigVariableBool dc_sort_inheritance_by_file;
 
 static const bool dc_multiple_inheritance = true;
 static const bool dc_virtual_inheritance = true;
-static const bool dc_sort_inheritance_by_file = false;
+static const bool dc_sort_inheritance_by_file = true;
 
 #endif  // WITHIN_PANDA
 


### PR DESCRIPTION
## Issue description
Using dcparser out-of-panda with multiple .DC files results in a compatibility error as Panda sorts inheritance by file by default. In particular, field numbers do not match.

## Solution description
See dcClass.cxx PRC variable for dc_sort_inheritance_by_file (defaults to true)

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
