### PR TITLE
fixes for a few docstrings

### DIFF
--- a/panda/src/express/multifile.I
+++ b/panda/src/express/multifile.I
@@ -68,7 +68,7 @@ get_timestamp() const {
 }
 
 /**
- * Changes the overall mudification timestamp of the multifile.  Note that this
+ * Changes the overall modification timestamp of the multifile.  Note that this
  * will be reset to the current time every time you modify a subfile.
  * Only set this if you know what you are doing!
  */

--- a/panda/src/gobj/texture.I
+++ b/panda/src/gobj/texture.I
@@ -1888,7 +1888,7 @@ set_filename(const Filename &filename) {
 }
 
 /**
- * Removes the alpha filename, if it was previously set.  See set_filename().
+ * Removes the filename, if it was previously set.  See set_filename().
  */
 INLINE void Texture::
 clear_filename() {
@@ -1904,8 +1904,8 @@ clear_filename() {
  * The Texture's get_filename() function returns the name of the image file
  * that was loaded into the buffer.  In the case where a texture specified two
  * separate files to load, a 1- or 3-channel color image and a 1-channel alpha
- * image, this Filename is update to contain the name of the image file that
- * was loaded into the buffer's alpha channel.
+ * image, the alpha_filename is updated to contain the name of the image file
+ * that was loaded into the buffer's alpha channel.
  */
 INLINE void Texture::
 set_alpha_filename(const Filename &alpha_filename) {
@@ -1935,7 +1935,7 @@ set_fullpath(const Filename &fullpath) {
 }
 
 /**
- * Removes the alpha fullpath, if it was previously set.  See set_fullpath().
+ * Removes the fullpath, if it was previously set.  See set_fullpath().
  */
 INLINE void Texture::
 clear_fullpath() {

--- a/panda/src/text/fontPool.I
+++ b/panda/src/text/fontPool.I
@@ -53,7 +53,7 @@ add_font(const std::string &filename, TextFont *font) {
 /**
  * Removes the indicated font from the pool, indicating it will never be
  * loaded again; the font may then be freed.  If this function is never
- * called, a reference count will be maintained on every font every loaded,
+ * called, a reference count will be maintained on every font ever loaded,
  * and fonts will never be freed.
  */
 INLINE void FontPool::


### PR DESCRIPTION
## Issue description
Minor, fixes a few docstrings around `FontPool` and `Texture`.

## Solution description
-

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
