### PR TITLE
pgui: Add more property-style accessors

### DIFF
--- a/panda/src/pgui/pgEntry.h
+++ b/panda/src/pgui/pgEntry.h
@@ -80,6 +80,7 @@ PUBLISHED:
 
   INLINE void set_cursor_position(int position);
   INLINE int get_cursor_position() const;
+  MAKE_PROPERTY(cursor_position, get_cursor_position, set_cursor_position);
 
   INLINE PN_stdfloat get_cursor_X() const;
   INLINE PN_stdfloat get_cursor_Y() const;
@@ -90,33 +91,45 @@ PUBLISHED:
   INLINE PN_stdfloat get_max_width() const;
   INLINE void set_num_lines(int num_lines);
   INLINE int get_num_lines() const;
+  MAKE_PROPERTY(max_chars, get_max_chars, set_max_chars);
+  MAKE_PROPERTY(max_width, get_max_width, set_max_width);
+  MAKE_PROPERTY(num_lines, get_num_lines, set_num_lines);
 
   INLINE void set_blink_rate(PN_stdfloat blink_rate);
   INLINE PN_stdfloat get_blink_rate() const;
+  MAKE_PROPERTY(blink_rate, get_blink_rate, set_blink_rate);
 
   INLINE NodePath get_cursor_def();
   INLINE void clear_cursor_def();
+  MAKE_PROPERTY(cursor_def, get_cursor_def);
 
   INLINE void set_cursor_keys_active(bool flag);
   INLINE bool get_cursor_keys_active() const;
+  MAKE_PROPERTY(cursor_keys_active, get_cursor_keys_active, set_cursor_keys_active);
 
   INLINE void set_obscure_mode(bool flag);
   INLINE bool get_obscure_mode() const;
+  MAKE_PROPERTY(obscure_mode, get_obscure_mode, set_obscure_mode);
 
   INLINE void set_overflow_mode(bool flag);
   INLINE bool get_overflow_mode() const;
+  MAKE_PROPERTY(overflow_mode, get_overflow_mode, set_overflow_mode);
 
   INLINE void set_candidate_active(const std::string &candidate_active);
   INLINE const std::string &get_candidate_active() const;
+  MAKE_PROPERTY(candidate_active, get_candidate_active, set_candidate_active);
 
   INLINE void set_candidate_inactive(const std::string &candidate_inactive);
   INLINE const std::string &get_candidate_inactive() const;
+  MAKE_PROPERTY(candidate_inactive, get_candidate_inactive, set_candidate_inactive);
 
   void set_text_def(int state, TextNode *node);
   TextNode *get_text_def(int state) const;
 
   virtual void set_active(bool active) final;
   virtual void set_focus(bool focus);
+  MAKE_PROPERTY(active, get_active, set_active);
+  MAKE_PROPERTY(focus, get_focus, set_focus);
 
   INLINE static std::string get_accept_prefix();
   INLINE static std::string get_accept_failed_prefix();
@@ -132,6 +145,12 @@ PUBLISHED:
   INLINE std::string get_erase_event() const;
   INLINE std::string get_cursormove_event() const;
 
+  MAKE_PROPERTY(accept_prefix, get_accept_prefix);
+  MAKE_PROPERTY(accept_failed_prefix, get_accept_failed_prefix);
+  MAKE_PROPERTY(overflow_prefix, get_overflow_prefix);
+  MAKE_PROPERTY(type_prefix, get_type_prefix);
+  MAKE_PROPERTY(erase_prefix, get_erase_prefix);
+  MAKE_PROPERTY(cursormove_prefix, get_cursormove_prefix);
 
   INLINE bool set_wtext(const std::wstring &wtext);
   INLINE std::wstring get_plain_wtext() const;

--- a/panda/src/pgui/pgFrameStyle.h
+++ b/panda/src/pgui/pgFrameStyle.h
@@ -47,27 +47,33 @@ PUBLISHED:
 
   INLINE void set_type(Type type);
   INLINE Type get_type() const;
+  MAKE_PROPERTY(type, get_type, set_type);
 
   INLINE void set_color(PN_stdfloat r, PN_stdfloat g, PN_stdfloat b, PN_stdfloat a);
   INLINE void set_color(const LColor &color);
   INLINE LColor get_color() const;
