### PR TITLE
Update ShowBase.py to Restrict Window Size

### DIFF
--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -1127,7 +1127,20 @@ class ShowBase(DirectObject.DirectObject):
             del kw['startDirect']
 
         self.openMainWindow(*args, **kw)
+        if self.win: #initialized when function is called  
+            """
+            kw.pop allows us to recieve arguments from openDefaultWindow  
+            to allow different programs to have set widths and heights  
+            """
+            minWidth = kw.pop('minWidth',120) 
+            minHeight = kw.pop('minHeight',120)
 
+             # Set minimum window size
+            props = WindowProperties() 
+            # Set minimum width & height
+            props.setMinSize(minWidth, minHeight)   
+            #Due to inheritence from ShowBase.pu, it allows all games to recieve restricted window size
+            self.win.requestProperties(props) 
         if startDirect:
             self.__doStartDirect()
 


### PR DESCRIPTION
Prevent window resize to zero for divide by zero errors and error in rendering textures

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

## Checklist
I have done my best to ensure that…
* [ ] …I have familiarized myself with the CONTRIBUTING.md file
* [ ] …this change follows the coding style and design patterns of the codebase
* [ ] …I own the intellectual property rights to this code
* [ ] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
