### PR TITLE
FIXED ISSUE ON MINIMUM WIDTH

### DIFF
--- a/panda/src/display/displaySearchParameters.cxx
+++ b/panda/src/display/displaySearchParameters.cxx
@@ -26,12 +26,18 @@ DisplaySearchParameters::
  */
 DisplaySearchParameters::
 DisplaySearchParameters() {
-  _minimum_width = 640;
-  _minimum_height = 480;
+  _minimum_width = 1;
+  _minimum_height = 1;
   _maximum_width = 6400;
   _maximum_height = 4800;
   _minimum_bits_per_pixel = 16;
   _maximum_bits_per_pixel = 32;
+}
+
+void displaySearchParameters::
+ validate_window_size(int &width, int &height) {
+  if (width < _minimum_width) width = _minimum_width;
+  if (height < _minimum_height) height = _minimum_height;
 }
 
 /**
@@ -39,15 +45,21 @@ DisplaySearchParameters() {
  */
 void DisplaySearchParameters::
 set_minimum_width (int minimum_width) {
-  _minimum_width = minimum_width;
+  _minimum_width = (minimum_width > 0) ? minimum_width : 1;
 }
-
+void DisplaySearchParameters::
+set_window_size(int requested_width, int requested_height) {
+  validate_window_size(requested_width, requested_height);
+    _current_width = requested_width;
+  _current_height = requested_height;
+  
+}
 /**
  *
  */
 void DisplaySearchParameters::
 set_maximum_width (int maximum_width) {
-  _maximum_width = maximum_width;
+   _maximum_width = (maximum_width > 0) ? maximum_width : 1;
 }
 
 /**
@@ -55,7 +67,7 @@ set_maximum_width (int maximum_width) {
  */
 void DisplaySearchParameters::
 set_minimum_height (int minimum_height) {
-  _minimum_height = minimum_height;
+ _minimum_height = (minimum_height > 0) ? minimum_height : 1;
 }
 
 /**
@@ -63,7 +75,7 @@ set_minimum_height (int minimum_height) {
  */
 void DisplaySearchParameters::
 set_maximum_height (int maximum_height) {
-  _maximum_height = maximum_height;
+   _maximum_height = (maximum_height > 0) ? maximum_height : 1;
 }
 
 /**

--- a/panda/src/display/displaySearchParameters.h
+++ b/panda/src/display/displaySearchParameters.h
@@ -39,6 +39,8 @@ public:
   int _maximum_height;
   int _minimum_bits_per_pixel;
   int _maximum_bits_per_pixel;
+   int _current_width;  
+  int _current_height;
 };
 
 #endif


### PR DESCRIPTION

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
Prevent window size from being set to zero #1689


## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
Added a function to make sure the window size is never too small, specifically not smaller than 1x1 pixels. Created a new method to set the window size, ensuring that the width and height always meet the minimum size requirement. Additionally, updated the setters for width and height to ensure they are never set to zero or negative values. This prevents errors and ensures valid window sizes.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [ ] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
