### PR TITLE
Adding BamCache::clear() to reset on-disk and in-memory cache .

### DIFF
--- a/panda/src/putil/bamCache.I
+++ b/panda/src/putil/bamCache.I
@@ -257,3 +257,11 @@ mark_index_stale() {
     _index_stale_since = time(nullptr);
   }
 }
+
+/** Clear the global cache **/ 
+INLINE void BamCache::
+clear_global() {
+  if (_global_ptr != nullptr) {
+    _global_ptr->clear();
+  }
+}

--- a/panda/src/putil/bamCache.cxx
+++ b/panda/src/putil/bamCache.cxx
@@ -958,6 +958,13 @@ do_read_record(const Filename &cache_pathname, bool read_data) {
 
   return record;
 }
+/* Reset the in-memory cache index to an empty state (caller must hold _lock). */
+void BamCache::
+reset_in_memory_index() {
+    delete _index;
+    _index = new BamCacheIndex;
+    _index_stale_since = 0;
+}
 
 /**
  * Returns the appropriate filename to use for a cache file, given the

--- a/panda/src/putil/bamCache.cxx
+++ b/panda/src/putil/bamCache.cxx
@@ -958,6 +958,80 @@ do_read_record(const Filename &cache_pathname, bool read_data) {
 
   return record;
 }
+
+/**
+ * Clear the model cache.
+ *
+ *
+ * Acquires the internal _lock for thread-safety (so callers do NOT need to hold the lock).
+ * If no cache root is configured ( _root.empty() ), returns immediately.
+ * If the cache is marked _read_only, resets only the in-memory index with warning message .
+ * If the VirtualFileSystem global pointer is not available, logs an error, resets only the in-memory index, and returns immediately.
+ * Otherwise, scans the cache root directory and deletes cache files matching the known cache extensions (.bam, .txo, .sho) .
+ * Removes the on-disk index file (if known) or the index reference file
+ * and clears the in-memory index reference contents.
+ * Resets the in-memory index to an empty BamCacheIndex.
+ * Marks the index stale and attempts to flush a new, empty on-disk index
+ * so other processes will observe the cleared state.
+ */
+void BamCache::
+clear() {
+    ReMutexHolder holder(_lock);
+
+    VirtualFileSystem *vfs = VirtualFileSystem::get_global_ptr();
+
+    if (_root.empty()) {
+        return;
+    }
+
+    // If the cache is read-only, only reset the in-memory index and log.
+    if (_read_only) {
+        util_cat.info() << "BamCache::clear(): cache is read-only; clearing in-memory index only.\n";
+        reset_in_memory_index();
+        return;
+    }
+
+    if (vfs == nullptr) {
+        util_cat.error() << "BamCache::clear(): VFS is not available\n";
+        reset_in_memory_index();
+        return;
+    }
+    // Delete cache files (.bam, .txo, .sho) in the cache root directory.
+    PT(VirtualFileList) contents = vfs->scan_directory(_root);
+    if (contents != nullptr) {
+        int num_files = contents->get_num_files();
+        for (int ci = 0; ci < num_files; ++ci) {
+            VirtualFile *file = contents->get_file(ci);
+            Filename filename = file->get_filename();
+            const std::string ext = filename.get_extension();
+
+            if (ext == "bam" || ext == "txo" || ext == "sho") {
+                Filename pathname(_root, filename);
+                if (!vfs->delete_file(pathname)) {
+                    util_cat.debug()
+                      << "Could not delete cache file " << pathname << "\n";
+                }
+            }
+        }
+    }
+
+    // Remove index files: the index file itself (if known) and the index ref.
+    Filename index_ref_pathname(_root, Filename("index_name.txt"));
+    if (!_index_pathname.empty()) {
+        vfs->delete_file(_index_pathname);
+        _index_pathname = Filename();
+        _index_ref_contents.clear();
+    } else {
+        vfs->delete_file(index_ref_pathname);
+    }
+
+    reset_in_memory_index();
+
+    // Try to write an empty index back to disk: mark stale then flush.
+    mark_index_stale();
+    flush_index();
+}
+
 /* Reset the in-memory cache index to an empty state (caller must hold _lock). */
 void BamCache::
 reset_in_memory_index() {

--- a/panda/src/putil/bamCache.h
+++ b/panda/src/putil/bamCache.h
@@ -81,7 +81,6 @@ PUBLISHED:
   void list_index(std::ostream &out, int indent_level = 0) const;
 
   void clear();
-  void reset_in_memory_index();
 
   INLINE static BamCache *get_global_ptr();
   INLINE static void consider_flush_global_index();
@@ -109,7 +108,7 @@ private:
   void merge_index(BamCacheIndex *new_index);
   void rebuild_index();
   INLINE void mark_index_stale();
-
+  void reset_in_memory_index(); 
   void add_to_index(const BamCacheRecord *record);
   void remove_from_index(const Filename &source_filename);
 

--- a/panda/src/putil/bamCache.h
+++ b/panda/src/putil/bamCache.h
@@ -81,6 +81,7 @@ PUBLISHED:
   void list_index(std::ostream &out, int indent_level = 0) const;
 
   void clear();
+  void reset_in_memory_index();
 
   INLINE static BamCache *get_global_ptr();
   INLINE static void consider_flush_global_index();

--- a/panda/src/putil/bamCache.h
+++ b/panda/src/putil/bamCache.h
@@ -80,9 +80,13 @@ PUBLISHED:
 
   void list_index(std::ostream &out, int indent_level = 0) const;
 
+  void clear();
+
   INLINE static BamCache *get_global_ptr();
   INLINE static void consider_flush_global_index();
   INLINE static void flush_global_index();
+
+  INLINE static void clear_global();
 
 PUBLISHED:
   MAKE_PROPERTY(active, get_active, set_active);

--- a/panda/src/putil/bamCacheIndex.I
+++ b/panda/src/putil/bamCacheIndex.I
@@ -20,3 +20,9 @@ BamCacheIndex() :
   _cache_size(0)
 {
 }
+INLINE void BamCache::
+clear_global() {
+  if (_global_ptr != nullptr) {
+    _global_ptr->clear();
+  }
+}

--- a/panda/src/putil/bamCacheIndex.I
+++ b/panda/src/putil/bamCacheIndex.I
@@ -20,9 +20,4 @@ BamCacheIndex() :
   _cache_size(0)
 {
 }
-INLINE void BamCache::
-clear_global() {
-  if (_global_ptr != nullptr) {
-    _global_ptr->clear();
-  }
-}
+


### PR DESCRIPTION
## Issue description
A function to clear the BamCache.

## Solution description
I created a method BamCache::clear() that clears the model cache , it is include lock to ensure thread safety. It deletes cache files under the configured cache root (.bam, .txo, .sho) and resets the in-memory index. I also created the in-memory reset into a private helper reset_in_memory_index() and added a clear_global() convenience wrapper for the global cache object.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
