### PR TITLE
DirectOptionMenu: Check whether text may change before attempting to set text

### DIFF
--- a/direct/src/gui/DirectOptionMenu.py
+++ b/direct/src/gui/DirectOptionMenu.py
@@ -295,7 +295,8 @@ class DirectOptionMenu(DirectButton):
         if newIndex is not None:
             self.selectedIndex = newIndex
             item = self['items'][self.selectedIndex]
-            self['text'] = item
+            if self['textMayChange']:
+                self['text'] = item
             if fCommand and self['command']:
                 # Pass any extra args to command
                 self['command'](*[item] + self['extraArgs'])


### PR DESCRIPTION
## Issue description
Without this check, DirectOptionMenu attempts to set its text whenever its current item is set--even if "textMayChange" is set to "False"/"0".

While largely harmless, this does seem to result in output spam from OnscreenText, complaining that "mayChange" has a value of "0".

## Solution description
This commit attempts to address this by first checking the value of "textMayChange" before attempting to set the value of the "text" parameter.

## Note
While I've submitted this for the "Master" branch, unless 1.11 is very close to release, I'd like to request that it also be added to the 1.10 branch.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.

Regarding "existing uses" above, this _shouldn't_ break anything. However, I suppose that it's vaguely possible that someone is, for some reason, relying on that output spam for something. This would, of course, break that.

As to the test suite, I'll admit that I haven't checked that for so minor a change.