### PR TITLE
add getPlayMode() for actor and anim interface

### DIFF
--- a/direct/src/actor/Actor.py
+++ b/direct/src/actor/Actor.py
@@ -737,6 +737,13 @@ class Actor(DirectObject, NodePath):
         else:
             return None
 
+    def getPlayMode(self, animName=None, partName=None):
+        if self.__animControlDict:
+            controls = self.getAnimControls(animName, partName, onlyPlaying=False)
+            if controls:
+                return controls[0].getPlayMode()
+        return None
+
     def hasLOD(self):
         """
         Return 1 if the actor has LODs, 0 otherwise
@@ -1762,7 +1769,7 @@ class Actor(DirectObject, NodePath):
         return None
 
     def getAnimControls(self, animName=None, partName=None, lodName=None,
-                        allowAsyncBind = True):
+                        allowAsyncBind = True, onlyPlaying = True):
         """getAnimControls(self, string, string=None, string=None)
 
         Returns a list of the AnimControls that represent the given
@@ -1840,7 +1847,7 @@ class Actor(DirectObject, NodePath):
                 # get all playing animations
                 for thisPart, animDict in animDictItems:
                     for anim in animDict.values():
-                        if anim.animControl and anim.animControl.isPlaying():
+                        if anim.animControl and (not onlyPlaying or anim.animControl.isPlaying()):
                             controls.append(anim.animControl)
             else:
                 # get the named animation(s) only.
@@ -2660,3 +2667,4 @@ class Actor(DirectObject, NodePath):
     get_base_frame_rate = getBaseFrameRate
     remove_anim_control_dict = removeAnimControlDict
     load_anims_on_all_lods = loadAnimsOnAllLODs
+    get_play_mode = getPlayMode

--- a/panda/src/putil/animInterface.I
+++ b/panda/src/putil/animInterface.I
@@ -232,6 +232,16 @@ is_playing() const {
 }
 
 /**
+ * Returns the current play mode of the animation; whether the animation is
+ * playing normally, looping, posing, or in ping-pong mode.
+ */
+INLINE AnimInterface::PlayMode AnimInterface::
+get_play_mode() const {
+  CDReader cdata(_cycler);
+  return cdata->get_play_mode();
+}
+
+/**
  * Should be called by a derived class to specify the native frame rate of the
  * animation.  It is legal to call this after the animation has already
  * started.
@@ -264,6 +274,11 @@ set_num_frames(int num_frames) {
 INLINE double AnimInterface::CData::
 get_frac() const {
   return get_full_fframe() - (double)get_full_frame(0);
+}
+
+INLINE AnimInterface::PlayMode AnimInterface::CData::
+get_play_mode() const {
+  return _play_mode;
 }
 
 INLINE std::ostream &

--- a/panda/src/putil/animInterface.h
+++ b/panda/src/putil/animInterface.h
@@ -38,6 +38,13 @@ protected:
   AnimInterface(const AnimInterface &copy);
 
 PUBLISHED:
+  enum PlayMode {
+    PM_pose,
+    PM_play,
+    PM_loop,
+    PM_pingpong,
+  };
+
   virtual ~AnimInterface();
   INLINE void play();
   INLINE void play(double from, double to);
@@ -59,6 +66,7 @@ PUBLISHED:
   INLINE int get_full_frame() const;
   INLINE double get_full_fframe() const;
   INLINE bool is_playing() const;
+  INLINE PlayMode get_play_mode() const;
 
   virtual void output(std::ostream &out) const;
 
@@ -73,6 +81,7 @@ PUBLISHED:
   MAKE_PROPERTY(full_frame, get_full_frame);
   MAKE_PROPERTY(full_fframe, get_full_fframe);
   MAKE_PROPERTY(playing, is_playing);
+  MAKE_PROPERTY(play_mode, get_play_mode);
 
 protected:
   INLINE void set_frame_rate(double frame_rate);
@@ -80,13 +89,6 @@ protected:
   virtual void animation_activated();
 
 private:
-  enum PlayMode {
-    PM_pose,
-    PM_play,
-    PM_loop,
-    PM_pingpong,
-  };
-
   // This data is not cycled, because it is a semi-permanent part of the
   // interface.  Also, some derivatives of AnimInterface don't even use it.
   int _num_frames;
@@ -112,6 +114,7 @@ private:
     int get_full_frame(int increment) const;
     double get_full_fframe() const;
     bool is_playing() const;
+    INLINE PlayMode get_play_mode() const;
 
     virtual void output(std::ostream &out) const;
 


### PR DESCRIPTION
## Issue description
As of right now there is not a way to know in which way an Actor is currently playing an animation (playing, looping, etc.) This PR fixes it.

## Solution description
I've published a getter for play_mode in AnimInterface and exposed a helper on Actor. since getAnimControls() didn't used to return controls that are not playing anything, it made the helper not work in Pose mode, so I added an optional argument to control that.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
