### PR TITLE
Bamcacherequest

### DIFF
--- a/panda/src/putil/bamCache.cxx
+++ b/panda/src/putil/bamCache.cxx
@@ -190,6 +190,20 @@ lookup(const Filename &source_filename, const string &cache_extension) {
  * via a prior call to lookup(), and then stored the data via
  * record->set_data().  Returns true on success, false on failure.
  */
+
+void BamCache::request_clear_cache() {
+    // Lock to ensure thread safety
+    ReMutexHolder holder(_lock);
+  
+
+    // Call existing cache clearing logic
+    clear_cache();
+
+    // Log the action
+    util_cat.info() << "Cache cleared via request.\n";
+    
+}
+
 bool BamCache::
 store(BamCacheRecord *record) {
   VirtualFileSystem *vfs = VirtualFileSystem::get_global_ptr();

--- a/panda/src/putil/bamCache.h
+++ b/panda/src/putil/bamCache.h
@@ -77,6 +77,7 @@ PUBLISHED:
 
   void consider_flush_index();
   void flush_index();
+  void request_clear_cache();
 
   void list_index(std::ostream &out, int indent_level = 0) const;
 


### PR DESCRIPTION
added a fucntion that clears cache on request .
function also include lock to ensure thread safety, calls the existing clear_cache method to perform the actual cache clearing, and logs the action using util_cat.info(). then added the function in header file of BAMCACHE  withing published

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. --> #1240 

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
added the method declaration void request_clear_cache(); within the PUBLISHED section of the header file (bamCache.h). This makes it part of the public API for the class and ensures it can be accessed by external code and then  implemented the request_clear_cache() function in the BamCache class 

## Checklist
I have done my best to ensure that…
* [ ] …I have familiarized myself with the CONTRIBUTING.md file
* [ ] …this change follows the coding style and design patterns of the codebase
* [ ] …I own the intellectual property rights to this code
* [ ] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
