### PR TITLE
Forward compatibility for splitting off net classes to separate panda3d.net

### DIFF
--- a/cmake/macros/Interrogate.cmake
+++ b/cmake/macros/Interrogate.cmake
@@ -341,10 +341,15 @@ function(add_python_module module)
     # Keep command lines short
     file(RELATIVE_PATH workdir_rel "${CMAKE_CURRENT_BINARY_DIR}" "${workdir_abs}")
 
+    get_target_property(target_module "${target}" IGATE_MODULE)
+    if(NOT target_module)
+      set(target_module "${module}")
+    endif()
+
     interrogate_sources(${target}
       "${workdir_abs}/${target}_igate.cxx"
       "${workdir_abs}/${target}.in"
-      "-python-native;-module;${module}")
+      "-python-native;-module;${target_module}")
 
     get_target_property(target_extensions "${target}" IGATE_EXTENSIONS)
     list(APPEND infiles_rel "${workdir_rel}/${target}.in")

--- a/cmake/macros/Interrogate.cmake
+++ b/cmake/macros/Interrogate.cmake
@@ -359,7 +359,7 @@ function(add_python_module module)
       make_directory "${CMAKE_CURRENT_BINARY_DIR}/${PANDA_CFG_INTDIR}"
     COMMAND host_interrogate_module
       -oc "${CMAKE_CURRENT_BINARY_DIR}/${PANDA_CFG_INTDIR}/${module}_module.cxx"
-      -module ${modname} -library ${modname}
+      -module ${module} -library ${modname}
       ${import_flags}
       ${INTERROGATE_MODULE_OPTIONS}
       ${IMOD_FLAGS} ${infiles_rel}

