### PR TITLE
Add Khronos Tonemap to Common Filters

### DIFF
--- a/direct/src/filter/CommonFilters.py
+++ b/direct/src/filter/CommonFilters.py
@@ -24,14 +24,14 @@ from panda3d.core import getDefaultCoordinateSystem, CS_zup_right, CS_zup_left
 
 from direct.task.TaskManagerGlobal import taskMgr
 
-from direct.filter.FilterManager import FilterManager
-from direct.filter.filterBloomI import BLOOM_I
-from direct.filter.filterBloomX import BLOOM_X
-from direct.filter.filterBloomY import BLOOM_Y
-from direct.filter.filterBlurX import BLUR_X
-from direct.filter.filterBlurY import BLUR_Y
-from direct.filter.filterCopy import COPY
-from direct.filter.filterDown4 import DOWN_4
+from .FilterManager import FilterManager
+from .filterBloomI import BLOOM_I
+from .filterBloomX import BLOOM_X
+from .filterBloomY import BLOOM_Y
+from .filterBlurX import BLUR_X
+from .filterBlurY import BLUR_Y
+from .filterCopy import COPY
+from .filterDown4 import DOWN_4
 
 class ToneMap:
     ACES = "ACES"


### PR DESCRIPTION
## Issue description
From #1659
Khronos released a reference PBR tone mapper that gives decent results without excessive need for tweaking, such as is the case with Filmic tone mappers. It might be a good default for Panda3D.

The current ACES tone mapper is fine, but it looks rather desaturated by default and requires application of custom LUTs in order to get good results.

We can add a parameter to the appropriate CommonFilters method to select the tone mapping operator.

## Solution description
Add the Khronos Tonemap to common filters. 
Allows for selecting the tone mapper in  the setHighDynamicRange function using the tonemap parameter (it's set to ACES by default). Add a ToneMap Enum so it is easier to select a tonemap.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
