### PR TITLE
build: Allow to build for riscv64

### DIFF
--- a/dtool/src/dtoolbase/dtool_platform.h
+++ b/dtool/src/dtoolbase/dtool_platform.h
@@ -96,6 +96,9 @@
 #elif defined(__arm__)
 #define DTOOL_PLATFORM "linux_arm"
 
+#elif defined(__riscv)
+#define DTOOL_PLATFORM "linux_riscv"
+
 #elif defined(__ppc__)
 #define DTOOL_PLATFORM "linux_ppc"
 

--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -1427,7 +1427,7 @@ def CompileCxx(obj,src,opts):
                 if optlevel >= 4 or target == "android":
                     cmd += " -fno-rtti"
 
-        if ('SSE2' in opts or not PkgSkip("SSE2")) and not arch.startswith("arm") and arch != 'aarch64':
+        if ('SSE2' in opts or not PkgSkip("SSE2")) and arch.find('86') > 0:
             if GetTarget() != "emscripten":
                 cmd += " -msse2"
 


### PR DESCRIPTION
## Issue description
Without this patch, building on machines with the riscv64 ISA fails, as those don't have a `-msse2` compiler option and `DTOOL_PLATFORM` is undefined.

## Solution description
we ensure, `-msse2` is only added on x86 platforms and define `DTOOL_PLATFORM`. This will also help for other architectures such as ppc and s390.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
