### PR TITLE
[draft] Add support for system-provided gestures

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.h
@@ -71,6 +71,7 @@ public:
   void handle_mouse_moved_event(bool in_window, double x, double y, bool absolute);
   void handle_wheel_event(double x, double y);
   void handle_magnify(double magnification, NSEventPhase eventPhase);
+  void handle_rotate(double rotation, NSEventPhase eventPhase);
   virtual ButtonMap *get_keyboard_map() const;
 
   INLINE NSWindow *get_nswindow() const;

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.h
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.h
@@ -33,6 +33,7 @@ typedef objc_object NSImage;
 typedef objc_object NSView;
 typedef objc_object NSWindow;
 typedef unsigned long NSUInteger;
+typedef NSUInteger NSEventPhase;
 #endif
 
 /**
@@ -69,6 +70,7 @@ public:
   void handle_mouse_button_event(int button, bool down);
   void handle_mouse_moved_event(bool in_window, double x, double y, bool absolute);
   void handle_wheel_event(double x, double y);
+  void handle_magnify(double magnification, NSEventPhase eventPhase);
   virtual ButtonMap *get_keyboard_map() const;
 
   INLINE NSWindow *get_nswindow() const;

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1788,6 +1788,26 @@ handle_wheel_event(double x, double y) {
   }
 }
 
+void CocoaGraphicsWindow::
+handle_magnify(double magnification, NSEventPhase eventPhase) {
+  GesturePhase phase = GesturePhase::UNKNOWN;
+  switch (eventPhase) {
+  case NSEventPhaseBegan:
+    phase = GesturePhase::BEGAN; break;
+  case NSEventPhaseChanged:
+  case NSEventPhaseStationary:
+    phase = GesturePhase::CHANGED; break;
+  case NSEventPhaseEnded:
+    phase = GesturePhase::ENDED; break;
+  case NSEventPhaseCancelled:
+    phase = GesturePhase::CANCELLED; break;
+  default:
+    break;
+  }
+
+  _input->magnify_gesture(magnification, phase);
+}
+
 /**
  * Returns a ButtonMap containing the association between raw buttons and
  * virtual buttons.

--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1788,8 +1788,8 @@ handle_wheel_event(double x, double y) {
   }
 }
 
-void CocoaGraphicsWindow::
-handle_magnify(double magnification, NSEventPhase eventPhase) {
+// private convenience method
+static GesturePhase gesture_phase_from_event_phase(NSEventPhase eventPhase) {
   GesturePhase phase = GesturePhase::UNKNOWN;
   switch (eventPhase) {
   case NSEventPhaseBegan:
@@ -1804,9 +1804,22 @@ handle_magnify(double magnification, NSEventPhase eventPhase) {
   default:
     break;
   }
+  return phase;
+}
 
+void CocoaGraphicsWindow::
+handle_magnify(double magnification, NSEventPhase eventPhase) {
+  GesturePhase phase = gesture_phase_from_event_phase(eventPhase);
   _input->magnify_gesture(magnification, phase);
 }
+
+void CocoaGraphicsWindow::
+handle_rotate(double rotation, NSEventPhase eventPhase) {
+  GesturePhase phase = gesture_phase_from_event_phase(eventPhase);
+  _input->rotate_gesture(rotation, phase);
+}
+
+
 
 /**
  * Returns a ButtonMap containing the association between raw buttons and

--- a/panda/src/cocoadisplay/cocoaPandaView.mm
+++ b/panda/src/cocoadisplay/cocoaPandaView.mm
@@ -165,6 +165,10 @@
   _graphicsWindow->handle_magnify([event magnification], [event phase]);
 }
 
+- (void)rotateWithEvent:(NSEvent*)event {
+  _graphicsWindow->handle_rotate([event rotation], [event phase]);
+}
+
 - (BOOL) isOpaque {
   return YES;
 }

--- a/panda/src/cocoadisplay/cocoaPandaView.mm
+++ b/panda/src/cocoadisplay/cocoaPandaView.mm
@@ -161,6 +161,10 @@
   _graphicsWindow->handle_wheel_event([event deltaX], [event deltaY]);
 }
 
+- (void)magnifyWithEvent:(NSEvent *)event {
+  _graphicsWindow->handle_magnify([event magnification], [event phase]);
+}
+
 - (BOOL) isOpaque {
   return YES;
 }

--- a/panda/src/device/inputDevice.I
+++ b/panda/src/device/inputDevice.I
@@ -20,6 +20,7 @@ INLINE InputDevice::
 InputDevice() {
   _button_events = new ButtonEventList;
   _pointer_events = new PointerEventList;
+  _gesture_events = new GestureEventList;
 }
 
 /**

--- a/panda/src/device/inputDevice.cxx
+++ b/panda/src/device/inputDevice.cxx
@@ -30,6 +30,7 @@ InputDevice(const std::string &name, DeviceClass dev_class) :
 {
   _button_events = new ButtonEventList;
   _pointer_events = new PointerEventList;
+  _gesture_events = new GestureEventList;
 }
 
 /**
@@ -93,6 +94,29 @@ get_pointer_events() {
   LightMutexHolder holder(_lock);
   PT(PointerEventList) result = new PointerEventList;
   swap(_pointer_events, result);
+  return result;
+}
+
+/**
+ * Returns true if this device has a pending gesture event,
+ * or false otherwise.  If this returns true, the particular event may be
+ * extracted via get_gesture_events().
+ */
+bool InputDevice::
+has_gesture_event() const {
+  LightMutexHolder holder(_lock);
+  return _gesture_events != nullptr && !_gesture_events->empty();
+}
+
+/**
+ * Returns a gestureEventList containing all the recent gesture events.
+ * Clears the list.
+ */
+PT(GestureEventList) InputDevice::
+get_gesture_events() {
+  LightMutexHolder holder(_lock);
+  PT(GestureEventList) result = new GestureEventList;
+  swap(_gesture_events, result);
   return result;
 }
 

