### PR TITLE
bullet: Expose btConvexHullShape::optimizeConvexHull in BulletConvexH…

### DIFF
--- a/panda/src/bullet/bulletConvexHullShape.cxx
+++ b/panda/src/bullet/bulletConvexHullShape.cxx
@@ -143,6 +143,26 @@ add_geom(const Geom *geom, const TransformState *ts) {
 }
 
 /**
+ *
+ */
+int BulletConvexHullShape::
+get_num_points() const {
+  LightMutexHolder holder(BulletWorld::get_global_lock());
+
+  return _shape->getNumPoints();
+}
+
+/**
+ *
+ */
+void BulletConvexHullShape::
+optimize_convex_hull() {
+  LightMutexHolder holder(BulletWorld::get_global_lock());
+
+  _shape->optimizeConvexHull();
+}
+
+/**
  * Tells the BamReader how to create objects of type BulletShape.
  */
 void BulletConvexHullShape::

--- a/panda/src/bullet/bulletConvexHullShape.h
+++ b/panda/src/bullet/bulletConvexHullShape.h
@@ -38,6 +38,11 @@ PUBLISHED:
   void add_geom(const Geom *geom,
                 const TransformState *ts=TransformState::make_identity());
 
+  int get_num_points() const;
+  void optimize_convex_hull();
+
+  MAKE_PROPERTY(num_points, get_num_points);
+
 public:
   virtual btCollisionShape *ptr() const;
 

--- a/tests/bullet/test_bullet_bam.py
+++ b/tests/bullet/test_bullet_bam.py
@@ -153,6 +153,29 @@ def test_convex_shape():
     assert shape.margin == shape2.margin
 
 
+def test_convex_hull_optimization():
+    shape = bullet.BulletConvexHullShape()
+    shape.add_array([
+        (-1.0, -1.0, -1.0),
+        (1.0, -1.0, -1.0),
+        (-1.0, 1.0, -1.0),
+        (-1.0, -1.0, 1.0),
+        (1.0, 1.0, -1.0),
+        (1.0, -1.0, 1.0),
+        (-1.0, 1.0, 1.0),
+        (1.0, 1.0, 1.0),
+        (0.0, 0.0, 0.0),
+    ])
+
+    assert shape.get_num_points() == 9
+    assert shape.num_points == 9
+
+    shape.optimize_convex_hull()
+
+    assert shape.get_num_points() == 8
+    assert shape.num_points == 8
+
+
 def test_ghost():
     node = bullet.BulletGhostNode("some ghost node")
 


### PR DESCRIPTION
…ullShape

## Issue description
This change resolves #1866 by exposing the `btConvexHullShape::optimizeConvexHull` method on the `BulletConvexHullShape` class. This allows automatically removing redundant/interior points from a convex hull, improving collision detection performance and physical accuracy when creating a convex hull programmatically from a mesh.
 fixes=#1866
## Solution description
We exposed the following methods/properties on the `BulletConvexHullShape` class:
* `void optimize_convex_hull()`: Calls the underlying `btConvexHullShape::optimizeConvexHull` under global lock protection.
* `int get_num_points() const`: Exposes a way to query the count of vertices currently defining the shape, matching the interface pattern of `BulletConvexPointCloudShape`.
* Python property `num_points` mapped to `get_num_points()`.

We also added a Python unit test `test_convex_hull_optimization` in `tests/bullet/test_bullet_bam.py` that verifies that adding a redundant interior point and then calling `optimize_convex_hull()` successfully reduces the point count by 1.

## Checklist
I have done my best to ensure that...
* [x] ...I have familiarized myself with the CONTRIBUTING.md file
* [x] ...this change follows the coding style and design patterns of the codebase
* [x] ...I own the intellectual property rights to this code
* [x] ...the intent of this change is clearly explained
* [x] ...existing uses of the Panda3D API are not broken
* [x] ...the changed code is adequately covered by the test suite, where possible.