### PR TITLE
Guard python specific extensions

### DIFF
--- a/panda/src/linmath/lmatrix3_ext_src.h
+++ b/panda/src/linmath/lmatrix3_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-12
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LMatrix3, which are called
  * instead of any C++ methods with the same prototype.
@@ -26,3 +28,5 @@ public:
 };
 
 #include "lmatrix3_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lmatrix4_ext_src.h
+++ b/panda/src/linmath/lmatrix4_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-12
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LMatrix4, which are called
  * instead of any C++ methods with the same prototype.
@@ -26,3 +28,5 @@ public:
 };
 
 #include "lmatrix4_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lpoint2_ext_src.h
+++ b/panda/src/linmath/lpoint2_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-13
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LPoint2, which are called
  * instead of any C++ methods with the same prototype.
@@ -27,3 +29,5 @@ public:
 };
 
 #include "lpoint2_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lpoint3_ext_src.h
+++ b/panda/src/linmath/lpoint3_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-13
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LPoint3, which are called
  * instead of any C++ methods with the same prototype.
@@ -27,3 +29,5 @@ public:
 };
 
 #include "lpoint3_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lpoint4_ext_src.h
+++ b/panda/src/linmath/lpoint4_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-13
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LPoint4, which are called
  * instead of any C++ methods with the same prototype.
@@ -27,3 +29,5 @@ public:
 };
 
 #include "lpoint4_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lvecBase2_ext_src.h
+++ b/panda/src/linmath/lvecBase2_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-13
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LVecBase2, which are called
  * instead of any C++ methods with the same prototype.
@@ -39,3 +41,5 @@ public:
 };
 
 #include "lvecBase2_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lvecBase3_ext_src.h
+++ b/panda/src/linmath/lvecBase3_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-13
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LVecBase3, which are called
  * instead of any C++ methods with the same prototype.
@@ -39,3 +41,5 @@ public:
 };
 
 #include "lvecBase3_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lvecBase4_ext_src.h
+++ b/panda/src/linmath/lvecBase4_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-13
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LVecBase4, which are called
  * instead of any C++ methods with the same prototype.
@@ -39,3 +41,5 @@ public:
 };
 
 #include "lvecBase4_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lvector2_ext_src.h
+++ b/panda/src/linmath/lvector2_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-13
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LVector2, which are called
  * instead of any C++ methods with the same prototype.
@@ -27,3 +29,5 @@ public:
 };
 
 #include "lvector2_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lvector3_ext_src.h
+++ b/panda/src/linmath/lvector3_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-13
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LVector3, which are called
  * instead of any C++ methods with the same prototype.
@@ -27,3 +29,5 @@ public:
 };
 
 #include "lvector3_ext_src.I"
+
+#endif

--- a/panda/src/linmath/lvector4_ext_src.h
+++ b/panda/src/linmath/lvector4_ext_src.h
@@ -11,6 +11,8 @@
  * @date 2013-09-13
  */
 
+#ifdef HAVE_PYTHON
+
 /**
  * This class defines the extension methods for LVector4, which are called
  * instead of any C++ methods with the same prototype.
@@ -27,3 +29,5 @@ public:
 };
 
 #include "lvector4_ext_src.I"
+
+#endif

--- a/panda/src/pipeline/CMakeLists.txt
+++ b/panda/src/pipeline/CMakeLists.txt
@@ -115,11 +115,9 @@ endif()
 
 set(P3PIPELINE_IGATEEXT
   pmutex_ext.h
-  pmutex_ext.I
   pythonThread.cxx
   pythonThread.h
   reMutex_ext.h
-  reMutex_ext.I
 )
 
 composite_sources(p3pipeline P3PIPELINE_SOURCES)

--- a/panda/src/putil/CMakeLists.txt
+++ b/panda/src/putil/CMakeLists.txt
@@ -129,20 +129,15 @@ set(P3PUTIL_IGATEEXT
   bamWriter_ext.h
   bitArray_ext.cxx
   bitArray_ext.h
-  bitArray_ext.I
   bitMask_ext.h
-  bitMask_ext.I
   callbackObject_ext.h
   doubleBitMask_ext.h
-  doubleBitMask_ext.I
   paramPyObject.cxx
   paramPyObject.h
-  paramPyObject.I
   pythonCallbackObject.cxx
   pythonCallbackObject.h
   sparseArray_ext.cxx
   sparseArray_ext.h
-  sparseArray_ext.I
   typedWritable_ext.cxx
   typedWritable_ext.h
 )

--- a/panda/src/putil/paramPyObject.cxx
+++ b/panda/src/putil/paramPyObject.cxx
@@ -13,6 +13,8 @@
 
 #include "paramPyObject.h"
 
+#ifdef HAVE_PYTHON
+
 TypeHandle ParamPyObject::_type_handle;
 
 /**
@@ -40,3 +42,5 @@ output(std::ostream &out) const {
   out << "<" << Py_TYPE(_value)->tp_name
       << " object at " << (void *)_value << ">";
 }
+
+#endif


### PR DESCRIPTION
## Issue description
This change adds proper guarding to methods that are specific to python bindings, allowing to build bindings for languages other than Python.

## Solution description
This PR has 2 commits. One focuses on removing `.I` files from `*_IGATEEXT` cmake variables since the `.I` files are not guarded for python support. The second adds some missing python guarding in a few header files.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
