### PR TITLE
Fixed bug 1292 Alpha problem with DirectGrid lines

### DIFF
--- a/direct/src/directtools/DirectGeometry.py
+++ b/direct/src/directtools/DirectGeometry.py
@@ -79,8 +79,8 @@ class LineNodePath(NodePath):
     def getVertex(self, index):
         return self.lineSegs.getVertex(index)
 
-    def getVertexColor(self):
-        return self.lineSegs.getVertexColor()
+    def getVertexColor(self, index):
+        return self.lineSegs.getVertexColor(index)
 
     def drawArrow(self, sv, ev, arrowAngle, arrowLength):
         """

--- a/direct/src/directtools/DirectGrid.py
+++ b/direct/src/directtools/DirectGrid.py
@@ -33,7 +33,7 @@ class DirectGrid(NodePath, DirectObject):
 
         self.centerLines = LineNodePath(self.lines)
         self.centerLines.lineNode.setName('centerLines')
-        self.centerLines.setColor(VBase4(1, 0, 0, 0))
+        self.centerLines.setColor(VBase4(1, 0, 0, 1))
         self.centerLines.setThickness(3)
 
         # Small marker to hilight snap-to-grid point


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
This change will prevent grid center lines from disappearing when transparency is enabled on the grid's parent NodePath.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
- Change center lines alpha from 0 to 1 in DirectGrid.py.
- Fix getVertexColor signature mismatch in DirectGeometry.py.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
