### PR TITLE
bullet: Fix deadlock when contact added callback accesses certain data or executes bullet methods

### DIFF
--- a/panda/src/bullet/bulletContactCallbacks.h
+++ b/panda/src/bullet/bulletContactCallbacks.h
@@ -88,7 +88,12 @@ contact_added_callback(btManifoldPoint &cp,
       BulletManifoldPoint mp(cp);
       BulletContactCallbackData cbdata(mp, node0, node1, id0, id1, index0, index1);
 
+      // Release the world mutex object so that bullet methods can be called from the callback.
+      LightMutex &mutex = BulletWorld::get_global_lock();
+
+      mutex.release();
       bullet_contact_added_callback->do_callback(&cbdata);
+      mutex.acquire();
     }
   }
 


### PR DESCRIPTION
## Issue description
This change addresses note 2 within issue #1562.

## Solution description
This change assumes the mutex for BulletWorld is already locked (as it should be in `do_physics`), and releases the mutex before calling the contact added callback, then reacquires the mutex. 

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
