### PR TITLE
Exposing the native OpenGL ID (issue ##1468)

### DIFF
--- a/panda/src/glstuff/glBufferContext_src.cxx
+++ b/panda/src/glstuff/glBufferContext_src.cxx
@@ -47,3 +47,10 @@ evict_lru() {
   update_data_size_bytes(0);
   set_resident(false);
 }
+
+/**
+ * Returns the native OpenGL buffer ID for this buffer.
+ */
+uint64_t CLP(BufferContext)::get_native_id() const {
+  return static_cast<uint64_t>(_index);
+}

--- a/panda/src/glstuff/glBufferContext_src.h
+++ b/panda/src/glstuff/glBufferContext_src.h
@@ -27,6 +27,9 @@ public:
 
   virtual void evict_lru();
 
+  // Override to expose OpenGL buffer ID
+  virtual uint64_t get_native_id() const override;
+
   CLP(GraphicsStateGuardian) *_glgsg;
 
   // This is the GL "name" of the data object.

--- a/panda/src/glstuff/glIndexBufferContext_src.cxx
+++ b/panda/src/glstuff/glIndexBufferContext_src.cxx
@@ -47,3 +47,11 @@ evict_lru() {
   update_data_size_bytes(0);
   mark_unloaded();
 }
+
+/**
+ * Returns the native OpenGL buffer ID for this buffer.
+ */
+uint64_t CLP(IndexBufferContext)::get_native_id() const {
+  return static_cast<uint64_t>(_index);
+}
+

--- a/panda/src/glstuff/glIndexBufferContext_src.h
+++ b/panda/src/glstuff/glIndexBufferContext_src.h
@@ -27,6 +27,10 @@ public:
 
   virtual void evict_lru();
 
+  // Override to expose OpenGL buffer ID
+  virtual uint64_t get_native_id() const override;
+
+
   CLP(GraphicsStateGuardian) *_glgsg;
 
   // This is the GL "name" of the data object.

--- a/panda/src/glstuff/glVertexBufferContext_src.cxx
+++ b/panda/src/glstuff/glVertexBufferContext_src.cxx
@@ -47,3 +47,10 @@ evict_lru() {
   update_data_size_bytes(0);
   mark_unloaded();
 }
+
+/**
+ * Returns the OpenGL buffer ID associated with this vertex buffer context.
+ */
+uint64_t CLP(VertexBufferContext)::get_native_id() const {
+  return static_cast<uint64_t>(_index);  // Return the OpenGL buffer ID
+}

--- a/panda/src/glstuff/glVertexBufferContext_src.h
+++ b/panda/src/glstuff/glVertexBufferContext_src.h
@@ -29,6 +29,9 @@ public:
 
   virtual void evict_lru();
 
+  // Override to expose OpenGL buffer ID
+  virtual uint64_t get_native_id() const override;
+
   CLP(GraphicsStateGuardian) *_glgsg;
 
   // This is the GL "name" of the data object.

--- a/panda/src/gobj/bufferContext.cxx
+++ b/panda/src/gobj/bufferContext.cxx
@@ -17,6 +17,27 @@
 TypeHandle BufferContext::_type_handle;
 
 /**
+ * Returns an implementation-defined handle or pointer that can be used
+ * to interface directly with the underlying API.
+ * Returns 0 if the underlying implementation does not support this.
+ */
+uint64_t BufferContext::
+get_native_id() const {
+  return 0;
+}
+
+/**
+ * Similar to get_native_id, but some implementations use a separate
+ * identifier for the buffer object associated with buffer textures.
+ * Returns 0 if the underlying implementation does not support this, or
+ * if this is not a buffer texture.
+ */
+uint64_t BufferContext::
+get_native_buffer_id() const {
+  return 0;
+}
+
+/**
  *
  */
 BufferContext::

--- a/panda/src/gobj/bufferContext.h
+++ b/panda/src/gobj/bufferContext.h
@@ -47,6 +47,9 @@ PUBLISHED:
   INLINE UpdateSeq get_modified() const;
   INLINE bool get_active() const;
   INLINE bool get_resident() const;
+  
+  virtual uint64_t get_native_id() const;
+  virtual uint64_t get_native_buffer_id() const;
 
   MAKE_PROPERTY(object, get_object);
 


### PR DESCRIPTION
## Issue description
This change exposes the native OpenGL buffer ID via a virtual method in BufferContext. It allows external tools and libraries to interoperate with GPU buffers without copying data between system memory and GPU memory
( Issue #1468 )

## Solution description
This PR adds a new method virtual uint64_t get_native_id() const override; to the BufferContext class which returns the contents of the _index member cast to a uint64_t. The method provides direct access to the native OpenGL buffer ID, enabling efficient interoperability with external libraries like CUDA, TensorFlow, and PyTorch. The implementation adheres to Panda3D's existing design patterns and coding style.

## Checklist
I have done my best to ensure that…
* [ ] …I have familiarized myself with the CONTRIBUTING.md file
* [ ] …this change follows the coding style and design patterns of the codebase
* [ ] …I own the intellectual property rights to this code
* [ ] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
