### PR TITLE
showbase: Annotate basic `ShowBase` setup/shutdown methods

### DIFF
--- a/direct/src/directbase/TestStart.py
+++ b/direct/src/directbase/TestStart.py
@@ -8,6 +8,9 @@ base = ShowBase.ShowBase()
 # Put an axis in the world:
 base.loader.loadModel("models/misc/xyzAxis").reparentTo(base.render)
 
+assert base.camera is not None
+assert base.camLens is not None
+
 base.camera.setPosHpr(0, -10.0, 0, 0, 0, 0)
 base.camLens.setFov(52.0)
 base.camLens.setNearFar(1.0, 10000.0)

--- a/direct/src/directbase/ThreeUpStart.py
+++ b/direct/src/directbase/ThreeUpStart.py
@@ -10,6 +10,9 @@ base = ThreeUpShow.ThreeUpShow()
 # Put an axis in the world:
 base.loader.loadModel("models/misc/xyzAxis").reparentTo(base.render)
 
+assert base.camera is not None
+assert base.camLens is not None
+
 base.camera.setPosHpr(0, -10.0, 0, 0, 0, 0)
 base.camLens.setFov(52.0)
 base.camLens.setNearFar(1.0, 10000.0)

--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -122,9 +122,11 @@ from . import DConfig
 from direct.extensions_native import NodePath_extensions # pylint: disable=unused-import
 
 # This needs to be available early for DirectGUI imports
+from typing import Any
+builtins: Any  # Tell mypy not to worry about us setting attributes on builtins
 import sys
 import builtins
-builtins.config = DConfig  # type: ignore[attr-defined]
+builtins.config = DConfig
 
 from direct.directnotify.DirectNotifyGlobal import directNotify, giveNotify
 from direct.directnotify.Notifier import Notifier
@@ -145,7 +147,7 @@ import importlib
 from direct.showbase import ExceptionVarDump
 from . import DirectObject
 from . import SfxPlayer
-from typing import Any, Callable, ClassVar, Literal, NoReturn
+from typing import Callable, ClassVar, Literal, NoReturn
 if __debug__:
     from direct.showbase import GarbageReport
     from direct.directutil import DeltaProfiler
@@ -193,7 +195,7 @@ class ShowBase(DirectObject.DirectObject):
         #: Set if the want-dev Config.prc variable is enabled.  By default, it
         #: is set to True except when using Python with the -O flag.
         self.__dev__ = ShowBaseGlobal.__dev__
-        builtins.__dev__ = self.__dev__  # type: ignore[attr-defined]
+        builtins.__dev__ = self.__dev__
 
         logStackDump = (ConfigVariableBool('log-stack-dump', False).value or
                         ConfigVariableBool('client-log-stack-dump', False).value)
@@ -517,41 +519,41 @@ class ShowBase(DirectObject.DirectObject):
 
         # DO NOT ADD TO THIS LIST.  We're trying to phase out the use of
         # built-in variables by ShowBase.  Use a Global module if necessary.
-        builtins.base = self  # type: ignore[attr-defined]
-        builtins.render2d = self.render2d  # type: ignore[attr-defined]
-        builtins.aspect2d = self.aspect2d  # type: ignore[attr-defined]
-        builtins.pixel2d = self.pixel2d  # type: ignore[attr-defined]
-        builtins.render = self.render  # type: ignore[attr-defined]
-        builtins.hidden = self.hidden  # type: ignore[attr-defined]
-        builtins.camera = self.camera  # type: ignore[attr-defined]
-        builtins.loader = self.loader  # type: ignore[attr-defined]
-        builtins.taskMgr = self.taskMgr  # type: ignore[attr-defined]
-        builtins.jobMgr = self.jobMgr  # type: ignore[attr-defined]
-        builtins.eventMgr = self.eventMgr  # type: ignore[attr-defined]
-        builtins.messenger = self.messenger  # type: ignore[attr-defined]
-        builtins.bboard = self.bboard  # type: ignore[attr-defined]
+        builtins.base = self
+        builtins.render2d = self.render2d
+        builtins.aspect2d = self.aspect2d
+        builtins.pixel2d = self.pixel2d
+        builtins.render = self.render
+        builtins.hidden = self.hidden
+        builtins.camera = self.camera
+        builtins.loader = self.loader
+        builtins.taskMgr = self.taskMgr
+        builtins.jobMgr = self.jobMgr
+        builtins.eventMgr = self.eventMgr
+        builtins.messenger = self.messenger
+        builtins.bboard = self.bboard
         # Config needs to be defined before ShowBase is constructed
         #builtins.config = self.config
