### PR TITLE
Prevent window resize to zero

### DIFF
--- a/panda/src/windisplay/winGraphicsWindow.cxx
+++ b/panda/src/windisplay/winGraphicsWindow.cxx
@@ -1517,22 +1517,22 @@ window_proc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
   switch (msg) {
   case WM_GETMINMAXINFO:
   {
-    MINMAXINFO* MinMaxInfo = (MINMAXINFO*)lparam;
+    MINMAXINFO* minmaxinfo = (MINMAXINFO*)lparam;
 
     int minClientWidth = 1;  // Minimum client area width
     int minClientHeight = 1; // Minimum client area height
 
     // Adjust window for non-client area
-    RECT clientRect = { 0, 0, minClientWidth, minClientHeight };
-    AdjustWindowRect(&clientRect, GetWindowLong(hwnd, GWL_STYLE), FALSE);
+    RECT rect = { 0, 0, minClientWidth, minClientHeight };
+    AdjustWindowRect(&rect, GetWindowLong(hwnd, GWL_STYLE), FALSE);
 
     // Calculate final size
-    int minWidth = clientRect.right - clientRect.left;
-    int minHeight = clientRect.bottom - clientRect.top;
+    int minWidth = rect.right - rect.left;
+    int minHeight = rect.bottom - rect.top;
 
     // Set the minimum track size in MINMAXINFO
-    MinMaxInfo->ptMinTrackSize.x = minWidth;  // Minimum window width
-    MinMaxInfo->ptMinTrackSize.y = minHeight; // Minimum window height
+    minmaxinfo->ptMinTrackSize.x = minWidth;  // Minimum window width
+    minmaxinfo->ptMinTrackSize.y = minHeight; // Minimum window height
   }
   break;
   case WM_MOUSEMOVE:

--- a/panda/src/windisplay/winGraphicsWindow.cxx
+++ b/panda/src/windisplay/winGraphicsWindow.cxx
@@ -1515,6 +1515,26 @@ window_proc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
   WindowProperties properties;
 
   switch (msg) {
+  case WM_GETMINMAXINFO:
+  {
+    MINMAXINFO* MinMaxInfo = (MINMAXINFO*)lparam;
+
+    int minClientWidth = 1;  // Minimum client area width
+    int minClientHeight = 1; // Minimum client area height
+
+    // Adjust window for non-client area
+    RECT clientRect = { 0, 0, minClientWidth, minClientHeight };
+    AdjustWindowRect(&clientRect, GetWindowLong(hwnd, GWL_STYLE), FALSE);
+
+    // Calculate final size
+    int minWidth = clientRect.right - clientRect.left;
+    int minHeight = clientRect.bottom - clientRect.top;
+
+    // Set the minimum track size in MINMAXINFO
+    MinMaxInfo->ptMinTrackSize.x = minWidth;  // Minimum window width
+    MinMaxInfo->ptMinTrackSize.y = minHeight; // Minimum window height
+  }
+  break;
   case WM_MOUSEMOVE:
     if (!_tracking_mouse_leaving) {
       // need to re-call TrackMouseEvent every time mouse re-enters window


### PR DESCRIPTION
## Issue description
Added a case in switch inside window_proc function in winGraphicsWindow.cxx file to prevent the window from being resized to a height of 0 and a width of less than 120. 

Issue https://github.com/panda3d/panda3d/issues/1689

## Solution description
On windows now the minimum window width now is 120 and minimum height is 1.
This prevents the occurrence division-by-zero errors, creation of invalid textures, etc. 

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
