### PR TITLE
cull: Fix crash caused by freeing a cull object with empty volume

### DIFF
--- a/panda/src/cull/cullBinBackToFront.cxx
+++ b/panda/src/cull/cullBinBackToFront.cxx
@@ -40,7 +40,7 @@ add_object(CullableObject *object, Thread *current_thread) {
   // Determine the center of the bounding volume.
   CPT(BoundingVolume) volume = object->_geom->get_bounds(current_thread);
   if (volume->is_empty()) {
-    delete object;
+    // No point in culling objects with no volume.
     return;
   }
 

--- a/panda/src/cull/cullBinFrontToBack.cxx
+++ b/panda/src/cull/cullBinFrontToBack.cxx
@@ -40,7 +40,7 @@ add_object(CullableObject *object, Thread *current_thread) {
   // Determine the center of the bounding volume.
   CPT(BoundingVolume) volume = object->_geom->get_bounds();
   if (volume->is_empty()) {
-    delete object;
+    // No point in culling objects with no volume.
     return;
   }
 


### PR DESCRIPTION
## Issue description

Panda3D crashes when an object with an empty volume is culled after commit https://github.com/panda3d/panda3d/commit/6823634f60a652be80b7ed627d1d11a2cea1e6c0.

This is caused by Panda3D attempting to free the cullable object's memory. This didn't use to be a problem before, but now that the CullableObject is part of an allocation table managed by CullResult's allocation table, we can't free the object itself since it is part of a larger allocation table object.

## Solution description

Remove the object deletion. When `CullResult` is deleted, the allocation table the CullableObject is part of will be deleted anyway.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
