### PR TITLE
CMake: Force GCC/Clang color diagnostics for Ninja (#1596)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,25 @@ if(APPLE)
   endif()
 endif()
 
+# Enable 'FORCE_ANSI_COLORED_OUTPUT' option when using Ninja.
+# Forces GCC/Clang compilers to enable color diagnostics. Enabled by default.
+if(CMAKE_GENERATOR STREQUAL "Ninja")
+  option(FORCE_ANSI_COLORED_OUTPUT "Always produce ANSI-colored output. (GNU/Clang only)" TRUE)
+
+  if(FORCE_ANSI_COLORED_OUTPUT)
+    set(CMAKE_COLOR_DIAGNOSTICS ON)
+    # CMake versions 3.24 and below do not support this option, so we have
+    # to invoke the color diagnostics flags manually.
+    if(CMAKE_VERSION VERSION_LESS "3.24.0")
+      if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        add_compile_options(-fdiagnostics-color=always)
+      elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        add_compile_options(-fcolor-diagnostics)
+      endif()
+    endif()
+  endif()
+endif()
+
 # Figure out the version
 set(_s "[\\t ]*") # CMake doesn't support \s*
 file(STRINGS "setup.cfg" _version REGEX "^version${_s}=${_s}")


### PR DESCRIPTION
## Issue description
Linux users are recommended to use Ninja when generating the build files through CMake. Ninja buffers output, so tools are writing to a pipe, not directly to the terminal, so auto-detection may turn ANSI colored output off conservatively.

## Solution description
This PR forces color diagnostics by setting `CMAKE_COLOR_DIAGNOSTICS` to `ON` on CMake versions 3.24 and above. For older CMake versions, compiler flags are invoked manually for GCC and Clang.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
