### PR TITLE
fix no display build case

### DIFF
--- a/panda/src/tinydisplay/CMakeLists.txt
+++ b/panda/src/tinydisplay/CMakeLists.txt
@@ -119,6 +119,10 @@ unset(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME)
 
 set_target_properties(p3tinydisplay PROPERTIES DEFINE_SYMBOL BUILDING_TINYDISPLAY)
 
+if (NOT (WIN32 OR HAVE_X11 OR HAVE_COCOA))
+  target_link_libraries(p3tinydisplay panda)
+endif()
+
 install(TARGETS p3tinydisplay
   EXPORT TinyDisplay COMPONENT TinyDisplay
   DESTINATION ${MODULE_DESTINATION}


### PR DESCRIPTION
Can happen when no android, no emscripten and no regular display set but with tinydisplay set which could be wasi case.