--- a/panda/src/device/inputDevice.h
+++ b/panda/src/device/inputDevice.h
@@ -23,6 +23,7 @@
 #include "pointerData.h"
 #include "trackerData.h"
 #include "clockObject.h"
+#include "gestureEvent.h"
 
 #include "pdeque.h"
 #include "pvector.h"
@@ -114,6 +115,9 @@ PUBLISHED:
 
     // The device provides information about battery life.
     BATTERY,
+
+    // The device reports input gestures
+    GESTURE,
 
     // Deprecated aliases.
     pointer = POINTER,
@@ -318,6 +322,8 @@ PUBLISHED:
   PT(ButtonEventList) get_button_events();
   bool has_pointer_event() const;
   PT(PointerEventList) get_pointer_events();
+  bool has_gesture_event() const;
+  PT(GestureEventList) get_gesture_events();
 
   virtual void output(std::ostream &out) const;
 
@@ -370,6 +376,7 @@ protected:
   bool _enable_pointer_events = false;
   PT(ButtonEventList) _button_events;
   PT(PointerEventList) _pointer_events;
+  PT(GestureEventList) _gesture_events;
 
   size_t _num_pointers = 0;
   typedef pvector<PointerData> Pointers;

--- a/panda/src/display/graphicsWindowInputDevice.cxx
+++ b/panda/src/display/graphicsWindowInputDevice.cxx
@@ -199,3 +199,11 @@ set_pointer_out_of_window(double time) {
                                seq, time);
   }
 }
+
+void GraphicsWindowInputDevice::
+magnify_gesture(double magnification, GesturePhase phase, double time) {
+  LightMutexHolder holder(_lock);
+  int seq = _event_sequence++;
+  _gesture_events->add_magnification_event(magnification, phase, seq, time);
+}
+

--- a/panda/src/display/graphicsWindowInputDevice.cxx
+++ b/panda/src/display/graphicsWindowInputDevice.cxx
@@ -207,3 +207,10 @@ magnify_gesture(double magnification, GesturePhase phase, double time) {
   _gesture_events->add_magnification_event(magnification, phase, seq, time);
 }
 
+void GraphicsWindowInputDevice::
+rotate_gesture(double rotation, GesturePhase phase, double time) {
+  LightMutexHolder holder(_lock);
+  int seq = _event_sequence++;
+  _gesture_events->add_rotation_event(rotation, phase, seq, time);
+}
+

