### PR TITLE
when pipelining off `from._cycler` may not exist

### DIFF
--- a/panda/src/pipeline/cycleDataLockedStageReader.I
+++ b/panda/src/pipeline/cycleDataLockedStageReader.I
@@ -183,7 +183,9 @@ CycleDataLockedStageReader(const CycleDataLockedStageReader<CycleDataType> &copy
  */
 template<class CycleDataType>
 INLINE CycleDataLockedStageReader<CycleDataType>::
-CycleDataLockedStageReader(CycleDataLockedStageReader<CycleDataType> &&from) noexcept {
+CycleDataLockedStageReader(CycleDataLockedStageReader<CycleDataType> &&from) noexcept :
+  _pointer(from._pointer)
+{
   from._pointer = nullptr;
 }
 

--- a/panda/src/pipeline/cycleDataLockedStageReader.I
+++ b/panda/src/pipeline/cycleDataLockedStageReader.I
@@ -183,9 +183,7 @@ CycleDataLockedStageReader(const CycleDataLockedStageReader<CycleDataType> &copy
  */
 template<class CycleDataType>
 INLINE CycleDataLockedStageReader<CycleDataType>::
-CycleDataLockedStageReader(CycleDataLockedStageReader<CycleDataType> &&from) noexcept :
-  _pointer(from._cycler)
-{
+CycleDataLockedStageReader(CycleDataLockedStageReader<CycleDataType> &&from) noexcept {
   from._pointer = nullptr;
 }
 


### PR DESCRIPTION
found when building with em++/3.13t
