### PR TITLE
showbase: Patch for iris intervals

### DIFF
--- a/direct/src/showbase/Transitions.py
+++ b/direct/src/showbase/Transitions.py
@@ -327,8 +327,6 @@ class Transitions:
         else:
             self.transitionIval = self.getIrisInIval(t, finishIval, blendType)
             self.__transitionFuture = AsyncFuture()
-            if finishIval:
-                self.transitionIval.append(finishIval)
             self.transitionIval.start()
             return self.__transitionFuture
 
@@ -349,8 +347,6 @@ class Transitions:
         else:
             self.transitionIval = self.getIrisOutIval(t, finishIval, blendType)
             self.__transitionFuture = AsyncFuture()
-            if finishIval:
-                self.transitionIval.append(finishIval)
             self.transitionIval.start()
             return self.__transitionFuture
 


### PR DESCRIPTION
## Issue description
When I implemented my Iris intervals, there was a duplicated line I missed causing rare occurrences for Iris intervals to give a blank black screen. This patch will fix that.

## Solution description
Remove a duplicated line adding the finish interval.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
