### PR TITLE
Add support for different coordinate systems for 3d audio

### DIFF
--- a/panda/src/audiotraits/openalAudioManager.cxx
+++ b/panda/src/audiotraits/openalAudioManager.cxx
@@ -715,21 +715,85 @@ get_active() const {
 void OpenALAudioManager::
 audio_3d_set_listener_attributes(PN_stdfloat px, PN_stdfloat py, PN_stdfloat pz, PN_stdfloat vx, PN_stdfloat vy, PN_stdfloat vz, PN_stdfloat fx, PN_stdfloat fy, PN_stdfloat fz, PN_stdfloat ux, PN_stdfloat uy, PN_stdfloat uz) {
   ReMutexHolder holder(_lock);
-  _position[0] = px;
-  _position[1] = pz;
-  _position[2] = -py;
+  CoordinateSystem cs = get_default_coordinate_system();
 
-  _velocity[0] = vx;
-  _velocity[1] = vz;
-  _velocity[2] = -vy;
+  switch (cs) {
+  case CS_yup_right:
+    _position[0] = px;
+    _position[1] = py;
+    _position[2] = pz;
 
-  _forward_up[0] = fx;
-  _forward_up[1] = fz;
-  _forward_up[2] = -fy;
+    _velocity[0] = vx;
+    _velocity[1] = vy;
+    _velocity[2] = vz;
 
-  _forward_up[3] = ux;
-  _forward_up[4] = uz;
-  _forward_up[5] = -uy;
+    _forward_up[0] = fx;
+    _forward_up[1] = fy;
+    _forward_up[2] = fz;
+
+    _forward_up[3] = ux;
+    _forward_up[4] = uy;
+    _forward_up[5] = uz;
+    break;
+
+  case CS_zup_right:
+    _position[0] = px;
+    _position[1] = pz;
+    _position[2] = -py;
+
+    _velocity[0] = vx;
+    _velocity[1] = vz;
+    _velocity[2] = -vy;
+
+    _forward_up[0] = fx;
+    _forward_up[1] = fz;
+    _forward_up[2] = -fy;
+
+    _forward_up[3] = ux;
+    _forward_up[4] = uz;
+    _forward_up[5] = -uy;
+    break;
+
+  case CS_yup_left:
+    _position[0] = px;
+    _position[1] = py;
+    _position[2] = -pz;
+
+    _velocity[0] = vx;
+    _velocity[1] = vy;
+    _velocity[2] = -vz;
+
+    _forward_up[0] = fx;
+    _forward_up[1] = fy;
+    _forward_up[2] = -fz;
+
+    _forward_up[3] = ux;
+    _forward_up[4] = uy;
+    _forward_up[5] = -uz;
+    break;
+
+  case CS_zup_left:
+    _position[0] = px;
+    _position[1] = pz;
+    _position[2] = py;
+
+    _velocity[0] = vx;
+    _velocity[1] = vz;
+    _velocity[2] = vy;
+
+    _forward_up[0] = fx;
+    _forward_up[1] = fz;
+    _forward_up[2] = fy;
+
+    _forward_up[3] = ux;
+    _forward_up[4] = uz;
+    _forward_up[5] = uy;
+    break;
+
+  default:
+    nassert_raise("invalid coordinate system");
+    return;
+  }
 
 
   make_current();
@@ -749,21 +813,85 @@ audio_3d_set_listener_attributes(PN_stdfloat px, PN_stdfloat py, PN_stdfloat pz,
 void OpenALAudioManager::
 audio_3d_get_listener_attributes(PN_stdfloat *px, PN_stdfloat *py, PN_stdfloat *pz, PN_stdfloat *vx, PN_stdfloat *vy, PN_stdfloat *vz, PN_stdfloat *fx, PN_stdfloat *fy, PN_stdfloat *fz, PN_stdfloat *ux, PN_stdfloat *uy, PN_stdfloat *uz) {
   ReMutexHolder holder(_lock);
-  *px = _position[0];
-  *py = -_position[2];
-  *pz = _position[1];
+    CoordinateSystem cs = get_default_coordinate_system();
 
-  *vx = _velocity[0];
-  *vy = -_velocity[2];
-  *vz = _velocity[1];
+  switch (cs) {
+  case CS_yup_right:
+    *px = _position[0];
+    *py = _position[1];
+    *pz = _position[2];
 
-  *fx = _forward_up[0];
-  *fy = -_forward_up[2];
-  *fz = _forward_up[1];
+    *vx = _velocity[0];
+    *vy = _velocity[1];
+    *vz = _velocity[2];
 
-  *ux = _forward_up[3];
-  *uy = -_forward_up[5];
-  *uz = _forward_up[4];
+    *fx = _forward_up[0];
+    *fy = _forward_up[1];
+    *fz = _forward_up[2];
+
+    *ux = _forward_up[3];
+    *uy = _forward_up[4];
+    *uz = _forward_up[5];
+    break;
+
+  case CS_zup_right:
+    *px = _position[0];
+    *py = -_position[2];
+    *pz = _position[1];
+
+    *vx = _velocity[0];
+    *vy = -_velocity[2];
+    *vz = _velocity[1];
+
+    *fx = _forward_up[0];
+    *fy = -_forward_up[2];
+    *fz = _forward_up[1];
+
+    *ux = _forward_up[3];
+    *uy = -_forward_up[5];
+    *uz = _forward_up[4];
+    break;
+
+  case CS_yup_left:
+    *px = _position[0];
+    *py = _position[1];
+    *pz = -_position[2];
+
+    *vx = _velocity[0];
+    *vy = _velocity[1];
+    *vz = -_velocity[2];
+
+    *fx = _forward_up[0];
+    *fy = _forward_up[1];
+    *fz = -_forward_up[2];
+
+    *ux = _forward_up[3];
+    *uy = _forward_up[4];
+    *uz = -_forward_up[5];
+    break;
+
+  case CS_zup_left:
+    *px = _position[0];
+    *py = _position[2];
+    *pz = _position[1];
+
+    *vx = _velocity[0];
+    *vy = _velocity[2];
+    *vz = _velocity[1];
+
+    *fx = _forward_up[0];
+    *fy = _forward_up[2];
+    *fz = _forward_up[1];
+
+    *ux = _forward_up[3];
+    *uy = _forward_up[5];
+    *uz = _forward_up[4];
+    break;
+
+  default:
+    nassert_raise("invalid coordinate system");
+    return;
+  }
 }
 
 /**

--- a/panda/src/audiotraits/openalAudioSound.cxx
+++ b/panda/src/audiotraits/openalAudioSound.cxx
@@ -14,6 +14,7 @@
 
 // Panda Headers
 #include "throw_event.h"
+#include "coordinateSystem.h"
 #include "openalAudioSound.h"
 #include "openalAudioManager.h"
 
@@ -745,13 +746,53 @@ length() const {
 void OpenALAudioSound::
 set_3d_attributes(PN_stdfloat px, PN_stdfloat py, PN_stdfloat pz, PN_stdfloat vx, PN_stdfloat vy, PN_stdfloat vz) {
   ReMutexHolder holder(OpenALAudioManager::_lock);
-  _location[0] = px;
-  _location[1] = pz;
-  _location[2] = -py;
+  CoordinateSystem cs = get_default_coordinate_system();
 
-  _velocity[0] = vx;
-  _velocity[1] = vz;
-  _velocity[2] = -vy;
+  switch (cs) {
+  case CS_yup_right:
+    _location[0] = px;
+    _location[1] = py;
+    _location[2] = pz;
+
+    _velocity[0] = vx;
+    _velocity[1] = vy;
+    _velocity[2] = vz;
+    break;
+
+  case CS_zup_right:
+    _location[0] = px;
+    _location[1] = pz;
+    _location[2] = -py;
+
+    _velocity[0] = vx;
+    _velocity[1] = vz;
+    _velocity[2] = -vy;
+    break;
+
+  case CS_yup_left:
+    _location[0] = px;
+    _location[1] = py;
+    _location[2] = -pz;
+
+    _velocity[0] = vx;
+    _velocity[1] = vy;
+    _velocity[2] = -vz;
+    break;
+
+  case CS_zup_left:
+    _location[0] = px;
+    _location[1] = pz;
+    _location[2] = py;
+
+    _velocity[0] = vx;
+    _velocity[1] = vz;
+    _velocity[2] = vy;
+    break;
+
+  default:
+    nassert_raise("invalid coordinate system");
+    return;
+  }
 
   if (is_playing()) {
     _manager->make_current();


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
Fixes #1749.
Continuation of #1766 due to inactivity. (I hope that is okay)

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
Check which coordinate system is used, swap and/or negate axes accordingly before sending it to OpenAL.

yup_right -> No change needed
zup_right -> Flip Y and Z axis and  negate Z
yup_left  -> Negate Z axis
zup_left -> Flip Y and Z axis

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
