### PR TITLE
Add a Default Release Sound for DirectButtons

### DIFF
--- a/direct/src/gui/DirectButton.py
+++ b/direct/src/gui/DirectButton.py
@@ -44,6 +44,7 @@ class DirectButton(DirectFrame):
             # Sounds to be used for button events
             ('rolloverSound', DGG.getDefaultRolloverSound(), self.setRolloverSound),
             ('clickSound',    DGG.getDefaultClickSound(),    self.setClickSound),
+            ('releaseSound',  DGG.getDefaultReleaseSound(),  self.setReleaseSound),
             # Can only be specified at time of widget contruction
             # Do the text/graphics appear to move when the button is clicked
             ('pressEffect',     1,         DGG.INITOPT),
@@ -108,6 +109,13 @@ class DirectButton(DirectFrame):
             # Pass any extra args to command
             self['command'](*self['extraArgs'])
 
+    def setRolloverSound(self):
+        rolloverSound = self['rolloverSound']
+        if rolloverSound:
+            self.guiItem.setSound(DGG.ENTER + self.guiId, rolloverSound)
+        else:
+            self.guiItem.clearSound(DGG.ENTER + self.guiId)
+
     def setClickSound(self):
         clickSound = self['clickSound']
         # Clear out sounds
@@ -122,9 +130,16 @@ class DirectButton(DirectFrame):
             if DGG.RMB in self['commandButtons']:
                 self.guiItem.setSound(DGG.B3PRESS + self.guiId, clickSound)
 
-    def setRolloverSound(self):
-        rolloverSound = self['rolloverSound']
-        if rolloverSound:
-            self.guiItem.setSound(DGG.ENTER + self.guiId, rolloverSound)
-        else:
-            self.guiItem.clearSound(DGG.ENTER + self.guiId)
+    def setReleaseSound(self):
+        releaseSound = self['releaseSound']
+        # Clear out sounds
+        self.guiItem.clearSound(DGG.B1RELEASE + self.guiId)
+        self.guiItem.clearSound(DGG.B2RELEASE + self.guiId)
+        self.guiItem.clearSound(DGG.B3RELEASE + self.guiId)
+        if releaseSound:
+            if DGG.LMB in self['commandButtons']:
+                self.guiItem.setSound(DGG.B1RELEASE + self.guiId, releaseSound)
+            if DGG.MMB in self['commandButtons']:
+                self.guiItem.setSound(DGG.B2RELEASE + self.guiId, releaseSound)
+            if DGG.RMB in self['commandButtons']:
+                self.guiItem.setSound(DGG.B3RELEASE + self.guiId, releaseSound)

--- a/direct/src/gui/DirectCheckBox.py
+++ b/direct/src/gui/DirectCheckBox.py
@@ -28,6 +28,7 @@ class DirectCheckBox(DirectButton):
             # Sounds to be used for button events
             ('rolloverSound', DGG.getDefaultRolloverSound(), self.setRolloverSound),
             ('clickSound',    DGG.getDefaultClickSound(),    self.setClickSound),
+            ('releaseSound',  DGG.getDefaultReleaseSound(),  self.setReleaseSound),
             # Can only be specified at time of widget contruction
             # Do the text/graphics appear to move when the button is clicked
             ('pressEffect',     1,         DGG.INITOPT),

--- a/direct/src/gui/DirectGuiGlobals.py
+++ b/direct/src/gui/DirectGuiGlobals.py
@@ -17,8 +17,9 @@ from panda3d.core import (
 
 defaultFont = None
 defaultFontFunc = TextNode.getDefaultFont
-defaultClickSound = None
 defaultRolloverSound = None
+defaultClickSound = None
+defaultReleaseSound = None
 defaultDialogGeom = None
 defaultDialogRelief = PGFrameStyle.TBevelOut
 drawOrder = 100
@@ -128,6 +129,13 @@ def getDefaultClickSound():
 def setDefaultClickSound(newSound):
     global defaultClickSound
     defaultClickSound = newSound
+
+def getDefaultReleaseSound():
+    return defaultReleaseSound
+
+def setDefaultReleaseSound(newSound):
+    global defaultReleaseSound
+    defaultReleaseSound = newSound
 
 def getDefaultFont():
     global defaultFont


### PR DESCRIPTION
## Issue description
While DirectButtons have an audio state in mind for hovering over and pressing a button, there isn't a native option for release sounds.  If someone wanted to develop an interface that has a final sound for when the button is let go, they would have to inherit from DirectButton only to include a binding for release sounds.  I feel like including the option for default release sounds would be consistent with rollover and press.

## Solution description
Simply put, I set up a binding just like `setClickSound()` called `setReleaseSound()` which handles the release events for the 3 mouse button bindings.  I also added a global to DirectGUIGlobals that mirrors the other default sounds.  (As a small bit of "tidying", I also arranged the sound functions in matching order.)

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
