### PR TITLE
showbase: Add functions to get interval for Iris Transitions

### DIFF
--- a/direct/src/showbase/Transitions.py
+++ b/direct/src/showbase/Transitions.py
@@ -264,6 +264,54 @@ class Transitions:
             self.iris = base.loader.loadModel(self.IrisModelName)
             self.iris.setPos(0, 0, 0)
 
+    def getIrisInIval(self, t=0.5, finishIval=None, blendType='noBlend'):
+        """
+        Returns an interval without starting it.  This is particularly useful in
+        cutscenes, so when the cutsceneIval is escaped out of we can finish the iris immediately
+        """
+        self.noTransitions()
+        self.loadIris()
+
+        scale = 0.18 * max(base.a2dRight, base.a2dTop)
+        transitionIval = Sequence(Func(self.iris.reparentTo, ShowBaseGlobal.aspect2d, DGG.FADE_SORT_INDEX),
+                                  LerpScaleInterval(self.iris, t,
+                                                    scale = scale,
+                                                    startScale = 0.01,
+                                                    blendType=blendType),
+                                 Func(self.iris.detachNode),
+                                 Func(self.__finishTransition),
+                                 name = self.irisTaskName,
+                                 )
+        if finishIval:
+            transitionIval.append(finishIval)
+        return transitionIval
+
+    def getIrisOutIval(self, t=0.5, finishIval=None, blendType='noBlend'):
+        """
+        Create a sequence that lerps the iris out, then
+        parents the iris to hidden
+        """
+        self.noTransitions()
+        self.loadIris()
+        self.loadFade()  # we need this to cover up the hole.
+
+        scale = 0.18 * max(base.a2dRight, base.a2dTop)
+        transitionIval = Sequence(Func(self.iris.reparentTo, ShowBaseGlobal.aspect2d, DGG.FADE_SORT_INDEX),
+                                  LerpScaleInterval(self.iris, t,
+                                                    scale = 0.01,
+                                                    startScale = scale,
+                                                    blendType=blendType),
+                                 Func(self.iris.detachNode),
+                                 # Use the fade to cover up the hole that the iris would leave
+                                 Func(self.fadeOut, 0),
+                                 Func(self.__finishTransition),
+                                 name = self.irisTaskName,
+                                 )
+
+        if finishIval:
+            transitionIval.append(finishIval)
+        return transitionIval
+
     def irisIn(self, t=0.5, finishIval=None, blendType = 'noBlend'):
         """
         Play an iris in transition over t seconds.
@@ -271,25 +319,13 @@ class Transitions:
         of the iris polygon up so it looks like we iris in. When the
         scale lerp is finished, it parents the iris polygon to hidden.
         """
-        self.noTransitions()
-        self.loadIris()
         if t == 0:
             self.iris.detachNode()
             fut = AsyncFuture()
             fut.setResult(None)
             return fut
         else:
-            self.iris.reparentTo(ShowBaseGlobal.aspect2d, DGG.FADE_SORT_INDEX)
-
-            scale = 0.18 * max(base.a2dRight, base.a2dTop)
-            self.transitionIval = Sequence(LerpScaleInterval(self.iris, t,
-                                                   scale = scale,
-                                                   startScale = 0.01,
-                                                   blendType=blendType),
-                                 Func(self.iris.detachNode),
-                                 Func(self.__finishTransition),
-                                 name = self.irisTaskName,
-                                 )
+            self.transitionIval = self.getIrisInIval(t, finishIval, blendType)
             self.__transitionFuture = AsyncFuture()
             if finishIval:
                 self.transitionIval.append(finishIval)
@@ -304,9 +340,6 @@ class Transitions:
         lerp is finished, it leaves the iris polygon covering the
         aspect2d plane until you irisIn or call noIris.
         """
-        self.noTransitions()
-        self.loadIris()
-        self.loadFade()  # we need this to cover up the hole.
         if t == 0:
             self.iris.detachNode()
             self.fadeOut(0)
@@ -314,19 +347,7 @@ class Transitions:
             fut.setResult(None)
             return fut
         else:
-            self.iris.reparentTo(ShowBaseGlobal.aspect2d, DGG.FADE_SORT_INDEX)
-
-            scale = 0.18 * max(base.a2dRight, base.a2dTop)
-            self.transitionIval = Sequence(LerpScaleInterval(self.iris, t,
-                                                   scale = 0.01,
-                                                   startScale = scale,
-                                                   blendType=blendType),
-                                 Func(self.iris.detachNode),
-                                 # Use the fade to cover up the hole that the iris would leave
-                                 Func(self.fadeOut, 0),
-                                 Func(self.__finishTransition),
-                                 name = self.irisTaskName,
-                                 )
+            self.transitionIval = self.getIrisOutIval(t, finishIval, blendType)
             self.__transitionFuture = AsyncFuture()
             if finishIval:
                 self.transitionIval.append(finishIval)


### PR DESCRIPTION
## Issue description
What is this change intended to accomplish?  What problem does it solve?
Since the Fade Transitions has these functions to get the interval, it only makes sense to make some for Iris as well.

Solution description
It is useful to use these functions for Iris transitions in Sequences and Parallels rather than something weird like:

`sequence = Sequence(Func(base.transitions.irisIn(5)), Wait(5))`

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