--- a/panda/src/display/graphicsWindowInputDevice.h
+++ b/panda/src/display/graphicsWindowInputDevice.h
@@ -60,6 +60,8 @@ PUBLISHED:
   INLINE void pointer_moved(double x, double y, double time = ClockObject::get_global_clock()->get_frame_time());
   INLINE void remove_pointer(int id);
 
+  void magnify_gesture(double magnification, GesturePhase phase, double time = ClockObject::get_global_clock()->get_frame_time());
+
 private:
   typedef pset<ButtonHandle> ButtonsHeld;
   ButtonsHeld _buttons_held;

--- a/panda/src/display/graphicsWindowInputDevice.h
+++ b/panda/src/display/graphicsWindowInputDevice.h
@@ -61,6 +61,7 @@ PUBLISHED:
   INLINE void remove_pointer(int id);
 
   void magnify_gesture(double magnification, GesturePhase phase, double time = ClockObject::get_global_clock()->get_frame_time());
+  void rotate_gesture(double rotation, GesturePhase phase, double time = ClockObject::get_global_clock()->get_frame_time());
 
 private:
   typedef pset<ButtonHandle> ButtonsHeld;

--- a/panda/src/display/mouseAndKeyboard.cxx
+++ b/panda/src/display/mouseAndKeyboard.cxx
@@ -34,6 +34,7 @@ MouseAndKeyboard(GraphicsWindow *window, int device, const std::string &name) :
   _xy_output = define_output("xy", EventStoreVec2::get_class_type());
   _button_events_output = define_output("button_events", ButtonEventList::get_class_type());
   _pointer_events_output = define_output("pointer_events", PointerEventList::get_class_type());
+  _gesture_events_output = define_output("gesture_events", GestureEventList::get_class_type());
 
   _pixel_xy = new EventStoreVec2(LPoint2(0.0f, 0.0f));
   _pixel_size = new EventStoreVec2(LPoint2(0.0f, 0.0f));
