### PR TITLE
Support 3d party dependencies on Mac using homebrew

### DIFF
--- a/cmake/macros/PackageConfig.cmake
+++ b/cmake/macros/PackageConfig.cmake
@@ -223,6 +223,14 @@ function(package_option name)
 
       target_link_libraries(PKG::${name} INTERFACE ${libs})
 
+      if(DEFINED ${found_as}_LIBRARY_DIRS)
+        set(libdir ${${found_as}_LIBRARY_DIRS})
+      elseif(DEFINED ${found_as}_LIBDIR)
+        set(libdir ${${found_as}_LIBDIR})
+      endif()
+
+      target_link_directories(PKG::${name} INTERFACE ${libdir})
+
       # Hide it from Interrogate
       set_target_properties(PKG::${name} PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "$<${_is_not_interrogate}:${includes}>")


### PR DESCRIPTION
## Issue description

Issue #1747

Homebrew is a common way to install 3rd party packages on macOS. It is essentially a package manager, similar to apt, etc ... on linux. A big difference is that homebrew does not usually install libraries and headers in /usr/include and /usr/lib, but in /opt/homebrew/packagename/lib. Therefore linking often requires a library search directory specified.

## Solution description
This patch fixes the package_option make function to add the library search path to the interface library it creates, so that linking works with libraries from homebrew on macOS.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
