### PR TITLE
MeshDrawer: Add Notes to the Comment-Documentation for the "link_segment" Method Regarding Parameter Handling

### DIFF
--- a/panda/src/grutil/meshDrawer.cxx
+++ b/panda/src/grutil/meshDrawer.cxx
@@ -416,6 +416,11 @@ void MeshDrawer::geometry(NodePath draw_node) {
 /**
  * Stars or continues linked segment.  Control position, frame, thickness and
  * color with parameters.  Frame contains u,v,u-size,v-size quadruple.
+ * Note that for the first two calls to this method, the "frame" parameter is
+ * ignored; it first takes effect as of the third call.
+ * Similarly, note that in the second call to this method, the "color" parameter
+ * is ignored; it only has effect in the first call and calls from the third
+ * onwards.
  */
 void MeshDrawer::
 link_segment(const LVector3 &pos, const LVector4 &frame,


### PR DESCRIPTION
This pull request updates the leading comment for the "link_segment" method, intending thereby to update the documentation for the method.

In short, it adds notes regarding the manner in which the method makes use of the "frame" and "color" parameters.

## Issue description
This is intended to address issue #1560--that is, that MeshDrawer has some--to my mind--unexpected-but-I-gather-intended behaviour in its usage of its "frame" parameter. Specifically, that it only starts making use of the "frame" parameter as of the _third_ call to the method; the parameter is ignored in the first two calls.

While doing so, I realised that it has a similar issue with its "color" parameter--it's ignored in the second call to the method--and so likewise added a note on the matter.

## Solution description
Since actually changing the method could well break extant code, I've opted to simply document the behaviour in the leading comment before the method. My impression is that this is sourced for the API documentation, thus updating said documentation, and so hopefully at least alerting other developers to this behaviour in the future.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [ ] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
