### PR TITLE
bam-info: add new option to list texture's file paths.

### DIFF
--- a/panda/src/pgraphnodes/sceneGraphAnalyzer.I
+++ b/panda/src/pgraphnodes/sceneGraphAnalyzer.I
@@ -253,3 +253,11 @@ PN_stdfloat SceneGraphAnalyzer::
 get_total_normal_length() const {
   return _total_normal_length;
 }
+
+/**
+ * Returns a Texture filled pmap.
+ */
+SceneGraphAnalyzer::Textures SceneGraphAnalyzer::
+get_textures() const {
+ return _textures;
+}

--- a/panda/src/pgraphnodes/sceneGraphAnalyzer.h
+++ b/panda/src/pgraphnodes/sceneGraphAnalyzer.h
@@ -39,6 +39,8 @@ PUBLISHED:
   SceneGraphAnalyzer();
   ~SceneGraphAnalyzer();
 
+  typedef pmap<Texture *, int> Textures;
+
   enum LodMode {
     LM_lowest,
     LM_highest,
@@ -86,6 +88,7 @@ PUBLISHED:
   INLINE int get_num_long_normals() const;
   INLINE int get_num_short_normals() const;
   INLINE PN_stdfloat get_total_normal_length() const;
+  INLINE Textures get_textures() const;
 
 private:
   void collect_statistics(PandaNode *node, bool under_instance);
@@ -106,7 +109,6 @@ private:
   typedef pset<CPT(GeomVertexArrayData) > VADatas;
   typedef pmap<const GeomVertexData *, int, IndirectCompareTo<GeomVertexData> > UniqueVDatas;
   typedef pmap<const GeomVertexArrayData *, int, IndirectCompareTo<GeomVertexArrayData> > UniqueVADatas;
-  typedef pmap<Texture *, int> Textures;
 
   LodMode _lod_mode;
 

--- a/pandatool/src/bam/bamInfo.cxx
+++ b/pandatool/src/bam/bamInfo.cxx
@@ -53,6 +53,11 @@ BamInfo() {
      "Output verbose information about each Geom in the Bam file.",
      &BamInfo::dispatch_none, &_verbose_geoms);
 
+  add_option
+    ("tex", "", 0,
+      "Lists each texture path found within the scene graph.",
+      &BamInfo::dispatch_none, &_verbose_textures);
+
   _num_scene_graphs = 0;
 }
 
@@ -207,6 +212,10 @@ describe_scene_graph(PandaNode *node) {
   if (_ls || _verbose_geoms || _verbose_transitions) {
     list_hierarchy(node, 0);
   }
+
+  if (_verbose_textures) {
+    list_textures();
+  }
 }
 
 /**
@@ -317,6 +326,19 @@ list_hierarchy(PandaNode *node, int indent_level) {
   for (int i = 0; i < num_children; i++) {
     PandaNode *child = node->get_child(i);
     list_hierarchy(child, indent_level + 2);
+  }
+}
+
+void BamInfo::
+list_textures() {
+  nout << "\n";
+  for (const auto &item : _analyzer.get_textures()) {
+    Texture* texture = item.first;
+    nout << texture->get_name() << ":\n";
+    nout << "  Filename: " << texture->get_filename() << "\n";
+    if (item.first->has_alpha_filename()) {
+      nout << "  Alpha Filename: " << texture->get_alpha_filename() << "\n";
+    }
   }
 }
 

--- a/pandatool/src/bam/bamInfo.h
+++ b/pandatool/src/bam/bamInfo.h
@@ -50,6 +50,7 @@ private:
   void describe_session(RecorderHeader *header, const Objects &objects);
   void describe_general_object(TypedWritable *object);
   void list_hierarchy(PandaNode *node, int indent_level);
+  void list_textures();
 
   typedef pvector<Filename> Filenames;
   Filenames _filenames;
@@ -57,6 +58,7 @@ private:
   bool _ls;
   bool _verbose_transitions;
   bool _verbose_geoms;
+  bool _verbose_textures;
 
   int _num_scene_graphs;
   SceneGraphAnalyzer _analyzer;


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
Resolves issue #1182. Add new `-tex` option to bam-info to list each texture's name and file path as well as an alpha path where applicable.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
Uses SceneGraphAnalyzer's `_textures` map to individually list out each texture name and associated file paths.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
