### PR TITLE
cocoadisplay: Fix compilation errors and warnings due to missing includes

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsPipe.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsPipe.mm
@@ -16,8 +16,12 @@
 #include "displayInformation.h"
 
 #import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSThread.h>
 #import <AppKit/NSApplication.h>
 #import <AppKit/NSRunningApplication.h>
+#import <AppKit/NSScreen.h>
 
 #include <mach-o/arch.h>
 


### PR DESCRIPTION
## Issue description

Recent changes in cocoadisplay codes introduces warnings during the compilation due to some now missing includes that were probably included indirectly.

Note: This is on macOS 12.1 x86 using SDK 10.9

<pre>
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:35:3: error: use of undeclared identifier 'NSThread'; did you mean 'NewThread'?
  NSThread* thread = [[NSThread alloc] init];
  ^~~~~~~~
  NewThread
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Threads.h:444:1: note: 'NewThread' declared here
NewThread(
^
In file included from panda/src/cocoadisplay/p3cocoadisplay_composite1.mm:1:
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:35:24: error: use of undeclared identifier 'NSThread'; did you mean 'NewThread'?
  NSThread* thread = [[NSThread alloc] init];
                       ^~~~~~~~
                       NewThread
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Threads.h:444:1: note: 'NewThread' declared here
NewThread(
^
In file included from panda/src/cocoadisplay/p3cocoadisplay_composite1.mm:1:
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:35:24: warning: receiver type 'OSErr (*)(ThreadStyle, ThreadEntryTPP, void *, Size, ThreadOptions, void **, ThreadID *)' (aka 'short (*)(unsigned int, void *(*)(void *), void *, long, unsigned int, void **, unsigned long *)') is not 'id' or interface pointer, consider casting it to 'id' [-Wreceiver-expr]
  NSThread* thread = [[NSThread alloc] init];
                       ^~~~~~~~
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:35:13: error: use of undeclared identifier 'thread'
  NSThread* thread = [[NSThread alloc] init];
            ^
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:35:24: warning: receiver type 'OSErr (*)(ThreadStyle, ThreadEntryTPP, void *, Size, ThreadOptions, void **, ThreadID *)' (aka 'short (*)(unsigned int, void *(*)(void *), void *, long, unsigned int, void **, unsigned long *)') is not 'id' or interface pointer, consider casting it to 'id' [-Wreceiver-expr]
  NSThread* thread = [[NSThread alloc] init];
                       ^~~~~~~~
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:36:4: error: use of undeclared identifier 'thread'
  [thread start];
   ^
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:37:4: error: use of undeclared identifier 'thread'
  [thread autorelease];
   ^
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:46:25: warning: receiver 'NSScreen' is a forward class and corresponding @interface may not exist [-Wreceiver-forward-class]
    NSEnumerator *e = [[NSScreen screens] objectEnumerator];
                        ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSWorkspace.h:13:72: note: forward declaration of class here
@class NSArray, NSError, NSImage, NSView, NSNotificationCenter, NSURL, NSScreen, NSRunningApplication;
                                                                       ^
In file included from panda/src/cocoadisplay/p3cocoadisplay_composite1.mm:1:
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:46:34: warning: class method '+screens' not found (return type defaults to 'id') [-Wobjc-method-access]
    NSEnumerator *e = [[NSScreen screens] objectEnumerator];
                                 ^~~~~~~
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:46:43: warning: instance method '-objectEnumerator' not found (return type defaults to 'id') [-Wobjc-method-access]
    NSEnumerator *e = [[NSScreen screens] objectEnumerator];
                                          ^~~~~~~~~~~~~~~~
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:47:37: warning: instance method '-nextObject' not found (return type defaults to 'id') [-Wobjc-method-access]
    while (screen = (NSScreen *) [e nextObject]) {
                                    ^~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:10:60: note: receiver is instance of class declared here
@class NSInvocation, NSMethodSignature, NSCoder, NSString, NSEnumerator;
                                                           ^
In file included from panda/src/cocoadisplay/p3cocoadisplay_composite1.mm:1:
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:48:32: warning: instance method '-deviceDescription' not found (return type defaults to 'id') [-Wobjc-method-access]
      NSNumber *num = [[screen deviceDescription] objectForKey: @"NSScreenNumber"];
                               ^~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSWorkspace.h:13:72: note: receiver is instance of class declared here
@class NSArray, NSError, NSImage, NSView, NSNotificationCenter, NSURL, NSScreen, NSRunningApplication;
                                                                       ^
In file included from panda/src/cocoadisplay/p3cocoadisplay_composite1.mm:1:
panda/src/cocoadisplay/cocoaGraphicsPipe.mm:48:51: warning: instance method '-objectForKey:' not found (return type defaults to 'id') [-Wobjc-method-access]
      NSNumber *num = [[screen deviceDescription] objectForKey: @"NSScreenNumber"];
                                                  ^~~~~~~~~~~~
</pre>


## Solution description

Just add the missing includes


## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
