### PR TITLE
Fix small dragging bugs with `DirectSlider`

### DIFF
--- a/panda/src/pgui/pgSliderBar.cxx
+++ b/panda/src/pgui/pgSliderBar.cxx
@@ -693,6 +693,11 @@ advance_scroll() {
  */
 void PGSliderBar::
 advance_page() {
+  // Do not try to advance the page while dragging
+  if (_dragging) {
+    return;
+  }
+
   // Is the mouse position left or right of the current thumb position?
   LPoint3 mouse = mouse_to_local(_mouse_pos) - _thumb_start;
   PN_stdfloat target_ratio = mouse.dot(_axis) / _range_x;
@@ -705,7 +710,7 @@ advance_page() {
     t = min(_ratio + _page_ratio - _scroll_ratio, target_ratio);
   }
   internal_set_ratio(t);
-  if (t == target_ratio) {
+  if (_ratio == target_ratio) {
     // We made it; begin dragging from now on until the user releases the
     // mouse.
     begin_drag();


### PR DESCRIPTION
:wave: Long time Panda3D user, first time contributor.

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->

I noticed some undesirable dragging behavior with `DirectSlider`. After clicking on the bar, when the thumb catches up to the cursor, we switch into dragging mode. After the mouse leaves the area of the slider, the thumb continues to somewhat track the movements of the mouse until the mouse reenters the slider area. This effect is more noticeable with larger page sizes.

<details>
<summary>Repro program and video</summary>

```py
from direct.showbase.ShowBase import ShowBase
from direct.gui.DirectSlider import DirectSlider

base = ShowBase()

DirectSlider(
    parent=base.aspect2d,
    frameSize=(-0.5,0.5,0.02,-0.02),
    thumb_frameSize=(-0.02,0.02,0.05,-0.05),
    range=(0, 1),
    pageSize=1,
)

base.run()
```

https://github.com/user-attachments/assets/62818f6b-7cc2-42d5-8e90-3b3cdd50a58b

</details>

Fixing this issue exposed another bug where the slider sometimes thinks it can switch to dragging mode while the cursor is actually outside the range of the slider.


## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

There are two parts to the solution:
- Check whether we are dragging before trying to advance the page. This prevents us from repeatedly calling `begin_drag` after dragging has already started.
- Compare `target_ratio` against `_ratio` instead of `t` when deciding to start dragging. `_radio` is clamped to the range of the slider bar so this should ensure we don't start dragging when the cursor is still outside the slider.

I did not see any test coverage I could update but if I missed somewhere I could add test cases please let me know!

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
