### PR TITLE
dcparser: fix segfault with nested class or switch

### DIFF
--- a/direct/src/dcparser/dcClass.I
+++ b/direct/src/dcparser/dcClass.I
@@ -80,3 +80,11 @@ stop_generate() {
   _class_generate_pcollector.stop();
 #endif
 }
+
+/**
+ * Returns the outer DCClass if this class is nested.
+ */
+INLINE DCClass *DCClass::
+get_outer() const {
+  return _outer;
+}

--- a/direct/src/dcparser/dcClass.cxx
+++ b/direct/src/dcparser/dcClass.cxx
@@ -64,7 +64,7 @@ public:
  *
  */
 DCClass::
-DCClass(DCFile *dc_file, const string &name, bool is_struct, bool bogus_class) :
+DCClass(DCFile *dc_file, const string &name, bool is_struct, bool bogus_class, DCClass *outer) :
 #ifdef WITHIN_PANDA
   _class_update_pcollector(_update_pcollector, name),
   _class_generate_pcollector(_generate_pcollector, name),
@@ -72,7 +72,8 @@ DCClass(DCFile *dc_file, const string &name, bool is_struct, bool bogus_class) :
   _dc_file(dc_file),
   _name(name),
   _is_struct(is_struct),
-  _bogus_class(bogus_class)
+  _bogus_class(bogus_class),
+  _outer(outer)
 {
   _number = -1;
   _constructor = nullptr;

--- a/direct/src/dcparser/dcClass.h
+++ b/direct/src/dcparser/dcClass.h
@@ -45,7 +45,8 @@ class DCParameter;
 class EXPCL_DIRECT_DCPARSER DCClass : public DCDeclaration {
 public:
   DCClass(DCFile *dc_file, const std::string &name,
-          bool is_struct, bool bogus_class);
+          bool is_struct, bool bogus_class,
+          DCClass *outer);
   ~DCClass();
 
 PUBLISHED:
@@ -140,6 +141,8 @@ public:
   bool add_field(DCField *field);
   void add_parent(DCClass *parent);
   void set_number(int number);
+  
+  INLINE DCClass *get_outer() const;
 
 private:
   void shadow_inherited_field(const std::string &name);
@@ -172,6 +175,8 @@ private:
   typedef pmap<int, DCField *> FieldsByIndex;
   FieldsByIndex _fields_by_index;
 
+  DCClass *_outer;
+    
   friend class DCField;
 
 #ifdef WITHIN_PANDA

--- a/direct/src/dcparser/dcParser.cxx.prebuilt
+++ b/direct/src/dcparser/dcParser.cxx.prebuilt
@@ -1756,7 +1756,7 @@ yyreduce:
   case 30:
 #line 299 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1651  */
     {
-  current_class = new DCClass(dc_file, (yyvsp[0].str), false, false);
+  current_class = new DCClass(dc_file, (yyvsp[0].str), false, false, current_class);
 }
 #line 1762 "built/tmp/dcParser.yxx.c" /* yacc.c:1651  */
     break;
@@ -1765,7 +1765,7 @@ yyreduce:
 #line 303 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1651  */
     {
   (yyval.u.dclass) = current_class;
-  current_class = (yyvsp[-4].u.dclass);
+  current_class = current_class->get_outer();
 }
 #line 1771 "built/tmp/dcParser.yxx.c" /* yacc.c:1651  */
     break;
@@ -1781,7 +1781,7 @@ yyreduce:
     DCClass *dclass = dc_file->get_class_by_name((yyvsp[0].str));
     if (dclass == nullptr) {
       // Create a bogus class as a forward reference.
-      dclass = new DCClass(dc_file, (yyvsp[0].str), false, true);
+      dclass = new DCClass(dc_file, (yyvsp[0].str), false, true, nullptr);
       dc_file->add_class(dclass);
     }
     if (dclass->is_struct()) {
@@ -1873,7 +1873,7 @@ yyreduce:
   case 44:
 #line 403 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1651  */
     {
-  current_class = new DCClass(dc_file, (yyvsp[0].str), true, false);
+  current_class = new DCClass(dc_file, (yyvsp[0].str), true, false, current_class);
 }
 #line 1879 "built/tmp/dcParser.yxx.c" /* yacc.c:1651  */
     break;
@@ -1882,7 +1882,7 @@ yyreduce:
 #line 407 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1651  */
     {
   (yyval.u.dclass) = current_class;
-  current_class = (yyvsp[-4].u.dclass);
+  current_class = current_class->get_outer();
 }
 #line 1888 "built/tmp/dcParser.yxx.c" /* yacc.c:1651  */
     break;
@@ -1898,7 +1898,7 @@ yyreduce:
     DCClass *dstruct = dc_file->get_class_by_name((yyvsp[0].str));
     if (dstruct == nullptr) {
       // Create a bogus class as a forward reference.
-      dstruct = new DCClass(dc_file, (yyvsp[0].str), false, true);
+      dstruct = new DCClass(dc_file, (yyvsp[0].str), false, true, nullptr);
       dc_file->add_class(dstruct);
     }
     if (!dstruct->is_struct()) {
@@ -1975,7 +1975,7 @@ yyreduce:
     {
   if (current_class == nullptr) {
     yyerror("Cannot define a method outside of a struct or class.");
-    DCClass *temp_class = new DCClass(dc_file, "temp", false, false);  // memory leak.
+    DCClass *temp_class = new DCClass(dc_file, "temp", false, false, nullptr);  // memory leak.
     current_atomic = new DCAtomicField((yyvsp[-1].str), temp_class, false);
   } else {
     current_atomic = new DCAtomicField((yyvsp[-1].str), current_class, false);
@@ -2963,7 +2963,7 @@ yyreduce:
   case 176:
 #line 1245 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1651  */
     {
-  current_switch = new DCSwitch((yyvsp[-4].str), (yyvsp[-2].u.field));
+  current_switch = new DCSwitch((yyvsp[-4].str), (yyvsp[-2].u.field), current_switch);
 }
 #line 2969 "built/tmp/dcParser.yxx.c" /* yacc.c:1651  */
     break;
@@ -2972,7 +2972,7 @@ yyreduce:
 #line 1249 "direct/src/dcparser/dcParser.yxx" /* yacc.c:1651  */
     {
   (yyval.u.dswitch) = current_switch;
-  current_switch = (DCSwitch *)(yyvsp[-2].u.parameter);
+  current_switch = current_switch->get_outer();
 }
 #line 2978 "built/tmp/dcParser.yxx.c" /* yacc.c:1651  */
     break;

--- a/direct/src/dcparser/dcParser.yxx
+++ b/direct/src/dcparser/dcParser.yxx
@@ -297,12 +297,12 @@ dclass_or_struct:
 dclass:
         KW_DCLASS optional_name
 {
-  current_class = new DCClass(dc_file, $2, false, false);
+  current_class = new DCClass(dc_file, $2, false, false, current_class);
 }
         dclass_derivation '{' dclass_fields '}'
 {
   $$ = current_class;
-  current_class = $<u.dclass>3;
+  current_class = current_class->get_outer();
 }
         ;
 
@@ -317,7 +317,7 @@ dclass_name:
     DCClass *dclass = dc_file->get_class_by_name($1);
     if (dclass == nullptr) {
       // Create a bogus class as a forward reference.
-      dclass = new DCClass(dc_file, $1, false, true);
+      dclass = new DCClass(dc_file, $1, false, true, nullptr);
       dc_file->add_class(dclass);
     }
     if (dclass->is_struct()) {
@@ -401,12 +401,12 @@ dclass_field:
 struct:
         KW_STRUCT optional_name
 {
-  current_class = new DCClass(dc_file, $2, true, false);
+  current_class = new DCClass(dc_file, $2, true, false, current_class);
 }
         struct_derivation '{' struct_fields '}'
 {
   $$ = current_class;
-  current_class = $<u.dclass>3;
+  current_class = current_class->get_outer();
 }
         ;
 
@@ -421,7 +421,7 @@ struct_name:
     DCClass *dstruct = dc_file->get_class_by_name($1);
     if (dstruct == nullptr) {
       // Create a bogus class as a forward reference.
-      dstruct = new DCClass(dc_file, $1, false, true);
+      dstruct = new DCClass(dc_file, $1, false, true, nullptr);
       dc_file->add_class(dstruct);
     }
     if (!dstruct->is_struct()) {
@@ -490,7 +490,7 @@ atomic_field:
 {
   if (current_class == nullptr) {
     yyerror("Cannot define a method outside of a struct or class.");
-    DCClass *temp_class = new DCClass(dc_file, "temp", false, false);  // memory leak.
+    DCClass *temp_class = new DCClass(dc_file, "temp", false, false, nullptr);  // memory leak.
     current_atomic = new DCAtomicField($1, temp_class, false);
   } else {
     current_atomic = new DCAtomicField($1, current_class, false);
@@ -1243,12 +1243,12 @@ optional_name:
 switch:
         KW_SWITCH optional_name '(' parameter_or_atomic ')' '{'
 {
-  current_switch = new DCSwitch($2, $4);
+  current_switch = new DCSwitch($2, $4, current_switch);
 }
         switch_fields '}'
 {
   $$ = current_switch;
-  current_switch = (DCSwitch *)$<u.parameter>7;
+  current_switch = current_switch->get_outer();
 }
         ;
 

--- a/direct/src/dcparser/dcSimpleParameter.cxx
+++ b/direct/src/dcparser/dcSimpleParameter.cxx
@@ -2496,7 +2496,7 @@ create_nested_field(DCSubatomicType type, unsigned int divisor) {
 DCPackerInterface *DCSimpleParameter::
 create_uint32uint8_type() {
   if (_uint32uint8_type == nullptr) {
-    DCClass *dclass = new DCClass(nullptr, "", true, false);
+    DCClass *dclass = new DCClass(nullptr, "", true, false, nullptr);
     dclass->add_field(new DCSimpleParameter(ST_uint32));
     dclass->add_field(new DCSimpleParameter(ST_uint8));
     _uint32uint8_type = new DCClassParameter(dclass);

--- a/direct/src/dcparser/dcSwitch.cxx
+++ b/direct/src/dcparser/dcSwitch.cxx
@@ -26,9 +26,10 @@ using std::string;
  * via delete when the switch destructs.
  */
 DCSwitch::
-DCSwitch(const string &name, DCField *key_parameter) :
+DCSwitch(const string &name, DCField *key_parameter, DCSwitch *outer) :
   _name(name),
-  _key_parameter(key_parameter)
+  _key_parameter(key_parameter),
+  _outer(outer)
 {
   _default_case = nullptr;
   _fields_added = false;
@@ -518,6 +519,15 @@ do_check_match_switch(const DCSwitch *other) const {
   }
 
   return true;
+}
+
+
+/**
+ * Returns the outer DCSwitch if this switch is nested.
+ */
+DCSwitch *DCSwitch::
+get_outer() const {
+  return _outer;
 }
 
 /**

--- a/direct/src/dcparser/dcSwitch.h
+++ b/direct/src/dcparser/dcSwitch.h
@@ -29,7 +29,7 @@ class DCField;
  */
 class EXPCL_DIRECT_DCPARSER DCSwitch : public DCDeclaration {
 public:
-  DCSwitch(const std::string &name, DCField *key_parameter);
+  DCSwitch(const std::string &name, DCField *key_parameter, DCSwitch *outer);
   virtual ~DCSwitch();
 
 PUBLISHED:
@@ -56,7 +56,7 @@ public:
   bool add_default();
   bool add_field(DCField *field);
   void add_break();
-
+  
   const DCPackerInterface *apply_switch(const char *value_data, size_t length) const;
 
   virtual void output(std::ostream &out, bool brief) const;
@@ -70,6 +70,8 @@ public:
   virtual bool pack_default_value(DCPackData &pack_data, bool &pack_error) const;
 
   bool do_check_match_switch(const DCSwitch *other) const;
+  
+  DCSwitch *get_outer() const;
 
 public:
   typedef pvector<DCField *> Fields;
@@ -139,6 +141,8 @@ private:
   // This map indexes into the _cases vector, above.
   typedef pmap<vector_uchar, int> CasesByValue;
   CasesByValue _cases_by_value;
+  
+  DCSwitch *_outer;
 };
 
 #endif


### PR DESCRIPTION
## Issue description
https://github.com/panda3d/panda3d/issues/1499

## Solution description
- Create an outer attribute on DCClass and DCSwitch, and add this attribute in the constructor
- When constructing DCClass or DCSwitch, store the current_class/current_switch in the newly created object's `outer` attribute
- When done with the current_class/current_switch, put the previous one back with `get_outer()`.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [ ] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