@@ -75,6 +76,10 @@ do_transmit_data(DataGraphTraverser *, const DataNodeTransmit &,
   if (device->has_pointer_event()) {
     PT(PointerEventList) pel = device->get_pointer_events();
     output.set_data(_pointer_events_output, EventParameter(pel));
+  }
+  if (device->has_gesture_event()) {
+    PT(GestureEventList) gel = device->get_gesture_events();
+    output.set_data(_gesture_events_output, EventParameter(gel));
   }
 
   // Get the window size.

--- a/panda/src/display/mouseAndKeyboard.h
+++ b/panda/src/display/mouseAndKeyboard.h
@@ -56,6 +56,7 @@ private:
   int _xy_output;
   int _button_events_output;
   int _pointer_events_output;
+  int _gesture_events_output;
 
   PT(EventStoreVec2) _pixel_xy;
   PT(EventStoreVec2) _pixel_size;

--- a/panda/src/event/CMakeLists.txt
+++ b/panda/src/event/CMakeLists.txt
@@ -31,6 +31,7 @@ set(P3EVENT_SOURCES
   genericAsyncTask.cxx
   pointerEvent.cxx
   pointerEventList.cxx
+  gestureEvent.cxx
   config_event.cxx event.cxx eventHandler.cxx
   eventParameter.cxx eventQueue.cxx eventReceiver.cxx
   pt_Event.cxx

--- a/panda/src/event/config_event.cxx
+++ b/panda/src/event/config_event.cxx
@@ -24,6 +24,7 @@
 #include "eventParameter.h"
 #include "genericAsyncTask.h"
 #include "pointerEventList.h"
+#include "gestureEvent.h"
 
 #include "dconfig.h"
 
@@ -50,6 +51,8 @@ ConfigureFn(config_event) {
   EventStoreInt::init_type("EventStoreInt");
   EventStoreDouble::init_type("EventStoreDouble");
   GenericAsyncTask::init_type();
+  GestureEvent::init_type();
+  GestureEventList::init_type();
 
   ButtonEventList::register_with_read_factory();
   EventStoreInt::register_with_read_factory();

--- a/panda/src/event/gestureEvent.cxx
+++ b/panda/src/event/gestureEvent.cxx
@@ -1,0 +1,41 @@
+#include "gestureEvent.h"
+
+TypeHandle GestureEvent::_type_handle;
+TypeHandle GestureEventList::_type_handle;
+
+void GestureEventList::
+add_magnification_event(double magnification, GesturePhase phase, int seq, double time) {
+  GestureEvent me;
+  me._type = GestureType::MAGNIFICATION;
+  me._phase = phase;
+  me._sequence = seq;
+  me._time = time;
+
+  me._magnification = magnification;
+  _events.push_back(me);
+}
+
+void GestureEventList::
+output(std::ostream &out) const {
+  if (_events.empty()) {
+    out << "(no pointers)";
+  } else {
+    out << "(not implemented)";
+  }
+}
+
+bool GestureEventList::
+empty() const {
+  return _events.empty();
+}
+
+
+int GestureEventList::
+get_num_events() const {
+  return _events.size();
+}
+
+GestureEvent GestureEventList::
+get_event(int index) const {
+  return _events[index];
+}

--- a/panda/src/event/gestureEvent.cxx
+++ b/panda/src/event/gestureEvent.cxx
@@ -11,7 +11,7 @@ add_magnification_event(double magnification, GesturePhase phase, int seq, doubl
   me._sequence = seq;
   me._time = time;
 
-  me._magnification = magnification;
+  me._gestureData.magnification = magnification;
   _events.push_back(me);
 }
 

--- a/panda/src/event/gestureEvent.cxx
+++ b/panda/src/event/gestureEvent.cxx
@@ -16,6 +16,18 @@ add_magnification_event(double magnification, GesturePhase phase, int seq, doubl
 }
 
 void GestureEventList::
+add_rotation_event(double rotation, GesturePhase phase, int seq, double time) {
+  GestureEvent re;
+  re._type = GestureType::ROTATION;
+  re._phase = phase;
+  re._sequence = seq;
+  re._time = time;
+
+  re._gestureData.rotation = rotation;
+  _events.push_back(re);
+}
+
+void GestureEventList::
 output(std::ostream &out) const {
   if (_events.empty()) {
     out << "(no pointers)";

--- a/panda/src/event/gestureEvent.h
+++ b/panda/src/event/gestureEvent.h
@@ -1,0 +1,94 @@
+#ifndef GESTUREEVENT_H
+#define GESTUREEVENT_H
+
+#include "pandabase.h"
+
+
+enum class GesturePhase {
+  UNKNOWN,
+  BEGAN,
+  CHANGED,
+  ENDED,
+  CANCELLED
+};
+
+enum class GestureType {
+  UNKNOWN,
+  MAGNIFICATION,
+  ROTATION,
+  SWIPE
+};
+
+class EXPCL_PANDA_EVENT GestureEvent {
+public:
+
+  GestureType _type = GestureType::UNKNOWN;
+  GesturePhase _phase = GesturePhase::UNKNOWN;
+  int _sequence = 0;
+  double _time = 0.0;
+
+  virtual ~GestureEvent() {}
+
+  // Only valid if _type == MAGNIFICATION
+  double _magnification = 0.0;
+
+/**
+ * TypedObject implementation
+ */
+public:
+  static TypeHandle get_class_type() {
+    return _type_handle;
+  }
+  static void init_type() {
+    TypedObject::init_type();
+    register_type(_type_handle, "GestureEvent",
+                  TypedObject::get_class_type());
+  }
+  virtual TypeHandle get_type() const {
+    return get_class_type();
+  }
+  virtual TypeHandle force_init_type() {init_type(); return get_class_type();}
+
+private:
+  static TypeHandle _type_handle;
+};
+
+class EXPCL_PANDA_EVENT GestureEventList : public ParamValueBase {
+PUBLISHED:
+  GestureEventList() {};
+
+  bool empty() const;
+  int get_num_events() const;
+  GestureEvent get_event(int index) const;
+public:
+  virtual void output(std::ostream &out) const;
+
+  void add_magnification_event(double magnification, GesturePhase phase, int seq, double time);
+
+private:
+  typedef pdeque<GestureEvent> Events;
+  Events _events;
+
+/**
+ * TypedObject implementation
+ */
+
+public:
+  static TypeHandle get_class_type() {
+    return _type_handle;
+  }
+  static void init_type() {
+    ParamValueBase::init_type();
+    register_type(_type_handle, "GestureEventList",
+                  ParamValueBase::get_class_type());
+  }
+  virtual TypeHandle get_type() const {
+    return get_class_type();
+  }
+  virtual TypeHandle force_init_type() {init_type(); return get_class_type();}
+
+private:
+  static TypeHandle _type_handle;
+};
+
+#endif

--- a/panda/src/event/gestureEvent.h
+++ b/panda/src/event/gestureEvent.h
@@ -29,8 +29,18 @@ public:
 
   virtual ~GestureEvent() {}
 
-  // Only valid if _type == MAGNIFICATION
-  double _magnification = 0.0;
+  // Which one of these union values is valid depends on _type
+  union {
+    // Only valid if _type == MAGNIFICATION
+    double magnification;
+    // Only valid if _type == ROTATION
+    double rotation;
+    // Only valid if _type == SWIPE
+    struct {
+      double deltaX;
+      double deltaY;
+    } swipe;
+  } _gestureData;
 
 /**
  * TypedObject implementation

--- a/panda/src/event/gestureEvent.h
+++ b/panda/src/event/gestureEvent.h
@@ -74,6 +74,7 @@ public:
   virtual void output(std::ostream &out) const;
 
   void add_magnification_event(double magnification, GesturePhase phase, int seq, double time);
+  void add_rotation_event(double rotation, GesturePhase phase, int seq, double time);
 
 private:
   typedef pdeque<GestureEvent> Events;

--- a/panda/src/event/p3event_composite1.cxx
+++ b/panda/src/event/p3event_composite1.cxx
@@ -10,3 +10,4 @@
 #include "genericAsyncTask.cxx"
 #include "pointerEvent.cxx"
 #include "pointerEventList.cxx"
+#include "gestureEvent.cxx"

--- a/panda/src/tform/mouseWatcher.cxx
+++ b/panda/src/tform/mouseWatcher.cxx
@@ -1485,13 +1485,6 @@ do_transmit_data(DataGraphTraverser *trav, const DataNodeTransmit &input,
     int num_events = this_gesture_events->get_num_events();
     for (int i = 0; i < num_events; i++) {
       const GestureEvent &ge = this_gesture_events->get_event(i);
-
-      if (ge._type == GestureType::MAGNIFICATION) {
-        tform_cat.info() << "Magnification gesture!\n";
-      } else {
-        tform_cat.info() << "um no something else what!\n";
-      }
-
       throw_gesture_event(ge);
     }
 

--- a/panda/src/tform/mouseWatcher.cxx
+++ b/panda/src/tform/mouseWatcher.cxx
@@ -893,11 +893,45 @@ throw_event_pattern(const string &pattern, const MouseWatcherRegion *region,
     }
   }
 
+  tform_cat.info() << button_name << " event empty? " << event.empty() << "\n";
+
   if (!event.empty()) {
     throw_event(event, EventParameter(region), EventParameter(button_name));
     if (_eh != nullptr)
       throw_event_directly(*_eh, event, EventParameter(region),
                            EventParameter(button_name));
+  }
+}
+
+
+void MouseWatcher::
+throw_gesture_event(const GestureEvent &ge) {
+  string event_suffix = "";
+
+  switch (ge._phase) {
+  case GesturePhase::BEGAN:
+    event_suffix = "_began"; break;
+  case GesturePhase::ENDED:
+    event_suffix = "_ended"; break;
+  case GesturePhase::CANCELLED:
+    event_suffix = "_cancelled"; break;
+  default:
+    break;
+  }
+
+  switch (ge._type) {
+  case GestureType::MAGNIFICATION:
+    throw_event("magnification" + event_suffix, EventParameter(ge._gestureData.magnification));
+    break;
+  case GestureType::ROTATION:
+    throw_event("rotation" + event_suffix, EventParameter(ge._gestureData.rotation));
+    break;
+  case GestureType::SWIPE:
+    throw_event("swipe" + event_suffix, EventParameter(ge._gestureData.swipe.deltaX), EventParameter(ge._gestureData.swipe.deltaY));
+    break;
+  default:
+    tform_cat.error()
+          << "Unknown gesture type: " << static_cast<std::underlying_type<GestureType>::type>(ge._type) << "\n";
   }
 }
 
@@ -1457,6 +1491,8 @@ do_transmit_data(DataGraphTraverser *trav, const DataNodeTransmit &input,
       } else {
         tform_cat.info() << "um no something else what!\n";
       }
+
+      throw_gesture_event(ge);
     }
 
   }

--- a/panda/src/tform/mouseWatcher.cxx
+++ b/panda/src/tform/mouseWatcher.cxx
@@ -51,6 +51,7 @@ MouseWatcher(const string &name) :
   _xy_input = define_input("xy", EventStoreVec2::get_class_type());
   _button_events_input = define_input("button_events", ButtonEventList::get_class_type());
   _pointer_events_input = define_input("pointer_events", PointerEventList::get_class_type());
+  _gesture_events_input = define_input("gesture_events", GestureEventList::get_class_type());
 
   _pixel_xy_output = define_output("pixel_xy", EventStoreVec2::get_class_type());
   _pixel_size_output = define_output("pixel_size", EventStoreVec2::get_class_type());
@@ -1440,6 +1441,24 @@ do_transmit_data(DataGraphTraverser *trav, const DataNodeTransmit &input,
     // released a button (particularly likely with a touchscreen input that's
     // emulating a mouse).
     set_no_mouse();
+  }
+
+  if (input.has_data(_gesture_events_input)) {
+    tform_cat.info() << "Gesture event input!\n";
+    const GestureEventList *this_gesture_events;
+    DCAST_INTO_V(this_gesture_events, input.get_data(_gesture_events_input).get_ptr());
+
+    int num_events = this_gesture_events->get_num_events();
+    for (int i = 0; i < num_events; i++) {
+      const GestureEvent &ge = this_gesture_events->get_event(i);
+
+      if (ge._type == GestureType::MAGNIFICATION) {
+        tform_cat.info() << "Magnification gesture!\n";
+      } else {
+        tform_cat.info() << "um no something else what!\n";
+      }
+    }
+
   }
 
   // Now check the inactivity timer.

--- a/panda/src/tform/mouseWatcher.h
+++ b/panda/src/tform/mouseWatcher.h
@@ -277,6 +277,7 @@ private:
   int _xy_input;
   int _button_events_input;
   int _pointer_events_input;
+  int _gesture_events_input;
 
   // outputs
   int _pixel_xy_output;

--- a/panda/src/tform/mouseWatcher.h
+++ b/panda/src/tform/mouseWatcher.h
@@ -32,6 +32,7 @@
 #include "clockObject.h"
 #include "pvector.h"
 #include "displayRegion.h"
+#include "gestureEvent.h"
 
 class MouseWatcherParameter;
 class DisplayRegion;
@@ -175,6 +176,8 @@ protected:
   void throw_event_pattern(const std::string &pattern,
                            const MouseWatcherRegion *region,
                            const ButtonHandle &button);
+
+  void throw_gesture_event(const GestureEvent &ge);
 
   void move();
   void press(ButtonHandle button, bool keyrepeat);


### PR DESCRIPTION
## Issue description
See #1541

## Solution description
This adds a new hardware event type alongside ButtonEvent and PointerEvent called GestureEvent. GestureEvent follows the pattern of PointerEvent, mostly, but is distinct in some important ways that make it incompatible. For starters, a gesture event has the idea of a gesture phase, as it's tracking a single gesture over time.

The events fired follow a naming pattern after the phase; e.g. for the `MAGNIFICATION` gesture type, we have `magnification_began`, `magnification`, `magnification_ended` and `magnification_cancelled`.

That being said - this is a pretty 1:1 interpretation of gestures on Apple platforms (UIGestureRecognizer on iOS gives pretty much the same pattern, though I haven't added an implementation for it). I haven't looked in to how Windows or Linux provide this information, though I suspect it'll be pretty similar?

There's also the possibility of using the system-provided gesture recognisers e.g. `NSGestureRecognizer`, `UIGestureRecognizer`, `Microsoft.UI.Input.GestureRecognizer`. These allow for some more complex behaviours like gesture priority and exclusion. However, I think at that point we're maybe approaching the edge of what Panda is for…

TODO:
* [ ] Add implementation for GestureType::SWIPE on macOS
* [ ] Add some test cases (help please? how to do this?)

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
