### PR TITLE
Added missing control message types

### DIFF
--- a/direct/src/distributed/MsgTypes.py
+++ b/direct/src/distributed/MsgTypes.py
@@ -42,6 +42,9 @@ CONTROL_ADD_RANGE =                               9002
 CONTROL_REMOVE_RANGE =                            9003
 CONTROL_ADD_POST_REMOVE =                         9010
 CONTROL_CLEAR_POST_REMOVES =                      9011
+CONTROL_SET_CON_NAME =                            9012
+CONTROL_SET_CON_URL =                             9013
+CONTROL_LOG_MESSAGE =                             9014
 
 # State Server control messages:
 STATESERVER_CREATE_OBJECT_WITH_REQUIRED =         2000


### PR DESCRIPTION
## Issue description
Distributed MsgTypes is missing certain control (MD) messages, mostly used for telemetry and debugging.

## Solution description
Added the missing message types. See [Astron](https://github.com/Astron/Astron/blob/master/src/core/msgtypes.h#L39) and [Ardos](https://github.com/ksmit799/Ardos/blob/main/src/net/message_types.h#L41) for reference.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
