### PR TITLE
Add function for detecting auto repeate key events from i.e accessibi…

### DIFF
--- a/panda/src/x11display/config_x11display.cxx
+++ b/panda/src/x11display/config_x11display.cxx
@@ -91,6 +91,10 @@ ConfigVariableBool x_send_startup_notification
           "lets the window manager know that an application has launched, so "
           "that it no longer needs to display a spinning mouse cursor."));
 
+ConfigVariableBool x_detectable_auto_repeat
+("x-detectable-auto-repeat", false,
+ PRC_DESC("Set this true to enable detectable auto-repeat for keyboard input."));
+
 /**
  * Initializes the library.  This must be called at least once before any of
  * the functions or classes in this library can be used.  Normally it will be

--- a/panda/src/x11display/config_x11display.h
+++ b/panda/src/x11display/config_x11display.h
@@ -37,5 +37,6 @@ extern ConfigVariableInt x_cursor_size;
 extern ConfigVariableString x_wm_class_name;
 extern ConfigVariableString x_wm_class;
 extern ConfigVariableBool x_send_startup_notification;
+extern ConfigVariableBool x_detectable_auto_repeat;
 
 #endif

--- a/panda/src/x11display/x11GraphicsWindow.cxx
+++ b/panda/src/x11display/x11GraphicsWindow.cxx
@@ -126,10 +126,6 @@ x11GraphicsWindow(GraphicsEngine *engine, GraphicsPipe *pipe,
   add_input_device(device);
   _input = device;
 
-  // Disable accessibility settings
-  //disable_accessibility_settings();
-
-  // Enable detectable auto-repeat
   enable_detectable_auto_repeat();
 }
 

--- a/panda/src/x11display/x11GraphicsWindow.cxx
+++ b/panda/src/x11display/x11GraphicsWindow.cxx
@@ -97,8 +97,7 @@ x11GraphicsWindow(GraphicsEngine *engine, GraphicsPipe *pipe,
                   int flags,
                   GraphicsStateGuardian *gsg,
                   GraphicsOutput *host) :
-  GraphicsWindow(engine, pipe, name, fb_prop, win_prop, flags, gsg, host)
-{
+  GraphicsWindow(engine, pipe, name, fb_prop, win_prop, flags, gsg, host) {
   x11GraphicsPipe *x11_pipe;
   DCAST_INTO_V(x11_pipe, _pipe);
   _display = x11_pipe->get_display();
@@ -126,6 +125,12 @@ x11GraphicsWindow(GraphicsEngine *engine, GraphicsPipe *pipe,
   PT(GraphicsWindowInputDevice) device = GraphicsWindowInputDevice::pointer_and_keyboard(this, "keyboard_mouse");
   add_input_device(device);
   _input = device;
+
+  // Disable accessibility settings
+  //disable_accessibility_settings();
+
+  // Enable detectable auto-repeat
+  enable_detectable_auto_repeat();
 }
 
 /**
@@ -2744,4 +2749,18 @@ void x11GraphicsWindow::
 xim_preedit_done(XIC ic, XPointer client_data, XPointer call_data) {
   x11GraphicsWindow *window = (x11GraphicsWindow *)client_data;
   window->handle_preedit_done();
+}
+
+/**
+ * Enables detectable auto-repeat if supported by the X server.
+ */
+void x11GraphicsWindow::enable_detectable_auto_repeat() {
+  Bool supported;
+  if (XkbSetDetectableAutoRepeat(_display, True, &supported)) {
+    x11display_cat.info() << "Detectable auto-repeat enabled.\n";
+  } else if (!supported) {
+    x11display_cat.warning() << "Detectable auto-repeat is not supported by the X server.\n";
+  } else {
+    x11display_cat.error() << "Failed to set detectable auto-repeat.\n";
+  }
 }

--- a/panda/src/x11display/x11GraphicsWindow.cxx
+++ b/panda/src/x11display/x11GraphicsWindow.cxx
@@ -2750,7 +2750,12 @@ xim_preedit_done(XIC ic, XPointer client_data, XPointer call_data) {
 /**
  * Enables detectable auto-repeat if supported by the X server.
  */
-void x11GraphicsWindow::enable_detectable_auto_repeat() {
+void x11GraphicsWindow::
+enable_detectable_auto_repeat() {
+  if (!x_detectable_auto_repeat) {
+    return;
+  }
+  
   Bool supported;
   if (XkbSetDetectableAutoRepeat(_display, True, &supported)) {
     x11display_cat.info() << "Detectable auto-repeat enabled.\n";

--- a/panda/src/x11display/x11GraphicsWindow.h
+++ b/panda/src/x11display/x11GraphicsWindow.h
@@ -46,6 +46,8 @@ public:
 
   INLINE X11_Window get_xwindow() const;
 
+  void enable_detectable_auto_repeat();
+
 protected:
   virtual void close_window();
   virtual bool open_window();


### PR DESCRIPTION
…lity settings

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
Attempts to solve [#1478 ](https://github.com/panda3d/panda3d/issues/1478)
Use [XkbSetDetectableAutoRepeat](https://linux.die.net/man/3/xkbsetdetectableautorepeat) to avoid auto-repeat generated by OS accessibility settings, you need to call this function to enable detectable auto-repeat. This will allow to distinguish between key press events generated by actual key presses and those generated by auto-repeat.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

By calling [XkbSetDetectableAutoRepeat](https://linux.die.net/man/3/xkbsetdetectableautorepeat) with True, we enable detectable auto-repeat, which allows to distinguish between actual key presses and auto-repeat events. The supported variable will indicate whether the X server supports detectable auto-repeat. If it is not supported, we may need to handle auto-repeat events manually.
## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
