### PR TITLE
makepanda: fix for python >= 3.13 on android

### DIFF
--- a/makepanda/makepandacore.py
+++ b/makepanda/makepandacore.py
@@ -284,7 +284,7 @@ def GetHost():
         return 'darwin'
     elif sys.platform.startswith('linux'):
         try:
-            # Python seems to offer no built-in way to check this.
+            # Python versions before 3.13 reported android as "linux"
             osname = subprocess.check_output(["uname", "-o"])
             if osname.strip().lower() == b'android':
                 return 'android'
@@ -294,6 +294,9 @@ def GetHost():
             return 'linux'
     elif sys.platform.startswith('freebsd'):
         return 'freebsd'
+    # Handle for Python >= 3.13
+    elif sys.platform == 'android':
+        return 'android'
     else:
         exit('Unrecognized sys.platform: %s' % (sys.platform))
 

--- a/panda/src/android/site.py
+++ b/panda/src/android/site.py
@@ -6,6 +6,7 @@ from importlib.machinery import ModuleSpec
 
 from importlib import _bootstrap_external
 
+# This should not be needed once we bump the minimum python version requirement to 3.13
 sys.platform = "android"
 
 class AndroidExtensionFinder(MetaPathFinder):


### PR DESCRIPTION
android is now a supported platform Python since Python 3.13

Found initially during Python bump for Termux (https://github.com/termux/termux-packages/pull/27739)

Also seems like Pyright too hasn't caught up with this yet. So it needs
to be made aware as well

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
