### PR TITLE
showbase: Annotate callback methods

### DIFF
--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -177,6 +177,8 @@ class ShowBase(DirectObject.DirectObject):
     aspect2d: NodePath
     pixel2d: NodePath
 
+    cluster: Any | None
+
     def __init__(self, fStartDirect: bool = True, windowType: str | None = None) -> None:
         """Opens a window, sets up a 3-D and several 2-D scene graphs, and
         everything else needed to render the scene graph to the window.
@@ -1208,7 +1210,7 @@ class ShowBase(DirectObject.DirectObject):
             self.taskMgr.remove('clientSleep')
             self.taskMgr.add(self.__sleepCycleTask, 'clientSleep', sort = 55)
 
-    def __sleepCycleTask(self, task):
+    def __sleepCycleTask(self, task: object) -> int:
         Thread.sleep(self.clientSleep)
         #time.sleep(self.clientSleep)
         return Task.cont
@@ -1444,7 +1446,7 @@ class ShowBase(DirectObject.DirectObject):
         self.__configAspectRatio = aspectRatio
         self.adjustWindowAspectRatio(self.getAspectRatio())
 
-    def getAspectRatio(self, win = None):
+    def getAspectRatio(self, win: GraphicsOutput | None = None) -> float:
         # Returns the actual aspect ratio of the indicated (or main
         # window), or the default aspect ratio if there is not yet a
         # main window.
@@ -1453,7 +1455,7 @@ class ShowBase(DirectObject.DirectObject):
         if self.__configAspectRatio:
             return self.__configAspectRatio
 
-        aspectRatio = 1
+        aspectRatio: float = 1
 
         if win is None:
             win = self.win
@@ -1476,7 +1478,7 @@ class ShowBase(DirectObject.DirectObject):
 
         return aspectRatio
 
-    def getSize(self, win = None):
+    def getSize(self, win: GraphicsOutput | None = None) -> tuple[int, int]:
         """
         Returns the actual size of the indicated (or main window), or the
         default size if there is not yet a main window.
@@ -2176,7 +2178,7 @@ class ShowBase(DirectObject.DirectObject):
                 music.setLoop(looping)
                 music.play()
 
-    def __resetPrevTransform(self, state):
+    def __resetPrevTransform(self, state: object) -> int:
         # Clear out the previous velocity deltas now, after we have
         # rendered (the previous frame).  We do this after the render,
         # so that we have a chance to draw a representation of spheres
@@ -2187,7 +2189,7 @@ class ShowBase(DirectObject.DirectObject):
         PandaNode.resetAllPrevTransform()
         return Task.cont
 
-    def __dataLoop(self, state):
+    def __dataLoop(self, state: object) -> int:
         # Check if there were newly connected devices.
         self.devices.update()
 
@@ -2197,7 +2199,7 @@ class ShowBase(DirectObject.DirectObject):
         self.dgTrav.traverse(self.dataRootNode)
         return Task.cont
 
-    def __ivalLoop(self, state):
+    def __ivalLoop(self, state: object) -> int:
         # Execute all intervals in the global ivalMgr.
         IntervalManager.ivalMgr.step()
         return Task.cont
@@ -2215,7 +2217,7 @@ class ShowBase(DirectObject.DirectObject):
             self.shadowTrav.traverse(self.render)
         return Task.cont
 
-    def __collisionLoop(self, state):
+    def __collisionLoop(self, state: object) -> int:
         # run the collision traversal if we have a
         # CollisionTraverser set.
         if self.cTrav:
@@ -2227,14 +2229,14 @@ class ShowBase(DirectObject.DirectObject):
         messenger.send("collisionLoopFinished")
         return Task.cont
 
-    def __audioLoop(self, state):
+    def __audioLoop(self, state: object) -> int:
         if self.musicManager is not None:
             self.musicManager.update()
         for x in self.sfxManagerList:
             x.update()
         return Task.cont
 
