### PR TITLE
Use Win32 native calls for atomic also with clang-cl

### DIFF
--- a/dtool/src/dtoolbase/atomicAdjust.h
+++ b/dtool/src/dtoolbase/atomicAdjust.h
@@ -30,7 +30,7 @@ struct AtomicAdjust {
 #include "atomicAdjustDummyImpl.h"
 typedef AtomicAdjustDummyImpl AtomicAdjust;
 
-#elif (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))) || (defined(__clang__) && (__clang_major__ >= 3))
+#elif (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))) || (defined(__clang__) && (__clang_major__ >= 3) && !defined(WIN32_VC) )
 // GCC 4.7 and above has built-in __atomic functions for atomic operations.
 // Clang 3.0 and above also supports them.
 


### PR DESCRIPTION
Tackles #1745 .

Other option would be to change of checks to prefer win32 as @rdb mentioned in the issue.

## Checklist
I have done my best to ensure that…
* [ ] …I have familiarized myself with the CONTRIBUTING.md file
* [ ] …this change follows the coding style and design patterns of the codebase
* [ ] …I own the intellectual property rights to this code
* [ ] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