+  MAKE_PROPERTY(color, get_color, set_color);
 
   INLINE void set_texture(Texture *texture);
   INLINE bool has_texture() const;
   INLINE Texture *get_texture() const;
   INLINE void clear_texture();
+  MAKE_PROPERTY2(texture, has_texture, get_texture, set_texture, clear_texture);
 
   INLINE void set_width(PN_stdfloat x, PN_stdfloat y);
   INLINE void set_width(const LVecBase2 &width);
   INLINE const LVecBase2 &get_width() const;
+  MAKE_PROPERTY(width, get_width, set_width);
 
   INLINE void set_uv_width(PN_stdfloat u, PN_stdfloat v);
   INLINE void set_uv_width(const LVecBase2 &uv_width);
   INLINE const LVecBase2 &get_uv_width() const;
+  MAKE_PROPERTY(uv_width, get_uv_width, set_uv_width);
 
   INLINE void set_visible_scale(PN_stdfloat x, PN_stdfloat y);
   INLINE void set_visible_scale(const LVecBase2 &visible_scale);
   INLINE const LVecBase2 &get_visible_scale() const;
+  MAKE_PROPERTY(visible_scale, get_visible_scale, set_visible_scale);
 
   LVecBase4 get_internal_frame(const LVecBase4 &frame) const;
 

--- a/panda/src/pgui/pgItem.h
+++ b/panda/src/pgui/pgItem.h
@@ -132,6 +132,7 @@ PUBLISHED:
   bool has_state_def(int state) const;
   INLINE NodePath &get_state_def(int state);
   MAKE_SEQ(get_state_defs, get_num_state_defs, get_state_def);
+  MAKE_SEQ_PROPERTY(state_defs, get_num_state_defs, get_state_def);
   NodePath instance_to_state_def(int state, const NodePath &path);
 
   PGFrameStyle get_frame_style(int state);
@@ -170,6 +171,17 @@ PUBLISHED:
   INLINE std::string get_repeat_event(const ButtonHandle &button) const;
   INLINE std::string get_release_event(const ButtonHandle &button) const;
   INLINE std::string get_keystroke_event() const;
+
+  MAKE_PROPERTY(enter_prefix, get_enter_prefix);
+  MAKE_PROPERTY(exit_prefix, get_exit_prefix);
+  MAKE_PROPERTY(within_prefix, get_within_prefix);
+  MAKE_PROPERTY(without_prefix, get_without_prefix);
+  MAKE_PROPERTY(focus_in_prefix, get_focus_in_prefix);
+  MAKE_PROPERTY(focus_out_prefix, get_focus_out_prefix);
+  MAKE_PROPERTY(press_prefix, get_press_prefix);
+  MAKE_PROPERTY(repeat_prefix, get_repeat_prefix);
+  MAKE_PROPERTY(release_prefix, get_release_prefix);
+  MAKE_PROPERTY(keystroke_prefix, get_keystroke_prefix);
 
   INLINE LMatrix4 get_frame_inv_xform() const;
 

--- a/panda/src/pgui/pgScrollFrame.h
+++ b/panda/src/pgui/pgScrollFrame.h
@@ -56,20 +56,27 @@ PUBLISHED:
   INLINE const LVecBase4 &get_virtual_frame() const;
   INLINE bool has_virtual_frame() const;
   INLINE void clear_virtual_frame();
+  MAKE_PROPERTY2(virtual_frame,
+                 has_virtual_frame, get_virtual_frame,
+                 set_virtual_frame, clear_virtual_frame);
 
   INLINE void set_manage_pieces(bool manage_pieces);
   INLINE bool get_manage_pieces() const;
+  MAKE_PROPERTY(manage_pieces, get_manage_pieces, set_manage_pieces);
 
   INLINE void set_auto_hide(bool auto_hide);
   INLINE bool get_auto_hide() const;
+  MAKE_PROPERTY(auto_hide, get_auto_hide, set_auto_hide);
 
   INLINE void set_horizontal_slider(PGSliderBar *horizontal_slider);
   INLINE void clear_horizontal_slider();
   INLINE PGSliderBar *get_horizontal_slider() const;
+  MAKE_PROPERTY(horizontal_slider, get_horizontal_slider, set_horizontal_slider);
 
   INLINE void set_vertical_slider(PGSliderBar *vertical_slider);
   INLINE void clear_vertical_slider();
   INLINE PGSliderBar *get_vertical_slider() const;
