### PR TITLE
interrogate: avoid GC exceptions processing objects mid-construction

### DIFF
--- a/dtool/src/interrogate/interfaceMakerPythonNative.cxx
+++ b/dtool/src/interrogate/interfaceMakerPythonNative.cxx
@@ -3057,9 +3057,10 @@ write_module_class(ostream &out, Object *obj) {
       out << "static int Dtool_Traverse_" << ClassName << "(PyObject *self, visitproc visit, void *arg) {\n";
       out << "  // If the only reference remaining is the one held by the Python wrapper,\n";
       out << "  // report the circular reference to Python's GC, so that it can break it.\n";
-      out << "  " << cClassName  << " *local_this = nullptr;\n";
-      out << "  if (!Dtool_Call_ExtractThisPointer(self, Dtool_" << ClassName << ", (void **)&local_this)) {\n";
-      out << "    return -1;\n";
+      out << "  " << cClassName  << " *local_this;\n";
+      out << "  DTOOL_Call_ExtractThisPointerForType(self, &Dtool_" << ClassName << ", (void**)(&local_this));\n";
+      out << "  if (local_this == nullptr) {\n";
+      out << "    return 0;\n";
       out << "  }\n";
       out << "  if (local_this->get_ref_count() == (int)((Dtool_PyInstDef *)self)->_memory_rules) {\n";
       if (py_subclassable) {


### PR DESCRIPTION
## Issue description
After https://github.com/panda3d/panda3d/commit/38692dd525525e20cd06204a646b35dd7e39902a, GC pauses occuring before
the `__init__` function of the C++ backed object is called in a inheritance chain will
cause an exception during garbage collection and cause the python runtime to exit.

This can be observed by say, forcing a GC-pause in `MetaInterval.__init__` before it calls `CMetaInterval::__init__`.

## Solution description

This change replaces the call to Dtool_Call_ExtractThisPointer with a direct check for whether DtoolInstance_VOID_PTR is nullptr and exit with status 0 if that's the case, rather than raising an exception.


## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