-        builtins.ostream = Notify.out()  # type: ignore[attr-defined]
-        builtins.directNotify = directNotify  # type: ignore[attr-defined]
-        builtins.giveNotify = giveNotify  # type: ignore[attr-defined]
-        builtins.globalClock = clock  # type: ignore[attr-defined]
-        builtins.vfs = vfs  # type: ignore[attr-defined]
-        builtins.cpMgr = ConfigPageManager.getGlobalPtr()  # type: ignore[attr-defined]
-        builtins.cvMgr = ConfigVariableManager.getGlobalPtr()  # type: ignore[attr-defined]
-        builtins.pandaSystem = PandaSystem.getGlobalPtr()  # type: ignore[attr-defined]
+        builtins.ostream = Notify.out()
+        builtins.directNotify = directNotify
+        builtins.giveNotify = giveNotify
+        builtins.globalClock = clock
+        builtins.vfs = vfs
+        builtins.cpMgr = ConfigPageManager.getGlobalPtr()
+        builtins.cvMgr = ConfigVariableManager.getGlobalPtr()
+        builtins.pandaSystem = PandaSystem.getGlobalPtr()
         if __debug__:
-            builtins.deltaProfiler = DeltaProfiler.DeltaProfiler("ShowBase")  # type: ignore[attr-defined]
+            builtins.deltaProfiler = DeltaProfiler.DeltaProfiler("ShowBase")
             self.onScreenDebug = OnScreenDebug.OnScreenDebug()
-            builtins.onScreenDebug = self.onScreenDebug  # type: ignore[attr-defined]
+            builtins.onScreenDebug = self.onScreenDebug
 
         if self.wantRender2dp:
-            builtins.render2dp = self.render2dp  # type: ignore[attr-defined]
-            builtins.aspect2dp = self.aspect2dp  # type: ignore[attr-defined]
-            builtins.pixel2dp = self.pixel2dp  # type: ignore[attr-defined]
+            builtins.render2dp = self.render2dp
+            builtins.aspect2dp = self.aspect2dp
+            builtins.pixel2dp = self.pixel2dp
 
         # Now add this instance to the ShowBaseGlobal module scope.
-        builtins.run = ShowBaseGlobal.run  # type: ignore[attr-defined]
+        builtins.run = ShowBaseGlobal.run
         ShowBaseGlobal.base = self
         ShowBaseGlobal.__dev__ = self.__dev__
 
@@ -687,10 +689,10 @@ class ShowBase(DirectObject.DirectObject):
 
         # Remove the built-in base reference
         if getattr(builtins, 'base', None) is self:
-            del builtins.run  # type: ignore[attr-defined]
-            del builtins.base  # type: ignore[attr-defined]
-            del builtins.loader  # type: ignore[attr-defined]
-            del builtins.taskMgr  # type: ignore[attr-defined]
+            del builtins.run
+            del builtins.base
+            del builtins.loader
+            del builtins.taskMgr
             ShowBaseGlobal = sys.modules.get('direct.showbase.ShowBaseGlobal', None)
             if ShowBaseGlobal:
                 del ShowBaseGlobal.base