+  MAKE_PROPERTY(vertical_slider, get_vertical_slider, set_vertical_slider);
 
   void remanage();
   INLINE void recompute();

--- a/panda/src/pgui/pgScrollFrame.h
+++ b/panda/src/pgui/pgScrollFrame.h
@@ -71,12 +71,16 @@ PUBLISHED:
   INLINE void set_horizontal_slider(PGSliderBar *horizontal_slider);
   INLINE void clear_horizontal_slider();
   INLINE PGSliderBar *get_horizontal_slider() const;
-  MAKE_PROPERTY(horizontal_slider, get_horizontal_slider, set_horizontal_slider);
+  MAKE_PROPERTY2(horizontal_slider,
+                 get_horizontal_slider, get_horizontal_slider,
+                 set_horizontal_slider, clear_horizontal_slider);
 
   INLINE void set_vertical_slider(PGSliderBar *vertical_slider);
   INLINE void clear_vertical_slider();
   INLINE PGSliderBar *get_vertical_slider() const;
-  MAKE_PROPERTY(vertical_slider, get_vertical_slider, set_vertical_slider);
+  MAKE_PROPERTY2(vertical_slider,
+                 get_vertical_slider, get_vertical_slider,
+                 set_vertical_slider, clear_vertical_slider);
 
   void remanage();
   INLINE void recompute();

--- a/panda/src/pgui/pgSliderBar.h
+++ b/panda/src/pgui/pgSliderBar.h
@@ -92,17 +92,23 @@ PUBLISHED:
   INLINE void set_thumb_button(PGButton *thumb_button);
   INLINE void clear_thumb_button();
   INLINE PGButton *get_thumb_button() const;
-  MAKE_PROPERTY(thumb_button, get_thumb_button, set_thumb_button);
+  MAKE_PROPERTY2(thumb_button,
+                 get_thumb_button, get_thumb_button,
+                 set_thumb_button, clear_thumb_button);
 
   INLINE void set_left_button(PGButton *left_button);
   INLINE void clear_left_button();
   INLINE PGButton *get_left_button() const;
-  MAKE_PROPERTY(left_button, get_left_button, set_left_button);
+  MAKE_PROPERTY2(left_button,
+                 get_left_button, get_left_button,
+                 set_left_button, clear_left_button);
 
   INLINE void set_right_button(PGButton *right_button);
   INLINE void clear_right_button();
   INLINE PGButton *get_right_button() const;
-  MAKE_PROPERTY(right_button, get_right_button, set_right_button);
+  MAKE_PROPERTY2(right_button,
+                 get_right_button, get_right_button,
+                 set_right_button, clear_right_button);
 
   INLINE static std::string get_adjust_prefix();
   INLINE std::string get_adjust_event() const;

--- a/panda/src/pgui/pgSliderBar.h
+++ b/panda/src/pgui/pgSliderBar.h
@@ -56,6 +56,7 @@ PUBLISHED:
 
   INLINE void set_axis(const LVector3 &axis);
   INLINE const LVector3 &get_axis() const;
+  MAKE_PROPERTY(axis, get_axis, set_axis);
 
   INLINE void set_range(PN_stdfloat min_value, PN_stdfloat max_value);
   INLINE PN_stdfloat get_min_value() const;
@@ -63,40 +64,52 @@ PUBLISHED:
 
   INLINE void set_scroll_size(PN_stdfloat scroll_size);
   INLINE PN_stdfloat get_scroll_size() const;
+  MAKE_PROPERTY(scroll_size, get_scroll_size, set_scroll_size);
 
   INLINE void set_page_size(PN_stdfloat page_size);
   INLINE PN_stdfloat get_page_size() const;
+  MAKE_PROPERTY(page_size, get_page_size, set_page_size);
 
   INLINE void set_value(PN_stdfloat value);
   INLINE PN_stdfloat get_value() const;
+  MAKE_PROPERTY(value, get_value, set_value);
 
   INLINE void set_ratio(PN_stdfloat ratio);
   INLINE PN_stdfloat get_ratio() const;
+  MAKE_PROPERTY(ratio, get_ratio, set_ratio);
 
   INLINE bool is_button_down() const;
