### PR TITLE
DirectEntry.py: Use the _autoCapListener to prevent the blockage of the "type" event

### DIFF
--- a/direct/src/gui/DirectEntry.py
+++ b/direct/src/gui/DirectEntry.py
@@ -211,8 +211,8 @@ class DirectEntry(DirectFrame):
         if self['focusInCommand']:
             self['focusInCommand'](*self['focusInExtraArgs'])
         if self['autoCapitalize']:
-            self.accept(self.guiItem.getTypeEvent(), self._handleTyping)
-            self.accept(self.guiItem.getEraseEvent(), self._handleErasing)
+            self._autoCapListener.accept(self.guiItem.getTypeEvent(), self._handleTyping)
+            self._autoCapListener.accept(self.guiItem.getEraseEvent(), self._handleErasing)
 
     def _handleTyping(self, guiEvent):
         self._autoCapitalize()


### PR DESCRIPTION
Changing "focusInCommandFunc"'s call to "accept" such that it now uses the "_autoCapListener" listener object, as in the case of the similar call in "autoCapitalizeFunc".

This should prevent DirectEntry from blocking the user's attempts to bind the "type" event.

## Issue description
As shown in [this issue](https://github.com/panda3d/panda3d/issues/1804), as it stands a DirectEntry with auto-capitalisation set will block the binding of the "type" event.

## Solution description
As it happens, DirectEntry already has a system in place to prevent such blockage: a DirectObject named "_autoCapListener", which accepts the "type" event in place of the DirectEntry itself.

At least, when constructing the DirectEntry.

When the "focusInCommandFunc" method is called, however, the code therein re-accepts the "type" event--and does so with the DirectEntry, not "_autoCapListener".

This pull-request then changes the code in "focusInCommandFunc" to instead use "_autoCapListener", in keeping with the code that is called by the constructor.

A quick test seems to show that this solution works.

## Checklist
I have done my best to ensure that…
* [ X ] …I have familiarized myself with the CONTRIBUTING.md file
* [ X ] …this change follows the coding style and design patterns of the codebase
* [ X ] …I own the intellectual property rights to this code
* [ X ] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ X ] …the changed code is adequately covered by the test suite, where possible.

(Regarding the second-to-last above, it's hard to say whether anyone has written code that--whether intentionally or implicitly--relies on the original behaviour.)

(Regarding the last above, I presume that the changes are covered to the extent that DirectEntry was previously covered, as the changes are very limited in scope.)