### PR TITLE
fix assertion failure on GSG destruction after window close

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1578,36 +1578,12 @@ handle_close_event() {
 
   _window = nil;
 
-  // Get rid of the GSG
-  if (_gsg != nullptr) {
-    unbind_context();
-    _gsg.clear();
-  }
-
-  // Dump the view, too
-  if (_view != nil) {
-    [_view release];
-    _view = nil;
-  }
-
-  // Unhide the mouse cursor
-  if (_mouse_hidden) {
-    [NSCursor unhide];
-    _mouse_hidden = false;
-  }
-
-  // Release the cursor.
-  if (_cursor != nil) {
-    [_cursor release];
-    _cursor = nil;
-  }
+  close_window();
 
   WindowProperties properties;
   properties.set_open(false);
   properties.set_cursor_hidden(false);
   system_changed_properties(properties);
-
-  GraphicsWindow::close_window();
 }
 
 /**


### PR DESCRIPTION
## Issue description

On macOS, closing a `p3vulkandisplay` window via the OS close button (cmd+q) caused an assert reported on #1871 .

## Solution description
`CocoaGraphicsWindow::handle_close_event()` duplicated `GraphicsWindow::close_window()`'s cleanup inline (releasing the GSG, view, cursor, etc.) and then call `GraphicsWindow::close_window()` directly at the end. That bypassed any derived `close_window()` override.

This PR replaces the inline cleanup with a single call to the virtual `close_window()`.

Disclaimer: I used Claude Code to help me track down the problem and find a solution. I thoroughly reviewed the changes to understand the rationale and the fix.

Command I used to build the branch:

```sh
➜  panda3d git:(fix/vulkan-window-close-gsg-assert) ✗ pwd
/Users/daniel/Dev/panda3d-playground/panda3d
➜  panda3d git:(fix/vulkan-window-close-gsg-assert) ✗ FW=/opt/homebrew/opt/python@3.12/Frameworks/Python.framework/Versions/3.12
HB=/opt/homebrew
../venv/bin/python3.12 makepanda/makepanda.py --everything --threads=6 \
  --no-fftw --no-mimalloc --no-gles --no-gles2 --no-egl --no-openexr --no-fmodex --no-speedtree --no-gtk3 --no-dx9 \
  --python-incdir=$FW/include --python-libdir=$FW/lib \
  --glslang-incdir=$HB/include --glslang-libdir=$HB/lib \
  --spirv-cross-incdir=$HB/include --spirv-cross-libdir=$HB/lib \
  --spirv-tools-incdir=$HB/include --spirv-tools-libdir=$HB/lib \
  --vulkan-incdir=$HB/include --vulkan-libdir=$HB/opt/vulkan-loader/lib
Version: 1.11.0
Platform: macosx-11.0-arm64
Using macOS 15.4 SDK
Using Python 3.12
Target OS: darwin
Target arch: arm64
```

And validated the fix like so:

```sh
➜  panda3d-playground pwd
/Users/daniel/Dev/panda3d-playground
➜  panda3d-playground PYTHONPATH=panda3d/built venv/bin/python3.12 minimal.py 
Known pipe types:
  VulkanGraphicsPipe
(1 aux display modules not yet loaded.)
Window open. Now close the runtime to trigger the assert.
➜  panda3d-playground 
```


## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [ ] …the changed code is adequately covered by the test suite, where possible.

**Note**: regarding writing a test to cover it, I tested it manually and I'm not sure if you'd want a test that requires creating a window and then closing it. Please advise.