-    def __garbageCollectStates(self, state):
+    def __garbageCollectStates(self, state: object) -> int:
         """ This task is started only when we have
         garbage-collect-states set in the Config.prc file, in which
         case we're responsible for taking out Panda's garbage from
@@ -2245,7 +2247,7 @@ class ShowBase(DirectObject.DirectObject):
         RenderState.garbageCollect()
         return Task.cont
 
-    def __igLoop(self, state):
+    def __igLoop(self, state: object) -> int:
         if __debug__:
             # We render the watch variables for the onScreenDebug as soon
             # as we reasonably can before the renderFrame().
@@ -2285,7 +2287,7 @@ class ShowBase(DirectObject.DirectObject):
         throw_new_frame()
         return Task.cont
 
-    def __igLoopSync(self, state):
+    def __igLoopSync(self, state: object) -> int:
         if __debug__:
             # We render the watch variables for the onScreenDebug as soon
             # as we reasonably can before the renderFrame().
@@ -2294,6 +2296,7 @@ class ShowBase(DirectObject.DirectObject):
         if self.recorder:
             self.recorder.recordFrame()
 
+        assert self.cluster is not None
         self.cluster.collectData()
 
         # Finally, render the frame.
@@ -2323,6 +2326,7 @@ class ShowBase(DirectObject.DirectObject):
             time.sleep(0.1)
 
         self.graphicsEngine.readyFlip()
+        assert self.cluster is not None
         self.cluster.waitForFlipCommand()
         self.graphicsEngine.flipFrame()
 
@@ -2753,7 +2757,7 @@ class ShowBase(DirectObject.DirectObject):
                 self.oobeVis.reparentTo(self.camera)
             self.oobeMode = 1
 
-    def __oobeButton(self, suffix, button):
+    def __oobeButton(self, suffix: str, button: str) -> None:
         if button.startswith('mouse'):
             # Eat mouse buttons.
             return
@@ -3073,7 +3077,7 @@ class ShowBase(DirectObject.DirectObject):
         else:
             return Task.cont
 
-    def windowEvent(self, win):
+    def windowEvent(self, win: GraphicsOutput) -> None:
         if win != self.win:
             # This event isn't about our window.
             return
@@ -3092,9 +3096,9 @@ class ShowBase(DirectObject.DirectObject):
                 self.userExit()
 
             if properties.getForeground() and not self.mainWinForeground:
-                self.mainWinForeground = 1
+                self.mainWinForeground = True
             elif not properties.getForeground() and self.mainWinForeground:
-                self.mainWinForeground = 0
+                self.mainWinForeground = False
                 if __debug__:
                     if self.__autoGarbageLogging:
                         GarbageReport.b_checkForGarbageLeaks()
@@ -3102,12 +3106,12 @@ class ShowBase(DirectObject.DirectObject):
             if properties.getMinimized() and not self.mainWinMinimized:
                 # If the main window is minimized, throw an event to
                 # stop the music.
-                self.mainWinMinimized = 1
+                self.mainWinMinimized = True
                 messenger.send('PandaPaused')
             elif not properties.getMinimized() and self.mainWinMinimized:
                 # If the main window is restored, throw an event to
                 # restart the music.
-                self.mainWinMinimized = 0
+                self.mainWinMinimized = False
                 messenger.send('PandaRestarted')
 
             # If we have not forced the aspect ratio, let's see if it has
@@ -3125,7 +3129,7 @@ class ShowBase(DirectObject.DirectObject):
                     if self.wantRender2dp:
                         self.pixel2dp.setScale(2.0 / xsize, 1.0, 2.0 / ysize)
 
-    def adjustWindowAspectRatio(self, aspectRatio):
+    def adjustWindowAspectRatio(self, aspectRatio: float) -> None:
         """ This function is normally called internally by
         `windowEvent()`, but it may also be called to explicitly adjust
         the aspect ratio of the render/render2d DisplayRegion, by a


### PR DESCRIPTION
## Change description
These changes annotate the callback methods (and methods called by those methods) on `ShowBase` that are used by code that is already type-hinted. Of note is the fact that many of these take a second argument that is unused. I have elected to annotate these arguments with `object` to signify that any object can be passed here, but something like `AsyncTask` or `AsyncTask | None` is also an option.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
