### PR TITLE
ffmpeg: Use ch_layout in favor of removed channel_layout and channels

### DIFF
--- a/panda/src/ffmpeg/ffmpegVideoCursor.cxx
+++ b/panda/src/ffmpeg/ffmpegVideoCursor.cxx
@@ -614,10 +614,10 @@ close_stream() {
     avcodec_flush_buffers(_video_ctx);
 #endif
 
-    avcodec_close(_video_ctx);
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(55, 52, 0)
     avcodec_free_context(&_video_ctx);
 #else
+    avcodec_close(_video_ctx);
     av_free(_video_ctx);
 #endif
   }


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
In https://github.com/FFmpeg/FFmpeg/commit/65ddc74988245a01421a63c5cffa4d900c47117c, the `channel_layout` and `channels` members in `AVCodecParameters` and `AVCodecContext` were removed. This corresponds to the libavformat version 60.25.100. 

They have been deprecated since libavformat version 59.18.101: https://github.com/FFmpeg/FFmpeg/commit/548aeb93834b8425c86d1ce60fddc1d41805724d

The `avcodec_close` function has also been deprecated for a while, it is unnecessary to call both `avcodec_close` and `avcodec_free_context`.

## Solution description

When compiling with a version older than 59.18.101, use the old `channel_layout` and `channels` members. For versions newer than 59.18.101, use the new `ch_layout` member.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
