### PR TITLE
egg-palettize: fix writing Magfilter

### DIFF
--- a/pandatool/src/egg-palettize/txaFileFilter.cxx
+++ b/pandatool/src/egg-palettize/txaFileFilter.cxx
@@ -92,7 +92,7 @@ post_load(Texture *tex) {
   egg_tex->set_alpha_mode(tex_image.get_alpha_mode());
   egg_tex->set_format(props._format);
   egg_tex->set_minfilter(props._minfilter);
-  egg_tex->set_minfilter(props._magfilter);
+  egg_tex->set_magfilter(props._magfilter);
   egg_tex->set_anisotropic_degree(props._anisotropic_degree);
 
   tex->set_aux_data("egg", egg_tex);


### PR DESCRIPTION
Fixes a typo that applied the value from the Minfilter to the entry of the Magfilter when using `egg-palettize`.

## Issue description
Egg files that contained textures had the same value for the Magfilter applied that was set for the Minfilter. This was due to a typo in the code.

Reproducer:
1. Create a static font with `egg-mkfont`, using the palettize parameter.
2. Examine the created Egg file entries for the Textures `minfilter` and `magfilter`
3. `magfilter` will contain `linear_mipmap_linear` which should not be a valid magnification filter.

## Solution description
The fix will carry on using the correct magfilter value. For the reproducer above, the entry in the resulting Egg file will be `linear`.

I'm not sure whether we should add an assert when magfilter > FT_linear is being applied/whether this really should be an invalid value. https://github.com/panda3d/panda3d/blob/deb24afe18c6f40a74033b8b41a6231ac910ebee/pandatool/src/palettizer/txaLine.cxx#L498 sets `FT_linear_mipmap_linear` to magfilter, whereby it probably should be `FT_linear`.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