--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -102,7 +102,6 @@ from panda3d.core import (
     RescaleNormalAttrib,
     SceneGraphAnalyzerMeter,
     TexGenAttrib,
-    TexMemWatcher,
     Texture,
     TextureStage,
     Thread,
@@ -309,7 +308,7 @@ class ShowBase(DirectObject.DirectObject):
         self.mouseInterface: NodePath | None = None
         self.drive: NodePath | None = None
         self.trackball: NodePath | None = None
-        self.texmem: TexMemWatcher | None = None
+        self.texmem: Any | None = None
         self.showVertices: NodePath | None = None
         self.deviceButtonThrowers: list[NodePath] = []
 

--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -1190,7 +1190,7 @@ class ShowBase(DirectObject.DirectObject):
             self.setSceneGraphAnalyzerMeter(flag.value)
         return success
 
-    def setSleep(self, amount):
+    def setSleep(self, amount: float) -> None:
         """
         Sets up a task that calls python 'sleep' every frame.  This is a simple
         way to reduce the CPU usage (and frame rate) of a panda program.
@@ -1210,7 +1210,7 @@ class ShowBase(DirectObject.DirectObject):
         #time.sleep(self.clientSleep)
         return Task.cont
 
-    def setFrameRateMeter(self, flag):
+    def setFrameRateMeter(self, flag: bool) -> None:
         """
         Turns on or off (according to flag) a standard frame rate
         meter in the upper-right corner of the main window.
@@ -1224,7 +1224,7 @@ class ShowBase(DirectObject.DirectObject):
                 self.frameRateMeter.clearWindow()
                 self.frameRateMeter = None
 
-    def setSceneGraphAnalyzerMeter(self, flag):
+    def setSceneGraphAnalyzerMeter(self, flag: bool) -> None:
         """
         Turns on or off (according to flag) a standard frame rate
         meter in the upper-right corner of the main window.
@@ -1247,7 +1247,7 @@ class ShowBase(DirectObject.DirectObject):
                 mouseKeyboard = self.dataRoot.find("**/*"))
         self.winControls.append(winCtrl)
 
-    def setupRender(self):
+    def setupRender(self) -> None:
         """
         Creates the render scene graph, the primary scene graph for
         rendering 3-d geometry.
@@ -1257,11 +1257,11 @@ class ShowBase(DirectObject.DirectObject):
         self.render.setAttrib(RescaleNormalAttrib.makeDefault())
 
         self.render.setTwoSided(0)
-        self.backfaceCullingEnabled = 1
-        self.textureEnabled = 1
-        self.wireframeEnabled = 0
+        self.backfaceCullingEnabled = True
+        self.textureEnabled = True
+        self.wireframeEnabled = False
 
-    def setupRender2d(self):
+    def setupRender2d(self) -> None:
         """
         Creates the render2d scene graph, the primary scene graph for
         2-d objects and gui elements that are superimposed over the
@@ -1360,7 +1360,7 @@ class ShowBase(DirectObject.DirectObject):
         if xsize > 0 and ysize > 0:
             self.pixel2d.setScale(2.0 / xsize, 1.0, 2.0 / ysize)
 
-    def setupRender2dp(self):
+    def setupRender2dp(self) -> None:
         """
         Creates a render2d scene graph, the secondary scene graph for
         2-d objects and gui elements that are superimposed over the
@@ -1682,7 +1682,7 @@ class ShowBase(DirectObject.DirectObject):
 
         return camera2dp
 
-    def setupDataGraph(self):
+    def setupDataGraph(self) -> None:
         """
         Creates the data graph and populates it with the basic input
         devices.
@@ -2011,7 +2011,7 @@ class ShowBase(DirectObject.DirectObject):
             self.physicsMgr.doPhysics(dt)
         return Task.cont
 
-    def createStats(self, hostname=None, port=None):
+    def createStats(self, hostname: str | None = None, port: int | None = None) -> bool:
         """
         If want-pstats is set in Config.prc, or the `wantStats` member is
         otherwise set to True, connects to the PStats server.
@@ -2328,7 +2328,7 @@ class ShowBase(DirectObject.DirectObject):
         throw_new_frame()
         return Task.cont
 
-    def restart(self, clusterSync=False, cluster=None):
+    def restart(self, clusterSync: bool = False, cluster=None) -> None:
         self.shutdown()
         # __resetPrevTransform goes at the very beginning of the frame.
         self.taskMgr.add(

--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -380,7 +380,7 @@ class ShowBase(DirectObject.DirectObject):
         self.shadowTrav: CollisionTraverser | Literal[0] = 0
         self.cTravStack = Stack()
         # Ditto for an AppTraverser.
-        self.appTrav: CollisionTraverser | Literal[0] = 0
+        self.appTrav: Any | Literal[0] = 0
 
         # This is the DataGraph traverser, which we might as well
         # create now.


### PR DESCRIPTION
## Change description
These changes add type annotations to some basic `ShowBase` methods used on setup and shutdown. This mostly comprises adding annotations to attributes assigned in `ShowBase.__init__`. See also #1217, which aimed to do mostly the same thing, but seems to have been abandoned.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
