### PR TITLE
python: Remove usage of private _PyUnicode C API calls

### DIFF
--- a/dtool/src/interrogatedb/py_panda.cxx
+++ b/dtool/src/interrogatedb/py_panda.cxx
@@ -623,7 +623,7 @@ PyObject *Dtool_PyModuleInitHelper(const LibraryDef *defs[], const char *modulen
       if (main_module == NULL) {
         interrogatedb_cat.warning() << "Unable to import __main__\n";
       }
-      
+
       // Extract the __file__ attribute, if present.
       Filename main_dir;
       PyObject *file_attr = nullptr;
@@ -784,9 +784,7 @@ bool Dtool_ExtractArg(PyObject **result, PyObject *args, PyObject *kwds,
     if (kwds != nullptr && PyDict_GET_SIZE(kwds) == 1 &&
         PyDict_Next(kwds, &ppos, &key, result)) {
       // We got the item, we just need to make sure that it had the right key.
-#if PY_VERSION_HEX >= 0x03060000
-      return PyUnicode_CheckExact(key) && _PyUnicode_EqualToASCIIString(key, keyword);
-#elif PY_MAJOR_VERSION >= 3
+#if PY_MAJOR_VERSION >= 3
       return PyUnicode_CheckExact(key) && PyUnicode_CompareWithASCIIString(key, keyword) == 0;
 #else
       return PyString_CheckExact(key) && strcmp(PyString_AS_STRING(key), keyword) == 0;

--- a/panda/src/pgraph/renderState_ext.cxx
+++ b/panda/src/pgraph/renderState_ext.cxx
@@ -39,7 +39,7 @@ make(PyObject *args, PyObject *kwds) {
     }
 
     // We got the item, we just need to make sure that it had the right key.
-    if (!PyUnicode_CheckExact(key) || !_PyUnicode_EqualToASCIIString(key, "override")) {
+    if (!PyUnicode_CheckExact(key) || PyUnicode_CompareWithASCIIString(key, "override") != 0) {
       Dtool_Raise_TypeError("RenderState.make() received an unexpected keyword argument");
       return nullptr;
     }


### PR DESCRIPTION
## Issue description
Python 3.13 has unpublished the _PyUnicode_EqualToASCIIString private C API call. It is now part of the internal API: https://github.com/python/cpython/issues/106320

## Solution description
This pull request replaces the private _PyUnicode_EqualToASCIIString API call with the similar public PyUnicode_CompareWithASCIIString API call.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
