### PR TITLE
pview: add shift+r keyboard bind to reload all textures

### DIFF
--- a/panda/src/testbed/pview.cxx
+++ b/panda/src/testbed/pview.cxx
@@ -165,6 +165,17 @@ event_0(const Event *event, void *) {
 }
 
 void
+event_R(const Event *event, void *) {
+  // shift-R(eload): reload all textures
+  TextureCollection collection = TexturePool::get_global_ptr()->find_all_textures("*");
+  for (int i = 0; i < collection.size(); ++i)
+  {
+    nout << "Reloading texture " << collection[i]->get_filename() << std::endl;
+    collection[i]->reload();
+  }
+}
+
+void
 usage() {
   cerr <<
     "\n"
@@ -513,6 +524,7 @@ main(int argc, char **argv) {
     framework.define_key("shift-f", "flatten hierarchy", event_F, nullptr);
     framework.define_key("alt-enter", "toggle between window/fullscreen", event_Enter, nullptr);
     framework.define_key("2", "split the window", event_2, nullptr);
+    framework.define_key("shift-r", "reload textures", event_R, nullptr);
     if (pview_test_hack) {
       framework.define_key("0", "run quick hacky test", event_0, nullptr);
     }


### PR DESCRIPTION
## Issue description
This is basically an RFC for the following change:

Adds a simple bind (shift+r) to reload all textures in the TexturePool in pview, to reduce the friction of edit texture -> exit pview -> reopen pview -> repeat.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
