### PR TITLE
(draft) allow to run offscreen C++ test with headless pview

### DIFF
--- a/panda/src/testbed/pview.cxx
+++ b/panda/src/testbed/pview.cxx
@@ -28,6 +28,7 @@
 #include "asyncTaskManager.h"
 #include "asyncTask.h"
 #include "boundingSphere.h"
+#include "load_prc_file.h"
 
 using std::cerr;
 using std::endl;
@@ -198,7 +199,10 @@ help() {
     "  -i\n"
     "      Ignore bundle/group names.  Normally, the <group> name must match\n"
     "      the <bundle> name, or the animation will not be used.\n\n"
-
+    
+    "  -o\n"
+    "      Use window-type offscreen\n\n"
+    
     "  -s filename\n"
     "      After displaying the models, immediately take a screenshot and\n"
     "      exit.\n\n"
@@ -375,6 +379,10 @@ main(int argc, char **argv) {
 
     case 'i':
       hierarchy_match_flags |= PartGroup::HMF_ok_wrong_root_name;
+      break;
+      
+    case 'o':
+      load_prc_file_data("", "window-type offscreen");
       break;
 
     case 's':

--- a/panda/src/testbed/pview.cxx
+++ b/panda/src/testbed/pview.cxx
@@ -359,7 +359,7 @@ main(int argc, char **argv) {
 
   extern char *optarg;
   extern int optind;
-  static const char *optflags = "acls:DVhiLP:S";
+  static const char *optflags = "aclos:DVhiLP:S";
   int flag = getopt(argc, argv, optflags);
 
   while (flag != EOF) {

--- a/panda/src/testbed/pview.cxx
+++ b/panda/src/testbed/pview.cxx
@@ -199,10 +199,10 @@ help() {
     "  -i\n"
     "      Ignore bundle/group names.  Normally, the <group> name must match\n"
     "      the <bundle> name, or the animation will not be used.\n\n"
-    
+
     "  -o\n"
-    "      Use window-type offscreen\n\n"
-    
+    "      Do not open window (window-type offscreen)\n\n"
+
     "  -s filename\n"
     "      After displaying the models, immediately take a screenshot and\n"
     "      exit.\n\n"
@@ -343,6 +343,7 @@ public:
 int
 main(int argc, char **argv) {
   preprocess_argv(argc, argv);
+
   framework.open_framework(argc, argv);
   framework.set_window_title("Panda Viewer");
 
@@ -380,8 +381,9 @@ main(int argc, char **argv) {
     case 'i':
       hierarchy_match_flags |= PartGroup::HMF_ok_wrong_root_name;
       break;
-      
+
     case 'o':
+        nout << "off type window set" << endl;
       load_prc_file_data("", "window-type offscreen");
       break;
 

--- a/panda/src/tinydisplay/CMakeLists.txt
+++ b/panda/src/tinydisplay/CMakeLists.txt
@@ -1,0 +1,91 @@
+set(P3TINYDISPLAY_HEADERS
+  config_tinydisplay.h
+  tinyGeomMunger.I tinyGeomMunger.h
+  tinySDLGraphicsPipe.I tinySDLGraphicsPipe.h
+  tinySDLGraphicsWindow.I tinySDLGraphicsWindow.h
+  tinyGraphicsBuffer.I tinyGraphicsBuffer.h
+  tinyGraphicsStateGuardian.I tinyGraphicsStateGuardian.h
+  tinyTextureContext.I tinyTextureContext.h
+  tinyWinGraphicsPipe.I tinyWinGraphicsPipe.h
+  tinyWinGraphicsWindow.I tinyWinGraphicsWindow.h
+  tinyXGraphicsPipe.I tinyXGraphicsPipe.h
+  tinyXGraphicsWindow.I tinyXGraphicsWindow.h
+  tinyOffscreenGraphicsPipe.I tinyOffscreenGraphicsPipe.h
+  tinyOffscreenGraphicsWindow.I tinyOffscreenGraphicsWindow.h
+  srgb_tables.h
+  zbuffer.h
+  zfeatures.h
+  zgl.h
+  zline.h
+  zmath.h
+  ztriangle.h
+  ztriangle_two.h
+  ztriangle_code_1.h
+  ztriangle_code_2.h
+  ztriangle_code_3.h
+  ztriangle_code_4.h
+  ztriangle_table.h
+  store_pixel.h
+  store_pixel_code.h
+  store_pixel_table.h
+)
+
+set(P3TINYDISPLAY_SOURCES
+  clip.cxx
+  config_tinydisplay.cxx
+  error.cxx
+  image_util.cxx
+  init.cxx
+  td_light.cxx
+  memory.cxx
+  specbuf.cxx
+  store_pixel.cxx
+  td_texture.cxx
+  tinyGeomMunger.cxx
+  tinyGraphicsBuffer.cxx
+  tinyGraphicsStateGuardian.cxx
+  tinyOffscreenGraphicsPipe.cxx
+  tinyOffscreenGraphicsWindow.cxx
+  tinySDLGraphicsPipe.cxx
+  tinySDLGraphicsWindow.cxx
+  tinyTextureContext.cxx
+  tinyWinGraphicsPipe.cxx
+  tinyWinGraphicsWindow.cxx
+  tinyXGraphicsPipe.cxx
+  tinyXGraphicsWindow.cxx
+  vertex.cxx
+  ztriangle_table.cxx
+  ztriangle_1.cxx
+  ztriangle_2.cxx
+  ztriangle_3.cxx
+  ztriangle_4.cxx
+  srgb_tables.cxx
+  zbuffer.cxx
+  zdither.cxx
+  zline.cxx
+  zmath.cxx
+)
+
+composite_sources(p3tinydisplay P3TINYDISPLAY_SOURCES)
+add_component_library(p3tinydisplay SYMBOL BUILDING_TINYDISPLAY ${P3TINYDISPLAY_HEADERS} ${P3TINYDISPLAY_SOURCES})
+if (HAVE_X11)
+    target_link_libraries(p3tinydisplay panda p3x11display)
+# p3windisplay
+# p3cocoadisplay
+elseif (WASI OR EMSCRIPTEN)
+    target_link_libraries(p3tinydisplay panda )
+else()
+    message(WARNING "no display and not headless build")
+    target_link_libraries(p3tinydisplay panda )
+endif()
+
+
+if(NOT BUILD_METALIBS)
+  install(TARGETS p3tinydisplay
+    EXPORT Core COMPONENT Core
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d
+    ARCHIVE COMPONENT CoreDevel)
+endif()
+install(FILES ${P3TINYDISPLAY_HEADERS} COMPONENT CoreDevel DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/panda3d)

--- a/panda/src/tinydisplay/config_tinydisplay.cxx
+++ b/panda/src/tinydisplay/config_tinydisplay.cxx
@@ -21,6 +21,7 @@
 #include "tinySDLGraphicsPipe.h"
 #include "tinySDLGraphicsWindow.h"
 #include "tinyOffscreenGraphicsPipe.h"
+#include "tinyOffscreenGraphicsWindow.h"
 #include "tinyGraphicsBuffer.h"
 #include "tinyGraphicsStateGuardian.h"
 #include "tinyGeomMunger.h"
@@ -114,6 +115,7 @@ init_libtinydisplay() {
 #endif
 
   TinyOffscreenGraphicsPipe::init_type();
+  TinyOffscreenGraphicsWindow::init_type();
   selection->add_pipe_type(TinyOffscreenGraphicsPipe::get_class_type(),
                            TinyOffscreenGraphicsPipe::pipe_constructor);
   ps->set_system_tag("TinyPanda", "", "");

--- a/panda/src/tinydisplay/tinyOffscreenGraphicsPipe.cxx
+++ b/panda/src/tinydisplay/tinyOffscreenGraphicsPipe.cxx
@@ -75,7 +75,7 @@ make_output(const std::string &name,
     return nullptr;
   }
 
-  TinyGraphicsStateGuardian *tinygsg = 0;
+  TinyGraphicsStateGuardian *tinygsg = nullptr;
   if (gsg != 0) {
     DCAST_INTO_R(tinygsg, gsg, nullptr);
   }

--- a/panda/src/tinydisplay/tinyOffscreenGraphicsPipe.cxx
+++ b/panda/src/tinydisplay/tinyOffscreenGraphicsPipe.cxx
@@ -70,9 +70,33 @@ make_output(const std::string &name,
             GraphicsOutput *host,
             int retry,
             bool &precertify) {
-  // Only thing to try: a TinyGraphicsBuffer
 
-  if (retry == 0) {
+  if (!_is_valid) {
+    return nullptr;
+  }
+
+  TinyGraphicsStateGuardian *tinygsg = 0;
+  if (gsg != 0) {
+    DCAST_INTO_R(tinygsg, gsg, nullptr);
+  }
+
+  if (retry == 0 && _is_valid) {
+    if (((flags&BF_require_parasite)!=0)||
+        ((flags&BF_refuse_window)!=0)||
+        ((flags&BF_resizeable)!=0)||
+        ((flags&BF_size_track_host)!=0)||
+        ((flags&BF_rtt_cumulative)!=0)||
+        ((flags&BF_can_bind_color)!=0)||
+        ((flags&BF_can_bind_every)!=0)) {
+      return nullptr;
+    }
+    return new TinyOffscreenGraphicsWindow(engine, this, name, fb_prop, win_prop,
+                                   flags, gsg, host);
+  }
+
+  // Second thing to try: a TinyGraphicsBuffer
+
+  if (retry == 1) {
     if (((flags&BF_require_parasite)!=0)||
         ((flags&BF_require_window)!=0)) {
       return nullptr;
@@ -83,3 +107,4 @@ make_output(const std::string &name,
   // Nothing else left to try.
   return nullptr;
 }
+

--- a/panda/src/tinydisplay/tinyOffscreenGraphicsPipe.cxx
+++ b/panda/src/tinydisplay/tinyOffscreenGraphicsPipe.cxx
@@ -76,7 +76,7 @@ make_output(const std::string &name,
   }
 
   TinyGraphicsStateGuardian *tinygsg = nullptr;
-  if (gsg != 0) {
+  if (gsg != nullptr) {
     DCAST_INTO_R(tinygsg, gsg, nullptr);
   }
 

--- a/panda/src/tinydisplay/tinyOffscreenGraphicsPipe.cxx
+++ b/panda/src/tinydisplay/tinyOffscreenGraphicsPipe.cxx
@@ -18,6 +18,7 @@
 #include "tinyGraphicsBuffer.h"
 #include "config_tinydisplay.h"
 #include "frameBufferProperties.h"
+#include "tinyOffscreenGraphicsWindow.h"
 
 TypeHandle TinyOffscreenGraphicsPipe::_type_handle;
 

--- a/panda/src/tinydisplay/tinyOffscreenGraphicsWindow.I
+++ b/panda/src/tinydisplay/tinyOffscreenGraphicsWindow.I
@@ -1,0 +1,12 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file tinySDLGraphicsWindow.I
+ * @author drose
+ * @date 2008-04-24
+ */

--- a/panda/src/tinydisplay/tinyOffscreenGraphicsWindow.cxx
+++ b/panda/src/tinydisplay/tinyOffscreenGraphicsWindow.cxx
@@ -1,0 +1,290 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file tinyOffscreenGraphicsWindow.cxx
+ * @author drose
+ * @date 2008-04-24
+ */
+
+#include "pandabase.h"
+
+
+#include "tinyOffscreenGraphicsWindow.h"
+#include "tinyGraphicsStateGuardian.h"
+#include "config_tinydisplay.h"
+#include "tinyOffscreenGraphicsPipe.h"
+#include "mouseButton.h"
+#include "keyboardButton.h"
+#include "graphicsPipe.h"
+
+TypeHandle TinyOffscreenGraphicsWindow::_type_handle;
+
+/**
+ *
+ */
+TinyOffscreenGraphicsWindow::
+TinyOffscreenGraphicsWindow(GraphicsEngine *engine, GraphicsPipe *pipe,
+                      const std::string &name,
+                      const FrameBufferProperties &fb_prop,
+                      const WindowProperties &win_prop,
+                      int flags,
+                      GraphicsStateGuardian *gsg,
+                      GraphicsOutput *host) :
+  GraphicsWindow(engine, pipe, name, fb_prop, win_prop, flags, gsg, host)
+{
+  //_screen = nullptr;
+  _frame_buffer = nullptr;
+  _pitch = 0;
+  update_pixel_factor();
+
+  add_input_device(GraphicsWindowInputDevice::pointer_and_keyboard(this, "keyboard_mouse"));
+}
+
+/**
+ *
+ */
+TinyOffscreenGraphicsWindow::
+~TinyOffscreenGraphicsWindow() {
+}
+
+/**
+ * This function will be called within the draw thread before beginning
+ * rendering for a given frame.  It should do whatever setup is required, and
+ * return true if the frame should be rendered, or false if it should be
+ * skipped.
+ */
+bool TinyOffscreenGraphicsWindow::
+begin_frame(FrameMode mode, Thread *current_thread) {
+  begin_frame_spam(mode);
+  if (_gsg == nullptr) {
+    return false;
+  }
+
+  TinyGraphicsStateGuardian *tinygsg;
+  DCAST_INTO_R(tinygsg, _gsg, false);
+
+  tinygsg->_current_frame_buffer = _frame_buffer;
+  tinygsg->reset_if_new();
+
+  _gsg->set_current_properties(&get_fb_properties());
+  return _gsg->begin_frame(current_thread);
+}
+
+/**
+ * This function will be called within the draw thread after rendering is
+ * completed for a given frame.  It should do whatever finalization is
+ * required.
+ */
+void TinyOffscreenGraphicsWindow::
+end_frame(FrameMode mode, Thread *current_thread) {
+  end_frame_spam(mode);
+  nassertv(_gsg != nullptr);
+
+  if (mode == FM_render) {
+    // end_render_texture();
+    copy_to_textures();
+  }
+
+  _gsg->end_frame(current_thread);
+
+  if (mode == FM_render) {
+    trigger_flip();
+  }
+}
+
+/**
+ * This function will be called within the draw thread after begin_flip() has
+ * been called on all windows, to finish the exchange of the front and back
+ * buffers.
+ *
+ * This should cause the window to wait for the flip, if necessary.
+ */
+void TinyOffscreenGraphicsWindow::
+end_flip() {
+  if (!_flip_ready) {
+    GraphicsWindow::end_flip();
+    return;
+  }
+/*
+  int fb_xsize = get_fb_x_size();
+  int fb_ysize = get_fb_y_size();
+  ZB_copyFrameBuffer(_frame_buffer, _screen->pixels, _pitch);
+*/
+  GraphicsWindow::end_flip();
+}
+
+/**
+ * Do whatever processing is necessary to ensure that the window responds to
+ * user events.  Also, honor any requests recently made via
+ * request_properties()
+ *
+ * This function is called only within the window thread.
+ */
+void TinyOffscreenGraphicsWindow::
+process_events() {
+  GraphicsWindow::process_events();
+/*
+  if (_screen == nullptr) {
+    return;
+  }
+*/
+}
+
+/**
+ * Applies the requested set of properties to the window, if possible, for
+ * instance to request a change in size or minimization status.
+ *
+ * The window properties are applied immediately, rather than waiting until
+ * the next frame.  This implies that this method may *only* be called from
+ * within the window thread.
+ *
+ * The return value is true if the properties are set, false if they are
+ * ignored.  This is mainly useful for derived classes to implement extensions
+ * to this function.
+ */
+void TinyOffscreenGraphicsWindow::
+set_properties_now(WindowProperties &properties) {
+  GraphicsWindow::set_properties_now(properties);
+  if (!properties.is_any_specified()) {
+    // The base class has already handled this case.
+    return;
+  }
+}
+
+/**
+ * Returns true if a call to set_pixel_zoom() will be respected, false if it
+ * will be ignored.  If this returns false, then get_pixel_factor() will
+ * always return 1.0, regardless of what value you specify for
+ * set_pixel_zoom().
+ *
+ * This may return false if the underlying renderer doesn't support pixel
+ * zooming, or if you have called this on a DisplayRegion that doesn't have
+ * both set_clear_color() and set_clear_depth() enabled.
+ */
+bool TinyOffscreenGraphicsWindow::
+supports_pixel_zoom() const {
+  return true;
+}
+
+/**
+ * Closes the window right now.  Called from the window thread.
+ */
+void TinyOffscreenGraphicsWindow::
+close_window() {
+  GraphicsWindow::close_window();
+}
+
+/**
+ * Opens the window right now.  Called from the window thread.  Returns true
+ * if the window is successfully opened, or false if there was a problem.
+ */
+bool TinyOffscreenGraphicsWindow::
+open_window() {
+
+  // GSG CreationInitialization
+  TinyGraphicsStateGuardian *tinygsg;
+  if (_gsg == 0) {
+    // There is no old gsg.  Create a new one.
+    tinygsg = new TinyGraphicsStateGuardian(_engine, _pipe, nullptr);
+    _gsg = tinygsg;
+
+  } else {
+    DCAST_INTO_R(tinygsg, _gsg, false);
+  }
+/*
+  _flags = Offscreen_SWSURFACE;
+  if (_properties.get_fullscreen()) {
+    _flags |= Offscreen_WINDOW_FULLSCREEN;
+  }
+
+  Offscreen_Window *win = Offscreen_CreateWindow("Panda3D", 0, 0, _properties.get_x_size(), _properties.get_y_size(), _flags);
+    _screen = Offscreen_GetWindowSurface(win);
+
+  if (_screen == nullptr) {
+    tinydisplay_cat.error()
+      << "Video mode set failed.\n";
+    return false;
+  }
+*/
+
+  create_frame_buffer();
+  if (_frame_buffer == nullptr) {
+    tinydisplay_cat.error()
+      << "Could not create frame buffer.\n";
+    return false;
+  }
+
+  tinygsg->_current_frame_buffer = _frame_buffer;
+
+  // Now that we have made the context current to a window, we can reset the
+  // GSG state if this is the first time it has been used.  (We can't just
+  // call reset() when we construct the GSG, because reset() requires having a
+  // current context.)
+  tinygsg->reset_if_new();
+
+  return true;
+}
+
+/**
+ * Creates a suitable frame buffer for the current window size.
+ */
+void TinyOffscreenGraphicsWindow::
+create_frame_buffer() {
+  if (_frame_buffer != nullptr) {
+    ZB_close(_frame_buffer);
+    _frame_buffer = nullptr;
+  }
+
+  int mode;
+/*
+  switch (_screen->format->BitsPerPixel) {
+  case  8:
+    tinydisplay_cat.error() << "Offscreen Palettes are currently not supported.\n";
+    return;
+
+  case 16:
+    mode = ZB_MODE_5R6G5B;
+    break;
+  case 24:
+    mode = ZB_MODE_RGB24;
+    break;
+  case 32:
+    mode = ZB_MODE_RGBA;
+    break;
+
+  default:
+    return;
+  }
+*/
+    mode = ZB_MODE_RGBA;
+
+    _frame_buffer = ZB_open(_properties.get_x_size(), _properties.get_y_size(), mode, 0, 0, 0, 0);
+
+    _pitch = 4; //  _screen->pitch * 32 / _screen->format->BitsPerPixel;
+}
+
+/**
+ * Maps from an Offscreen keysym to the corresponding Panda ButtonHandle.
+ */
+ButtonHandle TinyOffscreenGraphicsWindow::
+get_keyboard_button(int sym) {
+  tinydisplay_cat.info() << "unhandled keyboard button " << sym << "\n";
+  return ButtonHandle::none();
+}
+
+/**
+ * Maps from an Offscreen mouse button index to the corresponding Panda
+ * ButtonHandle.
+ */
+ButtonHandle TinyOffscreenGraphicsWindow::
+get_mouse_button(int button) {
+  tinydisplay_cat.info() << "unhandled mouse button " << button << "\n";
+
+  return ButtonHandle::none();
+}
+

--- a/panda/src/tinydisplay/tinyOffscreenGraphicsWindow.cxx
+++ b/panda/src/tinydisplay/tinyOffscreenGraphicsWindow.cxx
@@ -188,7 +188,7 @@ open_window() {
 
   // GSG CreationInitialization
   TinyGraphicsStateGuardian *tinygsg;
-  if (_gsg == 0) {
+  if (_gsg == nullptr) {
     // There is no old gsg.  Create a new one.
     tinygsg = new TinyGraphicsStateGuardian(_engine, _pipe, nullptr);
     _gsg = tinygsg;
@@ -196,21 +196,6 @@ open_window() {
   } else {
     DCAST_INTO_R(tinygsg, _gsg, false);
   }
-/*
-  _flags = Offscreen_SWSURFACE;
-  if (_properties.get_fullscreen()) {
-    _flags |= Offscreen_WINDOW_FULLSCREEN;
-  }
-
-  Offscreen_Window *win = Offscreen_CreateWindow("Panda3D", 0, 0, _properties.get_x_size(), _properties.get_y_size(), _flags);
-    _screen = Offscreen_GetWindowSurface(win);
-
-  if (_screen == nullptr) {
-    tinydisplay_cat.error()
-      << "Video mode set failed.\n";
-    return false;
-  }
-*/
 
   create_frame_buffer();
   if (_frame_buffer == nullptr) {

--- a/panda/src/tinydisplay/tinyOffscreenGraphicsWindow.h
+++ b/panda/src/tinydisplay/tinyOffscreenGraphicsWindow.h
@@ -1,0 +1,84 @@
+/**
+ * PANDA 3D SOFTWARE
+ * Copyright (c) Carnegie Mellon University.  All rights reserved.
+ *
+ * All use of this software is subject to the terms of the revised BSD
+ * license.  You should have received a copy of this license along
+ * with this source code in a file named "LICENSE."
+ *
+ * @file tinyOffscreenGraphicsWindow.h
+ * @author drose
+ * @date 2008-04-24
+ */
+
+#ifndef TINYOffscreenGRAPHICSWINDOW_H
+#define TINYOffscreenGRAPHICSWINDOW_H
+
+#include "pandabase.h"
+
+
+#include "tinyOffscreenGraphicsPipe.h"
+#include "graphicsWindow.h"
+#include "buttonHandle.h"
+#include "zbuffer.h"
+
+
+/**
+ * This graphics window class is implemented via Offscreen.
+ */
+class EXPCL_TINYDISPLAY TinyOffscreenGraphicsWindow : public GraphicsWindow {
+public:
+  TinyOffscreenGraphicsWindow(GraphicsEngine *engine, GraphicsPipe *pipe,
+                        const std::string &name,
+                        const FrameBufferProperties &fb_prop,
+                        const WindowProperties &win_prop,
+                        int flags,
+                        GraphicsStateGuardian *gsg,
+                        GraphicsOutput *host);
+  virtual ~TinyOffscreenGraphicsWindow();
+
+  virtual bool begin_frame(FrameMode mode, Thread *current_thread);
+  virtual void end_frame(FrameMode mode, Thread *current_thread);
+  virtual void end_flip();
+
+  virtual void process_events();
+  virtual void set_properties_now(WindowProperties &properties);
+
+  virtual bool supports_pixel_zoom() const;
+
+protected:
+  virtual void close_window();
+  virtual bool open_window();
+
+private:
+  void create_frame_buffer();
+  static ButtonHandle get_keyboard_button(int sym);
+  static ButtonHandle get_mouse_button(int button);
+
+private:
+  //SDL_Surface *_screen;
+  ZBuffer *_frame_buffer;
+  unsigned int _flags;
+  unsigned int _pitch;
+
+public:
+  static TypeHandle get_class_type() {
+    return _type_handle;
+  }
+  static void init_type() {
+    GraphicsWindow::init_type();
+    register_type(_type_handle, "TinyOffscreenGraphicsWindow",
+                  GraphicsWindow::get_class_type());
+  }
+  virtual TypeHandle get_type() const {
+    return get_class_type();
+  }
+  virtual TypeHandle force_init_type() {init_type(); return get_class_type();}
+
+private:
+  static TypeHandle _type_handle;
+};
+
+#include "tinyOffscreenGraphicsWindow.I"
+
+#endif


### PR DESCRIPTION
in case of a wasi/emsdk CI with tinydisplay

