### PR TITLE
direct: Annotate functions called directly by top-level code

### DIFF
--- a/direct/src/distributed/ClockDelta.py
+++ b/direct/src/distributed/ClockDelta.py
@@ -48,7 +48,7 @@ class ClockDelta(DirectObject.DirectObject):
 
     notify = DirectNotifyGlobal.directNotify.newCategory('ClockDelta')
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.globalClock = ClockObject.getGlobalClock()
 
         # self.delta is the relative delta from our clock to the

--- a/direct/src/extensions_native/extension_native_helpers.py
+++ b/direct/src/extensions_native/extension_native_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = ["Dtool_ObjectToDict", "Dtool_funcToMethod"]
 
 from collections.abc import Callable

--- a/direct/src/extensions_native/extension_native_helpers.py
+++ b/direct/src/extensions_native/extension_native_helpers.py
@@ -1,15 +1,17 @@
 __all__ = ["Dtool_ObjectToDict", "Dtool_funcToMethod"]
 
+from collections.abc import Callable
+
 
 def Dtool_ObjectToDict(cls, name, obj):
     cls.DtoolClassDict[name] = obj
 
 
-def Dtool_funcToMethod(func, cls, method_name=None):
+def Dtool_funcToMethod(func: Callable, cls, method_name: str | None = None) -> None:
     """Adds func to class so it is an accessible method; use method_name to specify the name to be used for calling the method.
     The new method is accessible to any instance immediately."""
-    func.__func__ = func
-    func.__self__ = None
+    func.__func__ = func  # type: ignore[attr-defined]
+    func.__self__ = None  # type: ignore[attr-defined]
     if not method_name:
         method_name = func.__name__
     cls.DtoolClassDict[method_name] = func

--- a/direct/src/showbase/ShowBase.py
+++ b/direct/src/showbase/ShowBase.py
@@ -382,7 +382,7 @@ class ShowBase(DirectObject.DirectObject):
         #: yourself every frame.
         self.cTrav: CollisionTraverser | Literal[0] = 0
         self.shadowTrav: CollisionTraverser | Literal[0] = 0
-        self.cTravStack = Stack()
+        self.cTravStack = Stack[CollisionTraverser]()
         # Ditto for an AppTraverser.
         self.appTrav: Any | Literal[0] = 0
 

--- a/direct/src/stdpy/thread.py
+++ b/direct/src/stdpy/thread.py
@@ -250,7 +250,7 @@ def exit():
     raise SystemExit
 
 
-def allocate_lock():
+def allocate_lock() -> LockType:
     return LockType()
 
 

--- a/direct/src/stdpy/threading2.py
+++ b/direct/src/stdpy/threading2.py
@@ -654,7 +654,7 @@ class _Timer(Thread):
 
 class _MainThread(Thread):
 
-    def __init__(self):
+    def __init__(self) -> None:
         Thread.__init__(self, name="MainThread")
         self._Thread__started = True
         _active_limbo_lock.acquire()

--- a/direct/src/tkpanels/Inspector.py
+++ b/direct/src/tkpanels/Inspector.py
@@ -48,7 +48,7 @@ def inspectorFor(anObject):
 
 ### initializing
 
-def initializeInspectorMap():
+def initializeInspectorMap() -> None:
     global _InspectorMap
     notFinishedTypes = ['BufferType',  'EllipsisType',  'FrameType', 'TracebackType', 'XRangeType']
 


### PR DESCRIPTION
## Change description
These changes annotate functions and methods that are called directly by top-level code elsewhere in the library, found by running mypy with the `--disallow-untyped-calls` option. This means that they are run by the test suite (since they run when the file is loaded) and their usage is covered by a type checker (since mypy checks top-level code and annotated functions).

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
