### PR TITLE
Add _clamp_blend_flag to partBundle

### DIFF
--- a/panda/src/chan/movingPartMatrix.cxx
+++ b/panda/src/chan/movingPartMatrix.cxx
@@ -116,7 +116,7 @@ get_blend_value(const PartBundle *root) {
           if (restore_initial_pose) {
             _value = _default_value;
           }
-        } else {
+        } else if (cdata->_clamp_blend_flag) {
           _value = net_value / net_effect;
         }
       }
@@ -185,9 +185,11 @@ get_blend_value(const PartBundle *root) {
           }
 
         } else {
-          net_value /= net_effect;
-          scale /= net_effect;
-          shear /= net_effect;
+          if (cdata->_clamp_blend_flag) {
+            net_value /= net_effect;
+            scale /= net_effect;
+            shear /= net_effect;
+          }
 
           // Now rebuild the matrix with the correct scale values.
 
@@ -264,10 +266,12 @@ get_blend_value(const PartBundle *root) {
           }
 
         } else {
-          scale /= net_effect;
-          hpr /= net_effect;
-          pos /= net_effect;
-          shear /= net_effect;
+          if (cdata->_clamp_blend_flag) {
+            scale /= net_effect;
+            hpr /= net_effect;
+            pos /= net_effect;
+            shear /= net_effect;
+          }
 
           compose_matrix(_value, scale, shear, hpr, pos);
         }
