### PR TITLE
ext: Use different names for each gen_next method

### DIFF
--- a/direct/src/interval/cInterval_ext.cxx
+++ b/direct/src/interval/cInterval_ext.cxx
@@ -24,7 +24,7 @@ extern struct Dtool_PyTypedObject Dtool_CInterval;
 /**
  * Yields continuously until the interval is done.
  */
-static PyObject *gen_next(PyObject *self) {
+static PyObject *gen_next_c_interval(PyObject *self) {
   const CInterval *ival;
   if (!Dtool_Call_ExtractThisPointer(self, Dtool_CInterval, (void **)&ival)) {
     return nullptr;
@@ -54,7 +54,7 @@ __await__(PyObject *self) {
   // we call this via Python.
   PyObject *result = PyObject_CallMethod(self, "start", nullptr);
   Py_XDECREF(result);
-  return Dtool_NewGenerator(self, &gen_next);
+  return Dtool_NewGenerator(self, &gen_next_c_interval);
 }
 
 #endif  // HAVE_PYTHON

--- a/dtool/src/dtoolutil/iostream_ext.cxx
+++ b/dtool/src/dtoolutil/iostream_ext.cxx
@@ -227,7 +227,7 @@ readlines(Py_ssize_t hint) {
 /**
  * Yields continuously to read all the lines from the istream.
  */
-static PyObject *gen_next(PyObject *self) {
+static PyObject *gen_next_istream(PyObject *self) {
   istream *stream = nullptr;
   if (!Dtool_Call_ExtractThisPointer(self, Dtool_std_istream, (void **)&stream)) {
     return nullptr;
@@ -247,7 +247,7 @@ static PyObject *gen_next(PyObject *self) {
  */
 PyObject *Extension<istream>::
 __iter__(PyObject *self) {
-  return Dtool_NewGenerator(self, &gen_next);
+  return Dtool_NewGenerator(self, &gen_next_istream);
 }
 
 /**

--- a/panda/src/event/asyncFuture_ext.cxx
+++ b/panda/src/event/asyncFuture_ext.cxx
@@ -132,7 +132,7 @@ static PyObject *get_done_result(const AsyncFuture *future) {
 /**
  * Yields continuously until the task has finished.
  */
-static PyObject *gen_next(PyObject *self) {
+static PyObject *gen_next_asyncfuture(PyObject *self) {
   const AsyncFuture *future = nullptr;
   if (!Dtool_Call_ExtractThisPointer(self, Dtool_AsyncFuture, (void **)&future)) {
     return nullptr;
@@ -158,7 +158,7 @@ static PyObject *gen_next(PyObject *self) {
  */
 PyObject *Extension<AsyncFuture>::
 __await__(PyObject *self) {
-  return Dtool_NewGenerator(self, &gen_next);
+  return Dtool_NewGenerator(self, &gen_next_asyncfuture);
 }
 
 /**


### PR DESCRIPTION
## Issue description
Building Panda3D with `CMAKE_UNITY_BUILD_BATCH_SIZE` set to a ridiculously large number (like 500) results in a compilation error due to `gen_next` being redefined multiple times.

## Solution description
Rename `gen_next` in each extension to provide a unique name in each case. Feel free to change the names I've chosen if they are inadequate.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
