### PR TITLE
Added static build configurations to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
         - macos-nometa-standard-makefile
         - windows-standard-unity-msvc
         - windows-nopython-nometa-standard-msvc
-
+        # static build profiles
+        - ubuntu-static-standard-makefile
+        - windows-static-standard-msvc
+        - macos-static-standard-makefile
         include:
         - profile: ubuntu-bionic-double-standard-unity-makefile
           os: ubuntu-22.04
@@ -29,7 +32,8 @@ jobs:
           python: YES
           eigen: NO
           double: YES
-
+          link_type: SHARED
+          
         - profile: ubuntu-bionic-coverage-ninja
           os: ubuntu-22.04
           config: Coverage
@@ -40,6 +44,7 @@ jobs:
           python: YES
           eigen: NO
           double: NO
+          link_type: SHARED
 
         #- profile: macos-coverage-unity-xcode
         #  os: macOS-13
@@ -62,6 +67,7 @@ jobs:
           python: YES
           eigen: NO
           double: NO
+          link_type: SHARED
 
         - profile: windows-standard-unity-msvc
           os: windows-2022
@@ -73,6 +79,7 @@ jobs:
           python: YES
           eigen: NO
           double: NO
+          link_type: SHARED
 
         - profile: windows-nopython-nometa-standard-msvc
           os: windows-2022
@@ -84,6 +91,43 @@ jobs:
           python: NO
           eigen: NO
           double: NO
+          link_type: SHARED
+          
+        - profile: ubuntu-static-standard-makefile
+          os: ubuntu-22.04
+          config: Standard
+          unity: YES
+          generator: Unix Makefiles
+          compiler: Default
+          metalibs: YES
+          python: YES
+          eigen: NO
+          double: NO
+          link_type: STATIC
+
+        - profile: windows-static-standard-msvc
+          os: windows-2022
+          config: Standard
+          unity: YES
+          generator: Visual Studio 17 2022
+          compiler: Default
+          metalibs: YES
+          python: YES
+          eigen: NO
+          double: NO
+          link_type: STATIC
+
+        - profile: macos-static-standard-makefile
+          os: macOS-13
+          config: Standard
+          unity: NO
+          generator: Unix Makefiles
+          compiler: Default
+          metalibs: NO
+          python: YES
+          eigen: NO
+          double: NO
+          link_type: STATIC
 
     runs-on: ${{ matrix.os }}
 
@@ -178,6 +222,7 @@ jobs:
         ${compilerLauncher:-}
         -D CMAKE_UNITY_BUILD=${{ matrix.unity }}
         -D CMAKE_BUILD_TYPE="${{ matrix.config }}"
+        -D BUILD_SHARED_LIBS=${{ matrix.link_type == 'STATIC' && 'NO' || 'YES' }}
         -D BUILD_METALIBS=${{ matrix.metalibs }}
         -D HAVE_PYTHON=${{ runner.os != 'Windows' && matrix.python || 'NO' }}
         -D HAVE_EIGEN=${{ matrix.eigen }}


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
Hello, I saw an open issue <a href="https://github.com/panda3d/panda3d/issues/1535">#1535</a> for adding CI static build configurations for different platforms. I have added 3 jobs for testing static builds on Ubuntu, Windows and macOS based platforms to .github/workflows/ci.yml.


<!-- Explain here how your PR solves the problem, what approach it takes. -->
While testing the jobs on Github Actions, I noticed the following error:

`ImportError while loading conftest '/Users/runner/work/panda3d/panda3d/tests/conftest.py'.
../tests/conftest.py:3: in <module>
    from panda3d import core
E   ImportError: cannot import name 'core' from 'panda3d' (/Users/runner/work/panda3d/panda3d/build/panda3d/__init__.py)`


## Checklist

I have done my best to ensure that:

* [ ] I have familiarized myself with the CONTRIBUTING.md file
* [ ] this change follows the coding style and design patterns of the codebase
* [ ] I own the intellectual property rights to this code
* [ ] the intent of this change is clearly explained
* [ ] existing uses of the Panda3D API are not broken
* [ ] The changed code is adequately covered by the test suite, where possible.
