### PR TITLE
Fixed bug with default values in DirectGui

### DIFF
--- a/direct/src/gui/DirectGuiBase.py
+++ b/direct/src/gui/DirectGuiBase.py
@@ -97,6 +97,8 @@ from .OnscreenImage import *
 from direct.directtools.DirectUtil import ROUND_TO
 from direct.showbase import DirectObject
 from direct.task import Task
+from collections.abc import MutableSequence, MutableMapping, MutableSet
+from copy import deepcopy
 import sys
 
 if sys.version_info >= (3, 0):
@@ -224,7 +226,10 @@ class DirectGuiBase(DirectObject.DirectObject):
                         del keywords[name]
                     else:
                         # Use optionDefs value
-                        optionInfo[name] = [default, default, function]
+                        value = default
+                        if isinstance(default, (MutableSequence, MutableMapping, MutableSet)):
+                            value = deepcopy(default)
+                        optionInfo[name] = [default, value, function]
                 elif optionInfo[name][FUNCTION] is None:
                     # Only override function if not defined by derived class
                     optionInfo[name][FUNCTION] = function


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
This change is intended to fix issue #1587. Where mutable options for DirectGui items could be changed after creation time by modifying the value of the option with `gui["option"]`. 

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
I have simple added a check to see it the option is mutable, and if it is save a copy of the object as the default value instead of the original object. This makes sure that modifying the current value does not change the default.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
