### PR TITLE
Issue #1481: Add CMake for TinyDisplay module

### DIFF
--- a/panda/CMakeLists.txt
+++ b/panda/CMakeLists.txt
@@ -86,7 +86,7 @@ set(CORE_MODULE_COMPONENTS
   p3downloader p3event p3express p3gobj p3grutil p3gsgbase p3linmath
   p3mathutil p3movies p3parametrics p3pgraph p3pgraphnodes p3pgui
   p3pipeline p3pnmimage p3pstatclient p3putil p3recorder p3text p3tform
-  p3tinydisplay p3prc p3dtoolutil p3dtoolbase
+  p3prc p3dtoolutil p3dtoolbase
 )
 
 if(WANT_NATIVE_NET)

--- a/panda/CMakeLists.txt
+++ b/panda/CMakeLists.txt
@@ -54,6 +54,7 @@ add_subdirectory(src/recorder)
 add_subdirectory(src/testbed)
 add_subdirectory(src/text)
 add_subdirectory(src/tform)
+add_subdirectory(src/tinydisplay)
 add_subdirectory(src/vision)
 add_subdirectory(src/vrpn)
 add_subdirectory(src/wgldisplay)
@@ -85,7 +86,7 @@ set(CORE_MODULE_COMPONENTS
   p3downloader p3event p3express p3gobj p3grutil p3gsgbase p3linmath
   p3mathutil p3movies p3parametrics p3pgraph p3pgraphnodes p3pgui
   p3pipeline p3pnmimage p3pstatclient p3putil p3recorder p3text p3tform
-  p3prc p3dtoolutil p3dtoolbase
+  p3tinydisplay p3prc p3dtoolutil p3dtoolbase
 )
 
 if(WANT_NATIVE_NET)

--- a/panda/src/tinydisplay/CMakeLists.txt
+++ b/panda/src/tinydisplay/CMakeLists.txt
@@ -1,71 +1,60 @@
 set(P3TINYDISPLAY_HEADERS
-    config_tinydisplay.h
-    srgb_tables.h
-    store_pixel.h
-    store_pixel_code.h
-    store_pixel_table.h
-    tinyCocoaGraphicsPipe.I tinyCocoaGraphicsPipe.h
-    tinyCocoaGraphicsWindow.I tinyCocoaGraphicsWindow.h
-    tinyGeomMunger.I tinyGeomMunger.h
-    tinyGraphicsBuffer.I tinyGraphicsBuffer.h
-    tinyGraphicsStateGuardian.I tinyGraphicsStateGuardian.h
-    tinyOffscreenGraphicsPipe.I tinyOffscreenGraphicsPipe.h
-    tinySDLGraphicsPipe.I tinySDLGraphicsPipe.h
-    tinySDLGraphicsWindow.I tinySDLGraphicsWindow.h
-    tinyTextureContext.I tinyTextureContext.h
-    tinyWinGraphicsPipe.I tinyWinGraphicsPipe.h
-    tinyWinGraphicsWindow.I tinyWinGraphicsWindow.h
-    tinyXGraphicsWindow.I tinyXGraphicsWindow.h
-    zbuffer.h
-    zfeatures.h
-    zgl.h
-    zline.h
-    zmath.h
-    ztriangle.h
-    ztriangle_code_1.h
-    ztriangle_code_2.h
-    ztriangle_code_3.h
-    ztriangle_code_4.h
-    ztriangle_table.h
-    ztriangle_two.h
+  config_tinydisplay.h
+  tinyGeomMunger.I tinyGeomMunger.h
+  tinySDLGraphicsPipe.I tinySDLGraphicsPipe.h
+  tinySDLGraphicsWindow.I tinySDLGraphicsWindow.h
+  tinyGraphicsBuffer.I tinyGraphicsBuffer.h
+  tinyGraphicsStateGuardian.I tinyGraphicsStateGuardian.h
+  tinyTextureContext.I tinyTextureContext.h
+  tinyWinGraphicsPipe.I tinyWinGraphicsPipe.h
+  tinyWinGraphicsWindow.I tinyWinGraphicsWindow.h
+  tinyXGraphicsPipe.I tinyXGraphicsPipe.h
+  tinyXGraphicsWindow.I tinyXGraphicsWindow.h
+  tinyOffscreenGraphicsPipe.I tinyOffscreenGraphicsPipe.h
+  zbuffer.h
+  zfeatures.h
+  zgl.h
+  zline.h
+  zmath.h
+  ztriangle.h
+  ztriangle_two.h
+  ztriangle_code_1.h
+  ztriangle_code_2.h
+  ztriangle_code_3.h
+  ztriangle_code_4.h
+  ztriangle_table.h
+  store_pixel.h
+  store_pixel_code.h
+  store_pixel_table.h
 )
 
 set(P3TINYDISPLAY_SOURCES
-    clip.cxx
-    config_tinydisplay.cxx
-    error.cxx
-    image_util.cxx
-    init.cxx
-    memory.cxx
-    p3tinydisplay_composite1.cxx
-    p3tinydisplay_composite2.cxx
-    specbuf.cxx
-    srgb_tables.cxx
-    store_pixel.cxx
-    td_light.cxx
-    td_texture.cxx
-    tinyCocoaGraphicsPipe.cxx
-    tinyGeomMunger.cxx
-    tinyGraphicsBuffer.cxx
-    tinyGraphicsStateGuardian.cxx
-    tinyOffscreenGraphicsPipe.cxx
-    tinySDLGraphicsPipe.cxx
-    tinySDLGraphicsWindow.cxx
-    tinyTextureContext.cxx
-    tinyWinGraphicsPipe.cxx
-    tinyWinGraphicsWindow.cxx
-    tinyXGraphicsPipe.cxx
-    tinyXGraphicsWindow.cxx
-    vertex.cxx
-    zbuffer.cxx
-    zdither.cxx
-    zline.cxx
-    zmath.cxx
-    ztriangle_1.cxx
-    ztriangle_2.cxx
-    ztriangle_3.cxx
-    ztriangle_4.cxx
-    ztriangle_table.cxx
+  clip.cxx
+  config_tinydisplay.cxx
+  error.cxx
+  image_util.cxx
+  init.cxx
+  td_light.cxx
+  memory.cxx
+  specbuf.cxx
+  store_pixel.cxx
+  td_texture.cxx
+  tinyGeomMunger.cxx
+  tinyGraphicsBuffer.cxx
+  tinyGraphicsStateGuardian.cxx
+  tinyOffscreenGraphicsPipe.cxx
+  tinySDLGraphicsPipe.cxx
+  tinySDLGraphicsWindow.cxx
+  tinyTextureContext.cxx
+  tinyWinGraphicsPipe.cxx
+  tinyWinGraphicsWindow.cxx
+  tinyXGraphicsPipe.cxx
+  tinyXGraphicsWindow.cxx
+  vertex.cxx
+  zbuffer.cxx
+  zdither.cxx
+  zline.cxx
+  zmath.cxx
 )
 
 composite_sources(p3tinydisplay P3TINYDISPLAY_SOURCES)
