### PR TITLE
text: add 'small_caps' functionality to harfbuzz

### DIFF
--- a/panda/src/text/textAssembler.cxx
+++ b/panda/src/text/textAssembler.cxx
@@ -38,6 +38,7 @@
 
 #ifdef HAVE_HARFBUZZ
 #include <hb.h>
+#include <vector>
 #endif
 
 using std::max;
@@ -1787,7 +1788,7 @@ shape_buffer(hb_buffer_t *buf, PlacedGlyphs &placed_glyphs, PN_stdfloat &xpos,
   // but first, we need some of these defined sooner rather than later:
   DynamicTextFont *font = DCAST(DynamicTextFont, properties.get_font());
 
-  if (properties.has_small_caps()) {
+  if (properties.get_small_caps()) {
     // create a temporary buffer to iterate through
     hb_buffer_t *tmp_harfbuff = nullptr;
     tmp_harfbuff = hb_buffer_create();
@@ -1882,12 +1883,12 @@ shape_buffer(hb_buffer_t *buf, PlacedGlyphs &placed_glyphs, PN_stdfloat &xpos,
     int character = glyph_info[i].cluster;
     int glyph_index = glyph_info[i].codepoint;
 
-    // these are so that we may have individual 'character scales', especially for has_small_caps
+    // these are so that we may have individual 'character scales', especially for get_small_caps
     PN_stdfloat char_glyph_scale = glyph_scale;
     PN_stdfloat char_scale = scale;
 
     // check to see if small_caps == true, and change scales if necessary
-    if (properties.has_small_caps()) {
+    if (properties.get_small_caps()) {
       const UnicodeLatinMap::Entry *map_entry =
         UnicodeLatinMap::look_up((char32_t)character);
       if (map_entry != nullptr &&


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
This commit attempts to resolve issue #1666 (which was introduced when building with harfbuzz after commit 0dad38d), by adding code in TextAssembler.shape_buffer(), to handle the case where:
1. harfbuzz is built with the engine
2. is wanted via the config variable `text-use-harfbuzz` being set to true, and
3. the TextProperties associated with the to-be-drawn text also has the small_caps field set.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
If the above cases are all true, then the buffer is first remade with all harfbuzz 'codepoints' switched to the uppercase variant (if needed and possible), while keeping the harfbuzz 'cluster' value the same for tracking what characters need their scaling changed. 
Later when the glyphs are actually in the process of being generated, I check to see if those earlier 'cluster' values are lowercase values, and go ahead and use individual scale values for each character, using `get_small_caps_scale()` for these characters instead of the usual `get_glyph_scale()` in every other case.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
