### PR TITLE
Update Bullet example code to more accurately reflect mesh contents

### DIFF
--- a/samples/bullet-physics/20_bowl_and_eggs.py
+++ b/samples/bullet-physics/20_bowl_and_eggs.py
@@ -131,13 +131,14 @@ class Game(ShowBase):
 
         # Bowl
         visNP = loader.load_model('models/bowl.egg')
+        # This is necessary to incorporate internal transforms and submeshes into the geometry imported into Bullet. If
+        # you don't want to alter your model's internal structure, you can also follow the BulletConvexHullShape example
+        # below.
+        visNP.flatten_strong()
 
+        geom = visNP.findAllMatches('**/+GeomNode').get_path(0).node().get_geom(0)
         mesh = BulletTriangleMesh()
-        geomNodes = visNP.findAllMatches('**/+GeomNode')
-        for geomNode in geomNodes:
-            ts = geomNode.getTransform()
-            for geom in geomNode.node().getGeoms():
-                mesh.addGeom(geom, True, ts)
+        mesh.addGeom(geom)
 
         shape = BulletTriangleMeshShape(mesh, dynamic=True)
 
@@ -166,12 +167,10 @@ class Game(ShowBase):
 
             visNP = loader.load_model('models/egg.egg')
 
-            geom = (visNP.find_all_matches('**/+GeomNode')
-                    .get_path(0).node().get_geom(0))
             shape = BulletConvexHullShape()
             geomNodes = visNP.findAllMatches('**/+GeomNode')
             for geomNode in geomNodes:
-                ts = geomNode.getTransform()
+                ts = geomNode.getTransform(visNP)
                 for geom in geomNode.node().getGeoms():
                     shape.addGeom(geom, ts)
 

--- a/samples/bullet-physics/20_bowl_and_eggs.py
+++ b/samples/bullet-physics/20_bowl_and_eggs.py
@@ -132,10 +132,13 @@ class Game(ShowBase):
         # Bowl
         visNP = loader.load_model('models/bowl.egg')
 
-        geom = (visNP.findAllMatches('**/+GeomNode')
-                .get_path(0).node().get_geom(0))
         mesh = BulletTriangleMesh()
-        mesh.addGeom(geom)
+        geomNodes = visNP.findAllMatches('**/+GeomNode')
+        for geomNode in geomNodes:
+            ts = geomNode.getTransform()
+            for geom in geomNode.node().getGeoms():
+                mesh.addGeom(geom, True, ts)
+
         shape = BulletTriangleMeshShape(mesh, dynamic=True)
 
         body = BulletRigidBodyNode('Bowl')
@@ -166,7 +169,11 @@ class Game(ShowBase):
             geom = (visNP.find_all_matches('**/+GeomNode')
                     .get_path(0).node().get_geom(0))
             shape = BulletConvexHullShape()
-            shape.addGeom(geom)
+            geomNodes = visNP.findAllMatches('**/+GeomNode')
+            for geomNode in geomNodes:
+                ts = geomNode.getTransform()
+                for geom in geomNode.node().getGeoms():
+                    shape.addGeom(geom, ts)
 
             body = BulletRigidBodyNode('Egg-%i' % i)
             bodyNP = self.worldNP.attach_new_node(body)


### PR DESCRIPTION
Many meshes include multiple submeshes, as well as built-in transforms. The existing example code only takes the untransformed vertices of the first submesh, which creates some very confusing and time-consuming behavioral inconsistencies if someone is following an example with a model that is more complex than this. This fixes the example code to be more robust. The examples in the docs under Bullet collision shapes for Convex Hull and Triangle Mesh should also be updated.

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