@@ -73,10 +62,11 @@ add_component_library(p3tinydisplay SYMBOL BUILDING_TINYDISPLAY ${P3TINYDISPLAY_
 target_link_libraries(p3tinydisplay panda p3windisplay)
 
 if(NOT BUILD_METALIBS)
-    install(TARGETS p3tinydisplay
-      EXPORT Core COMPONENT Core
-      DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d
-      ARCHIVE COMPONENT CoreDevel)
+  install(TARGETS p3tinydisplay
+    EXPORT Core COMPONENT Core
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d
+    ARCHIVE COMPONENT CoreDevel)
 endif()
+install(FILES ${P3TINYDISPLAY_HEADERS} COMPONENT CoreDevel DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d)

--- a/panda/src/tinydisplay/CMakeLists.txt
+++ b/panda/src/tinydisplay/CMakeLists.txt
@@ -69,10 +69,8 @@ set(P3TINYDISPLAY_SOURCES
 )
 
 composite_sources(p3tinydisplay P3TINYDISPLAY_SOURCES)
-add_component_library(p3tinydisplay SYMBOL BUILDING_TINYDISPLAY
-    ${P3TINYDISPLAY_HEADERS} ${P3TINYDISPLAY_SOURCES})
+add_component_library(p3tinydisplay SYMBOL BUILDING_TINYDISPLAY ${P3TINYDISPLAY_HEADERS} ${P3TINYDISPLAY_SOURCES})
 target_link_libraries(p3tinydisplay panda p3windisplay)
-target_interrogate(p3tinydisplay ALL)
 
 if(NOT BUILD_METALIBS)
     install(TARGETS p3tinydisplay
@@ -82,4 +80,3 @@ if(NOT BUILD_METALIBS)
       INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d
       ARCHIVE COMPONENT CoreDevel)
 endif()
-install(FILES ${P3TINYDISPLAY_HEADERS} COMPONENT CoreDevel DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d)

--- a/panda/src/tinydisplay/CMakeLists.txt
+++ b/panda/src/tinydisplay/CMakeLists.txt
@@ -1,0 +1,85 @@
+set(P3TINYDISPLAY_HEADERS
+    config_tinydisplay.h
+    srgb_tables.h
+    store_pixel.h
+    store_pixel_code.h
+    store_pixel_table.h
+    tinyCocoaGraphicsPipe.I tinyCocoaGraphicsPipe.h
+    tinyCocoaGraphicsWindow.I tinyCocoaGraphicsWindow.h
+    tinyGeomMunger.I tinyGeomMunger.h
+    tinyGraphicsBuffer.I tinyGraphicsBuffer.h
+    tinyGraphicsStateGuardian.I tinyGraphicsStateGuardian.h
+    tinyOffscreenGraphicsPipe.I tinyOffscreenGraphicsPipe.h
+    tinySDLGraphicsPipe.I tinySDLGraphicsPipe.h
+    tinySDLGraphicsWindow.I tinySDLGraphicsWindow.h
+    tinyTextureContext.I tinyTextureContext.h
+    tinyWinGraphicsPipe.I tinyWinGraphicsPipe.h
+    tinyWinGraphicsWindow.I tinyWinGraphicsWindow.h
+    tinyXGraphicsWindow.I tinyXGraphicsWindow.h
+    zbuffer.h
+    zfeatures.h
+    zgl.h
+    zline.h
+    zmath.h
+    ztriangle.h
+    ztriangle_code_1.h
+    ztriangle_code_2.h
+    ztriangle_code_3.h
+    ztriangle_code_4.h
+    ztriangle_table.h
+    ztriangle_two.h
+)
+
+set(P3TINYDISPLAY_SOURCES
+    clip.cxx
+    config_tinydisplay.cxx
+    error.cxx
+    image_util.cxx
+    init.cxx
+    memory.cxx
+    p3tinydisplay_composite1.cxx
+    p3tinydisplay_composite2.cxx
+    specbuf.cxx
+    srgb_tables.cxx
+    store_pixel.cxx
+    td_light.cxx
+    td_texture.cxx
+    tinyCocoaGraphicsPipe.cxx
+    tinyGeomMunger.cxx
+    tinyGraphicsBuffer.cxx
+    tinyGraphicsStateGuardian.cxx
+    tinyOffscreenGraphicsPipe.cxx
+    tinySDLGraphicsPipe.cxx
+    tinySDLGraphicsWindow.cxx
+    tinyTextureContext.cxx
+    tinyWinGraphicsPipe.cxx
+    tinyWinGraphicsWindow.cxx
+    tinyXGraphicsPipe.cxx
+    tinyXGraphicsWindow.cxx
+    vertex.cxx
+    zbuffer.cxx
+    zdither.cxx
+    zline.cxx
+    zmath.cxx
+    ztriangle_1.cxx
+    ztriangle_2.cxx
+    ztriangle_3.cxx
+    ztriangle_4.cxx
+    ztriangle_table.cxx
+)
+
+composite_sources(p3tinydisplay P3TINYDISPLAY_SOURCES)
+add_component_library(p3tinydisplay SYMBOL BUILDING_TINYDISPLAY
+    ${P3TINYDISPLAY_HEADERS} ${P3TINYDISPLAY_SOURCES})
+target_link_libraries(p3tinydisplay panda p3windisplay)
+target_interrogate(p3tinydisplay ALL)
+
+if(NOT BUILD_METALIBS)
+    install(TARGETS p3tinydisplay
+      EXPORT Core COMPONENT Core
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d
+      ARCHIVE COMPONENT CoreDevel)
+endif()
+install(FILES ${P3TINYDISPLAY_HEADERS} COMPONENT CoreDevel DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d)

--- a/panda/src/tinydisplay/CMakeLists.txt
+++ b/panda/src/tinydisplay/CMakeLists.txt
@@ -1,72 +1,72 @@
 set(P3TINYDISPLAY_HEADERS
-  config_tinydisplay.h
-  tinyGeomMunger.I tinyGeomMunger.h
-  tinySDLGraphicsPipe.I tinySDLGraphicsPipe.h
-  tinySDLGraphicsWindow.I tinySDLGraphicsWindow.h
-  tinyGraphicsBuffer.I tinyGraphicsBuffer.h
-  tinyGraphicsStateGuardian.I tinyGraphicsStateGuardian.h
-  tinyTextureContext.I tinyTextureContext.h
-  tinyWinGraphicsPipe.I tinyWinGraphicsPipe.h
-  tinyWinGraphicsWindow.I tinyWinGraphicsWindow.h
-  tinyXGraphicsPipe.I tinyXGraphicsPipe.h
-  tinyXGraphicsWindow.I tinyXGraphicsWindow.h
-  tinyOffscreenGraphicsPipe.I tinyOffscreenGraphicsPipe.h
-  zbuffer.h
-  zfeatures.h
-  zgl.h
-  zline.h
-  zmath.h
-  ztriangle.h
-  ztriangle_two.h
-  ztriangle_code_1.h
-  ztriangle_code_2.h
-  ztriangle_code_3.h
-  ztriangle_code_4.h
-  ztriangle_table.h
-  store_pixel.h
-  store_pixel_code.h
-  store_pixel_table.h
+        config_tinydisplay.h
+        tinyGeomMunger.I tinyGeomMunger.h
+        tinySDLGraphicsPipe.I tinySDLGraphicsPipe.h
+        tinySDLGraphicsWindow.I tinySDLGraphicsWindow.h
+        tinyGraphicsBuffer.I tinyGraphicsBuffer.h
+        tinyGraphicsStateGuardian.I tinyGraphicsStateGuardian.h
+        tinyTextureContext.I tinyTextureContext.h
+        tinyWinGraphicsPipe.I tinyWinGraphicsPipe.h
+        tinyWinGraphicsWindow.I tinyWinGraphicsWindow.h
+        tinyXGraphicsPipe.I tinyXGraphicsPipe.h
+        tinyXGraphicsWindow.I tinyXGraphicsWindow.h
+        tinyOffscreenGraphicsPipe.I tinyOffscreenGraphicsPipe.h
+        zbuffer.h
+        zfeatures.h
+        zgl.h
+        zline.h
+        zmath.h
+        ztriangle.h
+        ztriangle_two.h
+        ztriangle_code_1.h
+        ztriangle_code_2.h
+        ztriangle_code_3.h
+        ztriangle_code_4.h
+        ztriangle_table.h
+        store_pixel.h
+        store_pixel_code.h
+        store_pixel_table.h
 )
 
 set(P3TINYDISPLAY_SOURCES
-  clip.cxx
-  config_tinydisplay.cxx
-  error.cxx
-  image_util.cxx
-  init.cxx
-  td_light.cxx
-  memory.cxx
-  specbuf.cxx
-  store_pixel.cxx
-  td_texture.cxx
-  tinyGeomMunger.cxx
-  tinyGraphicsBuffer.cxx
-  tinyGraphicsStateGuardian.cxx
-  tinyOffscreenGraphicsPipe.cxx
-  tinySDLGraphicsPipe.cxx
-  tinySDLGraphicsWindow.cxx
-  tinyTextureContext.cxx
-  tinyWinGraphicsPipe.cxx
-  tinyWinGraphicsWindow.cxx
-  tinyXGraphicsPipe.cxx
-  tinyXGraphicsWindow.cxx
-  vertex.cxx
-  zbuffer.cxx
-  zdither.cxx
-  zline.cxx
-  zmath.cxx
+        clip.cxx
+        config_tinydisplay.cxx
+        error.cxx
+        image_util.cxx
+        init.cxx
+        td_light.cxx
+        memory.cxx
+        specbuf.cxx
+        store_pixel.cxx
+        td_texture.cxx
+        tinyGeomMunger.cxx
+        tinyGraphicsBuffer.cxx
+        tinyGraphicsStateGuardian.cxx
+        tinyOffscreenGraphicsPipe.cxx
+        tinySDLGraphicsPipe.cxx
+        tinySDLGraphicsWindow.cxx
+        tinyTextureContext.cxx
+        tinyWinGraphicsPipe.cxx
+        tinyWinGraphicsWindow.cxx
+        tinyXGraphicsPipe.cxx
+        tinyXGraphicsWindow.cxx
+        vertex.cxx
+        zbuffer.cxx
+        zdither.cxx
+        zline.cxx
+        zmath.cxx
 )
 
 composite_sources(p3tinydisplay P3TINYDISPLAY_SOURCES)
 add_component_library(p3tinydisplay SYMBOL BUILDING_TINYDISPLAY ${P3TINYDISPLAY_HEADERS} ${P3TINYDISPLAY_SOURCES})
-target_link_libraries(p3tinydisplay panda p3windisplay)
+target_link_libraries(p3tinydisplay panda p3windisplay p3x11display p3cocoadisplay)
 
 if(NOT BUILD_METALIBS)
   install(TARGETS p3tinydisplay
-    EXPORT Core COMPONENT Core
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d
-    ARCHIVE COMPONENT CoreDevel)
+          EXPORT Core COMPONENT Core
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d
+          ARCHIVE COMPONENT CoreDevel)
 endif()
 install(FILES ${P3TINYDISPLAY_HEADERS} COMPONENT CoreDevel DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d)


### PR DESCRIPTION
## Issue description
This change is intended to fix Issue #1481 by adding a CMake file for TinyDisplay module. The intent is that this module is built when a user compiles using CMake.

## Solution description
A new CMakeLists.txt file is created in the TinyDisplay directory in the same style as the other modules. The core CMakeLists.txt file is also updated to read the TinyDisplay subdirectory.

I understand that not all headers from TinyDisplay are necessary for inclusion. I have modelled the list of headers and sources to be included from the equivalent `premake` file: https://github.com/panda3d/panda3d/blob/release/1.9.x/panda/src/tinydisplay/Sources.pp

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
