### PR TITLE
Remove reference to `--osxtarget` from build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,6 @@ you may build Panda3D using a command like the following:
 python makepanda/makepanda.py --everything --installer
 ```
 
-You may target a specific minimum macOS version using the --osxtarget flag
-followed by the release number, eg. 10.9 or 10.14.
-
 If the build was successful, makepanda will have generated a .dmg file in
 the source directory containing the installer.  Simply open it and run the
 package file in order to install the SDK onto your system.


### PR DESCRIPTION
## Issue description
The `--osxtarget` build option has been deprecated since 8231bc1. The build instructions in README.md for macOS still include instructions to use it.

## Solution description
This updates the build instructions in README.md to reflect that.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