@@ -342,10 +346,12 @@ get_blend_value(const PartBundle *root) {
           }
 
         } else {
-          scale /= net_effect;
-          quat /= net_effect;
-          pos /= net_effect;
-          shear /= net_effect;
+          if (cdata->_clamp_blend_flag) {
+            scale /= net_effect;
+            quat /= net_effect;
+            pos /= net_effect;
+            shear /= net_effect;
+          }
 
           // There should be no need to normalize the quaternion, assuming all
           // of the input quaternions were already normalized.

--- a/panda/src/chan/partBundle.I
+++ b/panda/src/chan/partBundle.I
@@ -83,6 +83,42 @@ get_anim_blend_flag() const {
 }
 
 /**
+ * Specifies whether the character clamps the weight of all
+ * currently playing animations to a total value of one or not.
+ * 
+ * When this value is true, the character will divide the result of the blending
+ * of all active animations by the sum of the effects each animation set on the corrisponding partBundle.
+ * For example, if you set two animations to play with an effect of 0.8 each, the end result is as if
+ * each animation was set with an effect of 0.625. (animation *= 1/(0.8 + 0.8))
+ *
+ * When this value is false, the above process does not occur, which if not accounted for may result in
+ * animations causing much more extreme, wild movements when blended together.
+ *
+ * The programmer may still account for this however, by manually dividing the weights of a semantic
+ * "animation layer" by their sum before setting their control effects.
+ * The benefit to disabling this flag is that it allows you to set "additive animation" on a character.
+ * For example, if you play animations A and B, a bone's position would be it's position in A plus it's
+ * position in b.
+ */
+INLINE void PartBundle::
+set_clamp_blend_flag(bool clamp_blend_flag) {
+  nassertv(Thread::get_current_pipeline_stage() == 0);
+  CDWriter cdata(_cycler);
+  cdata->_clamp_blend_flag = clamp_blend_flag;
+}
+
+/**
+ * Returns whether the character clamps the weight of it's active animations
+ * to one or not.
+ * See set_frame_blend_flag().
+ */
+INLINE bool PartBundle::
+get_clamp_blend_flag() const {
+  CDReader cdata(_cycler);
+  return cdata->_clamp_blend_flag;
+}
+
+/**
  * Specifies whether the character interpolates (blends) between two
  * sequential frames of an active animation, showing a smooth intra-frame
  * motion, or whether it holds each frame until the next frame is ready,

--- a/panda/src/chan/partBundle.cxx
+++ b/panda/src/chan/partBundle.cxx
@@ -60,6 +60,7 @@ PartBundle(const PartBundle &copy) :
   CDReader cdata_from(copy._cycler);
   cdata->_blend_type = cdata_from->_blend_type;
   cdata->_anim_blend_flag = cdata_from->_anim_blend_flag;
+  cdata->_clamp_blend_flag = cdata_from->_clamp_blend_flag;
   cdata->_frame_blend_flag = cdata_from->_frame_blend_flag;
   cdata->_root_xform = cdata_from->_root_xform;
 }
@@ -818,6 +819,7 @@ PartBundle::CData::
 CData() {
   _blend_type = anim_blend_type;
   _anim_blend_flag = false;
+  _clamp_blend_flag = true;
   _frame_blend_flag = interpolate_frames;
   _root_xform = LMatrix4::ident_mat();
   _last_control_set = nullptr;
@@ -832,6 +834,7 @@ PartBundle::CData::
 CData(const PartBundle::CData &copy) :
   _blend_type(copy._blend_type),
   _anim_blend_flag(copy._anim_blend_flag),
+  _clamp_blend_flag(copy._clamp_blend_flag),
   _frame_blend_flag(copy._frame_blend_flag),
   _root_xform(copy._root_xform),
   _last_control_set(copy._last_control_set),
@@ -860,6 +863,7 @@ void PartBundle::CData::
 write_datagram(BamWriter *manager, Datagram &dg) const {
   dg.add_uint8(_blend_type);
   dg.add_bool(_anim_blend_flag);
+  dg.add_bool(_clamp_blend_flag);
   dg.add_bool(_frame_blend_flag);
   _root_xform.write_datagram(dg);
 
@@ -874,6 +878,7 @@ void PartBundle::CData::
 fillin(DatagramIterator &scan, BamReader *manager) {
   _blend_type = (BlendType)scan.get_uint8();
   _anim_blend_flag = scan.get_bool();
+  _clamp_blend_flag = scan.get_bool();
   _frame_blend_flag = scan.get_bool();
   _root_xform.read_datagram(scan);
 }

--- a/panda/src/chan/partBundle.h
+++ b/panda/src/chan/partBundle.h
@@ -101,6 +101,9 @@ PUBLISHED:
   void set_anim_blend_flag(bool anim_blend_flag);
   INLINE bool get_anim_blend_flag() const;
 
+  INLINE void set_clamp_blend_flag(bool clamp_blend_flag);
+  INLINE bool get_clamp_blend_flag() const;
+
   INLINE void set_frame_blend_flag(bool frame_blend_flag);
   INLINE bool get_frame_blend_flag() const;
 
@@ -115,6 +118,7 @@ PUBLISHED:
 
   MAKE_PROPERTY(blend_type, get_blend_type, set_blend_type);
   MAKE_PROPERTY(anim_blend_flag, get_anim_blend_flag, set_anim_blend_flag);
+  MAKE_PROPERTY(clamp_blend_flag, get_clamp_blend_flag, set_clamp_blend_flag);
   MAKE_PROPERTY(frame_blend_flag, get_frame_blend_flag, set_frame_blend_flag);
   MAKE_PROPERTY(root_xform, get_root_xform, set_root_xform);
   MAKE_SEQ_PROPERTY(nodes, get_num_nodes, get_node);
@@ -191,6 +195,7 @@ private:
 
     BlendType _blend_type;
     bool _anim_blend_flag;
+    bool _clamp_blend_flag;
     bool _frame_blend_flag;
     LMatrix4 _root_xform;
     AnimControl *_last_control_set;


### PR DESCRIPTION
## Issue description
Gives users/programmers the option to disable the clamping of all animation weights to one when blending multiple animations.
Closes #1811 

## Solution description
Adds the boolean _clamp_blend_flag to partBundle's CycleData..
also adds the functionality that setting said flag "off" disables the divide by net_weight that normally occurs in MovingPartMatrix::get_blend_value().

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [ ] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.
