### PR TITLE
makepanda: Add PSTATS to the list of supported packages

### DIFF
--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -95,7 +95,7 @@ PkgListSet(["PYTHON", "DIRECT",                        # Python support
   "MFC", "WX", "FLTK",                                 # Used for web plug-in only
   "COCOA",                                             # macOS toolkits
   "X11",                                               # Unix platform support
-  "PANDATOOL", "PVIEW", "DEPLOYTOOLS",                 # Toolchain
+  "PANDATOOL", "PSTATS", "PVIEW", "DEPLOYTOOLS",       # Toolchain
   "SKEL",                                              # Example SKEL project
   "PANDAFX",                                           # Some distortion special lenses
   "PANDAPARTICLESYSTEM",                               # Built in particle system


### PR DESCRIPTION
## Issue description

Fixes #1790 : RPM branch of `MakeInstallerLinux()` uses `PkgSkip()` to conditionally creates desktop shortcuts for `pview` and `pstats` by respectively checking if `PVIEW` or `PSTATS` packages are selected by the user. However, `PSTATS` is not defined in the supported packages list, hence causing a crash when generating the rpm target.

## Solution description

Simply adding `PSTATS` when creating the list of supported packages seems to fix the issue on fresh builds.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
