### PR TITLE
palettizer: Fix magfilter on KW_mipmap

### DIFF
--- a/pandatool/src/palettizer/txaLine.cxx
+++ b/pandatool/src/palettizer/txaLine.cxx
@@ -495,7 +495,7 @@ match_texture(TextureImage *texture) const {
 
     case KW_mipmap:
       request._minfilter = EggTexture::FT_linear_mipmap_linear;
-      request._magfilter = EggTexture::FT_linear_mipmap_linear;
+      request._magfilter = EggTexture::FT_linear;
       break;
 
     case KW_anisotropic:


### PR DESCRIPTION
## Issue description
This fixes setting a mipmap filter on magfilter which is not valid by limiting it to FT_linear.

See #1585 

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