+  MAKE_PROPERTY(button_down, is_button_down);
 
   INLINE void set_resize_thumb(bool resize_thumb);
   INLINE bool get_resize_thumb() const;
+  MAKE_PROPERTY(resize_thumb, get_resize_thumb, set_resize_thumb);
 
   INLINE void set_manage_pieces(bool manage_pieces);
   INLINE bool get_manage_pieces() const;
+  MAKE_PROPERTY(manage_pieces, get_manage_pieces, set_manage_pieces);
 
   INLINE void set_thumb_button(PGButton *thumb_button);
   INLINE void clear_thumb_button();
   INLINE PGButton *get_thumb_button() const;
+  MAKE_PROPERTY(thumb_button, get_thumb_button, set_thumb_button);
 
   INLINE void set_left_button(PGButton *left_button);
   INLINE void clear_left_button();
   INLINE PGButton *get_left_button() const;
+  MAKE_PROPERTY(left_button, get_left_button, set_left_button);
 
   INLINE void set_right_button(PGButton *right_button);
   INLINE void clear_right_button();
   INLINE PGButton *get_right_button() const;
+  MAKE_PROPERTY(right_button, get_right_button, set_right_button);
 
   INLINE static std::string get_adjust_prefix();
   INLINE std::string get_adjust_event() const;
+  MAKE_PROPERTY(adjust_prefix, get_adjust_prefix);
 
   virtual void set_active(bool active) final;
+  MAKE_PROPERTY(active, get_active, set_active);
 
   void remanage();
   void recompute();

--- a/panda/src/pgui/pgTop.h
+++ b/panda/src/pgui/pgTop.h
@@ -51,9 +51,12 @@ PUBLISHED:
   void set_mouse_watcher(MouseWatcher *watcher);
   INLINE MouseWatcher *get_mouse_watcher() const;
   INLINE MouseWatcherGroup *get_group() const;
+  MAKE_PROPERTY(mouse_watcher, get_mouse_watcher, set_mouse_watcher);
+  MAKE_PROPERTY(group, get_group);
 
   INLINE void set_start_sort(int start_sort);
   INLINE int get_start_sort() const;
+  MAKE_PROPERTY(start_sort, get_start_sort, set_start_sort);
 
 public:
   // These methods duplicate the functionality of MouseWatcherGroup.

--- a/panda/src/pgui/pgVirtualFrame.h
+++ b/panda/src/pgui/pgVirtualFrame.h
@@ -59,12 +59,16 @@ PUBLISHED:
   INLINE const LVecBase4 &get_clip_frame() const;
   INLINE bool has_clip_frame() const;
   void clear_clip_frame();
+  MAKE_PROPERTY2(clip_frame, has_clip_frame, get_clip_frame, set_clip_frame, clear_clip_frame);
 
   INLINE void set_canvas_transform(const TransformState *transform);
   INLINE const TransformState *get_canvas_transform() const;
+  MAKE_PROPERTY(canvas_transform, get_canvas_transform, set_canvas_transform);
 
   INLINE PandaNode *get_canvas_node() const;
   INLINE PandaNode *get_canvas_parent() const;
+  MAKE_PROPERTY(canvas_node, get_canvas_node);
+  MAKE_PROPERTY(canvas_parent, get_canvas_parent);
 
 protected:
   virtual void clip_frame_changed();

--- a/panda/src/pgui/pgWaitBar.h
+++ b/panda/src/pgui/pgWaitBar.h
@@ -40,14 +40,17 @@ PUBLISHED:
 
   INLINE void set_range(PN_stdfloat range);
   INLINE PN_stdfloat get_range() const;
+  MAKE_PROPERTY(range, get_range, set_range);
 
   INLINE void set_value(PN_stdfloat value);
   INLINE PN_stdfloat get_value() const;
+  MAKE_PROPERTY(value, get_value, set_value);
 
   INLINE PN_stdfloat get_percent() const;
 
   INLINE void set_bar_style(const PGFrameStyle &style);
   INLINE PGFrameStyle get_bar_style() const;
+  MAKE_PROPERTY(bar_style, get_bar_style, set_bar_style);
 
 private:
   void update();


### PR DESCRIPTION
## Change description
These changes just allow for property-style access from Python to data in various `pgui` classes.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
