### PR TITLE
event: use the persistent python wrapper when appending task object

### DIFF
--- a/panda/src/event/pythonTask.cxx
+++ b/panda/src/event/pythonTask.cxx
@@ -1018,7 +1018,7 @@ call_function(PyObject *function) {
       __self__ = DTool_CreatePyInstance(this, Dtool_PythonTask, true, false);
     }
 
-    PyObject *result = PyObject_CallOneArg(function, Py_NewRef(__self__));
+    PyObject *result = PyObject_CallOneArg(function, __self__);
     Py_XDECREF(result);
   }
 }

--- a/panda/src/event/pythonTask.cxx
+++ b/panda/src/event/pythonTask.cxx
@@ -175,8 +175,16 @@ get_args() {
     }
 
     this->ref();
-    PyObject *self = DTool_CreatePyInstance(this, Dtool_PythonTask, true, false);
-    PyTuple_SET_ITEM(with_task, num_args, self);
+
+    // Check whether we have a Python wrapper.  This is not the case if the
+    // object has been created by C++ and never been exposed to Python code.
+    if (__self__ == nullptr)
+    {
+      // A __self__ instance does not exist, let's create one now.
+      __self__ = DTool_CreatePyInstance(this, Dtool_PythonTask, true, false);
+    }
+
+    PyTuple_SET_ITEM(with_task, num_args, Py_XNewRef(__self__));
     return with_task;
   }
   else {

--- a/panda/src/event/pythonTask.cxx
+++ b/panda/src/event/pythonTask.cxx
@@ -178,13 +178,12 @@ get_args() {
 
     // Check whether we have a Python wrapper.  This is not the case if the
     // object has been created by C++ and never been exposed to Python code.
-    if (__self__ == nullptr)
-    {
+    if (__self__ == nullptr) {
       // A __self__ instance does not exist, let's create one now.
       __self__ = DTool_CreatePyInstance(this, Dtool_PythonTask, true, false);
     }
 
-    PyTuple_SET_ITEM(with_task, num_args, Py_XNewRef(__self__));
+    PyTuple_SET_ITEM(with_task, num_args, Py_NewRef(__self__));
     return with_task;
   }
   else {

--- a/panda/src/event/pythonTask.cxx
+++ b/panda/src/event/pythonTask.cxx
@@ -174,11 +174,10 @@ get_args() {
       PyTuple_SET_ITEM(with_task, i, Py_NewRef(item));
     }
 
-    this->ref();
-
     // Check whether we have a Python wrapper.  This is not the case if the
     // object has been created by C++ and never been exposed to Python code.
     if (__self__ == nullptr) {
+      this->ref();
       // A __self__ instance does not exist, let's create one now.
       __self__ = DTool_CreatePyInstance(this, Dtool_PythonTask, true, false);
     }
@@ -1011,11 +1010,16 @@ call_owner_method(const char *method_name) {
 void PythonTask::
 call_function(PyObject *function) {
   if (function != Py_None) {
-    this->ref();
-    PyObject *self = DTool_CreatePyInstance(this, Dtool_PythonTask, true, false);
-    PyObject *result = PyObject_CallOneArg(function, self);
+    // Check whether we have a Python wrapper.  This is not the case if the
+    // object has been created by C++ and never been exposed to Python code.
+    if (__self__ == nullptr) {
+      // A __self__ instance does not exist, let's create one now.
+      this->ref();
+      __self__ = DTool_CreatePyInstance(this, Dtool_PythonTask, true, false);
+    }
+
+    PyObject *result = PyObject_CallOneArg(function, Py_NewRef(__self__));
     Py_XDECREF(result);
-    Py_DECREF(self);
   }
 }
 

--- a/panda/src/event/pythonTask.cxx
+++ b/panda/src/event/pythonTask.cxx
@@ -177,8 +177,8 @@ get_args() {
     // Check whether we have a Python wrapper.  This is not the case if the
     // object has been created by C++ and never been exposed to Python code.
     if (__self__ == nullptr) {
-      this->ref();
       // A __self__ instance does not exist, let's create one now.
+      this->ref();
       __self__ = DTool_CreatePyInstance(this, Dtool_PythonTask, true, false);
     }
 

--- a/tests/event/test_pythontask.py
+++ b/tests/event/test_pythontask.py
@@ -1,4 +1,4 @@
-from panda3d.core import PythonTask
+from panda3d.core import AsyncTaskManager, PythonTask
 from contextlib import contextmanager
 import pytest
 import types
@@ -115,3 +115,28 @@ def test_pythontask_cycle():
                 break
         else:
             pytest.fail('not found in garbage')
+
+def test_task_persistent_wrapper():
+    task_mgr = AsyncTaskManager.get_global_ptr()
+    task_chain = task_mgr.make_task_chain("test_task_persistent_wrapper")
+
+    # Create a subclass of PythonTask
+    class PythonTaskSubclassTest(PythonTask):
+        pass
+
+    def task_main(task):
+        # Set our result to be the input task we got into this function
+        task.set_result(task)
+        # Verify we got the subclass
+        assert isinstance(task, PythonTaskSubclassTest)
+        return task.done
+
+    task = PythonTaskSubclassTest(task_main)
+    task.set_task_chain(task_chain.name)
+    task_mgr.add(task)
+    task_chain.wait_for_tasks()
+
+    assert task.done()
+    assert not task.cancelled()
+    # Verify the task passed into the function is the same task we created
+    assert task.result() is task

--- a/tests/event/test_pythontask.py
+++ b/tests/event/test_pythontask.py
@@ -131,8 +131,17 @@ def test_task_persistent_wrapper():
         assert isinstance(task, PythonTaskSubclassTest)
         return task.done
 
+    done_callback_reached = False
+
+    def done_callback(task):
+        # Verify we got the subclass
+        assert isinstance(task, PythonTaskSubclassTest)
+        nonlocal done_callback_reached
+        done_callback_reached = True
+
     task = PythonTaskSubclassTest(task_main)
     task.set_task_chain(task_chain.name)
+    task.set_upon_death(done_callback)
     task_mgr.add(task)
     task_chain.wait_for_tasks()
 
@@ -140,3 +149,5 @@ def test_task_persistent_wrapper():
     assert not task.cancelled()
     # Verify the task passed into the function is the same task we created
     assert task.result() is task
+    # Verify the done callback worked and was tested
+    assert done_callback_reached


### PR DESCRIPTION
"event: use the persistent python wrapper when appending task object to args"


## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->


Seems to fix #1680 but also this is a nice optimization regardless since we no longer need to create a new python wrapper object every time we call into python.

Also fixes subclassing of PythonTask not passing in the subclass instance to the task function.

## Solution description
Don't create a new wrapper object if one exists when appending the task object to the function arguments, instead pass in a new reference to the existing `__self__` object

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