--- a/direct/src/cluster/ClusterClient.py
+++ b/direct/src/cluster/ClusterClient.py
@@ -2,13 +2,15 @@
 
 from panda3d.core import (
     ClockObject,
-    ConnectionWriter,
     Point3,
-    QueuedConnectionManager,
-    QueuedConnectionReader,
     VBase3,
     Vec3,
     decomposeMatrix,
+)
+from panda3d.net import (
+    ConnectionWriter,
+    QueuedConnectionManager,
+    QueuedConnectionReader,
 )
 from .ClusterMsgs import (
     CLUSTER_DAEMON_PORT,

--- a/direct/src/cluster/ClusterMsgs.py
+++ b/direct/src/cluster/ClusterMsgs.py
@@ -3,7 +3,7 @@
 # This module is intended to supply routines and dataformats common to
 # both ClusterClient and ClusterServer.
 
-from panda3d.core import NetDatagram
+from panda3d.net import NetDatagram
 from direct.distributed.PyDatagram import PyDatagram
 from direct.distributed.PyDatagramIterator import PyDatagramIterator
 import time

--- a/direct/src/cluster/ClusterServer.py
+++ b/direct/src/cluster/ClusterServer.py
@@ -1,12 +1,14 @@
 from panda3d.core import (
     ClockObject,
+    Vec3,
+)
+from panda3d.net import (
     ConnectionWriter,
     NetAddress,
     PointerToConnection,
     QueuedConnectionListener,
     QueuedConnectionManager,
     QueuedConnectionReader,
-    Vec3,
 )
 from .ClusterMsgs import (
     CLUSTER_CAM_FRUSTUM,

--- a/direct/src/distributed/ServerRepository.py
+++ b/direct/src/distributed/ServerRepository.py
@@ -4,19 +4,21 @@ from panda3d.core import (
     ConfigVariableBool,
     ConfigVariableDouble,
     ConfigVariableInt,
-    ConnectionWriter,
     DatagramIterator,
     Filename,
+    TPLow,
+    UniqueIdAllocator,
+    VirtualFileSystem,
+    getModelPath,
+)
+from panda3d.net import (
+    ConnectionWriter,
     NetAddress,
     NetDatagram,
     PointerToConnection,
     QueuedConnectionListener,
     QueuedConnectionManager,
     QueuedConnectionReader,
-    TPLow,
-    UniqueIdAllocator,
-    VirtualFileSystem,
-    getModelPath,
 )
 from panda3d.direct import DCFile
 from direct.distributed.MsgTypesCMU import (

--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -2866,7 +2866,8 @@ del_files = ['core.py', 'core.pyc', 'core.pyo',
              '_core.pyd', '_core.so',
              'direct.py', 'direct.pyc', 'direct.pyo',
              '_direct.pyd', '_direct.so',
-             'dtoolconfig.pyd', 'dtoolconfig.so']
+             'dtoolconfig.pyd', 'dtoolconfig.so',
+             'net.pyd', 'net.so']
 
 for basename in del_files:
     path = os.path.join(GetOutputDir(), 'panda3d', basename)
@@ -2914,6 +2915,20 @@ if not PkgSkip("PYTHON"):
 if __debug__:
     print("Warning: panda3d.dtoolconfig is deprecated, use panda3d.interrogatedb instead.")
 from .interrogatedb import *
+""")
+
+    # Add this for forward compatibility.
+    ConditionalWriteFile(GetOutputDir() + '/panda3d/net.py', """\
+__all__ = 'BufferedDatagramConnection', 'Buffered_DatagramConnection', 'Connection', 'ConnectionListener', 'ConnectionManager', 'ConnectionReader', 'ConnectionWriter', 'DatagramGeneratorNet', 'DatagramSinkNet', 'Dtool_BorrowThisReference', 'Dtool_PyNativeInterface', 'NetAddress', 'NetDatagram', 'PointerToBaseConnection', 'PointerToBase_Connection', 'PointerToConnection', 'PointerTo_Connection', 'QueuedConnectionListener', 'QueuedConnectionManager', 'QueuedConnectionReader', 'QueuedReturnConnectionListenerData', 'QueuedReturnDatagram', 'QueuedReturnNetDatagram', 'QueuedReturnPointerToConnection', 'QueuedReturn_ConnectionListenerData', 'QueuedReturn_Datagram', 'QueuedReturn_NetDatagram', 'QueuedReturn_PointerTo_Connection', 'RecentConnectionReader', 'SocketAddress', 'SocketFdset', 'SocketIP', 'SocketTCP', 'SocketTCPListen', 'SocketUDP', 'SocketUDPIncoming', 'SocketUDPOutgoing', 'Socket_Address', 'Socket_IP', 'Socket_TCP', 'Socket_TCP_Listen', 'Socket_UDP', 'Socket_UDP_Incoming', 'Socket_UDP_Outgoing', 'Socket_fdset'
+
+from . import core
+
+scope = globals()
+for name in __all__:
+    if hasattr(core, name):
+        scope[name] = getattr(core, name)
+
+del core, scope, name
 """)
 
 # PandaModules is now deprecated; generate a shim for backward compatibility.
@@ -3904,7 +3919,7 @@ if GetTarget() != 'emscripten':
 OPTS=['DIR:panda/src/nativenet']
 IGATEFILES=GetDirectoryContents('panda/src/nativenet', ["*.h", "*_composite*.cxx"])
 TargetAdd('libp3nativenet.in', opts=OPTS, input=IGATEFILES)
-TargetAdd('libp3nativenet.in', opts=['IMOD:panda3d.core', 'ILIB:libp3nativenet', 'SRCDIR:panda/src/nativenet'])
+TargetAdd('libp3nativenet.in', opts=['IMOD:panda3d.net', 'ILIB:libp3nativenet', 'SRCDIR:panda/src/nativenet'])
 
 #
 # DIRECTORY: panda/src/net/
@@ -3919,7 +3934,7 @@ OPTS=['DIR:panda/src/net']
 IGATEFILES=GetDirectoryContents('panda/src/net', ["*.h", "*_composite*.cxx"])
 IGATEFILES.remove("datagram_ui.h")
 TargetAdd('libp3net.in', opts=OPTS, input=IGATEFILES)
-TargetAdd('libp3net.in', opts=['IMOD:panda3d.core', 'ILIB:libp3net', 'SRCDIR:panda/src/net'])
+TargetAdd('libp3net.in', opts=['IMOD:panda3d.net', 'ILIB:libp3net', 'SRCDIR:panda/src/net'])
 
 #
 # DIRECTORY: panda/src/pstatclient/

--- a/panda/CMakeLists.txt
+++ b/panda/CMakeLists.txt
@@ -137,15 +137,33 @@ if __debug__:
 from .interrogatedb import *
 ")
 
+  set(net_file "__all__ = 'BufferedDatagramConnection', 'Buffered_DatagramConnection', 'Connection', 'ConnectionListener', 'ConnectionManager', 'ConnectionReader', 'ConnectionWriter', 'DatagramGeneratorNet', 'DatagramSinkNet', 'Dtool_BorrowThisReference', 'Dtool_PyNativeInterface', 'NetAddress', 'NetDatagram', 'PointerToBaseConnection', 'PointerToBase_Connection', 'PointerToConnection', 'PointerTo_Connection', 'QueuedConnectionListener', 'QueuedConnectionManager', 'QueuedConnectionReader', 'QueuedReturnConnectionListenerData', 'QueuedReturnDatagram', 'QueuedReturnNetDatagram', 'QueuedReturnPointerToConnection', 'QueuedReturn_ConnectionListenerData', 'QueuedReturn_Datagram', 'QueuedReturn_NetDatagram', 'QueuedReturn_PointerTo_Connection', 'RecentConnectionReader', 'SocketAddress', 'SocketFdset', 'SocketIP', 'SocketTCP', 'SocketTCPListen', 'SocketUDP', 'SocketUDPIncoming', 'SocketUDPOutgoing', 'Socket_Address', 'Socket_IP', 'Socket_TCP', 'Socket_TCP_Listen', 'Socket_UDP', 'Socket_UDP_Incoming', 'Socket_UDP_Outgoing', 'Socket_fdset'
+
+from . import core
+
+scope = globals()
+for name in __all__:
+    if hasattr(core, name):
+        scope[name] = getattr(core, name)
+
+del core, scope, name
+")
+
   if(IS_MULTICONFIG)
     foreach(config ${CMAKE_CONFIGURATION_TYPES})
       # Generate an __init__.py in the per-configuration directory.
       file(WRITE "${PROJECT_BINARY_DIR}/${config}/panda3d/__init__.py" ${init_file})
       file(WRITE "${PROJECT_BINARY_DIR}/${config}/panda3d/dtoolconfig.py" ${dtoolconfig_file})
+      if(HAVE_NET)
+        file(WRITE "${PROJECT_BINARY_DIR}/${config}/panda3d/net.py" ${net_file})
+      endif()
     endforeach(config)
   else()
     file(WRITE "${PROJECT_BINARY_DIR}/panda3d/__init__.py" ${init_file})
     file(WRITE "${PROJECT_BINARY_DIR}/panda3d/dtoolconfig.py" ${dtoolconfig_file})
+    if(HAVE_NET)
+      file(WRITE "${PROJECT_BINARY_DIR}/${config}/panda3d/net.py" ${net_file})
+    endif()
   endif()
 
   # Also generate a panda3d.dist-info directory.

--- a/panda/src/nativenet/CMakeLists.txt
+++ b/panda/src/nativenet/CMakeLists.txt
@@ -37,6 +37,10 @@ add_component_library(p3nativenet SYMBOL BUILDING_PANDA_NATIVENET
 target_link_libraries(p3nativenet p3pandabase pandaexpress)
 target_interrogate(p3nativenet ALL)
 
+# These are temporarily built with -module panda3d.net, even though they are
+# still part of panda3d.core, see #1466
+set_target_properties(p3nativenet PROPERTIES IGATE_MODULE panda3d.net)
+
 if(NOT BUILD_METALIBS)
   install(TARGETS p3nativenet
     EXPORT Core COMPONENT Core

--- a/panda/src/net/CMakeLists.txt
+++ b/panda/src/net/CMakeLists.txt
@@ -36,6 +36,10 @@ add_component_library(p3net SYMBOL BUILDING_PANDA_NET
 target_link_libraries(p3net p3nativenet p3pipeline p3pandabase pandaexpress)
 target_interrogate(p3net ALL)
 
+# These are temporarily built with -module panda3d.net, even though they are
+# still part of panda3d.core, see #1466
+set_target_properties(p3net PROPERTIES IGATE_MODULE panda3d.net)
+
 if(WIN32)
   target_link_libraries(p3net iphlpapi.lib)
 endif()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -36,6 +36,13 @@ def test_imports_panda3d():
                 importlib.import_module('panda3d.%s' % (module))
 
 
+def test_imports_panda3d_net():
+    from panda3d import core
+    from panda3d import net
+    assert core.ConnectionWriter == net.ConnectionWriter
+    assert core.ConnectionWriter.__module__ == 'panda3d.net'
+
+
 def test_imports_direct():
     import direct.actor.Actor
     import direct.actor.DistributedActor


### PR DESCRIPTION
## Issue description
This change is intended to prepare for #1466, which is about moving the net and nativenet classes to a separate `panda3d.net` module, while retaining compatibility for now.

## Solution description
For compatibility, the classes remain in `panda3d.core`, but there is a new `panda3d/net.py` file that specifically imports those classes from `panda3d.core`.  Regardless of where they are imported from, they do have a `__module__` field of `panda3d.net`.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
