### PR TITLE
bullet: Expose get_num_points and get_point in BulletConvexHullShape

### DIFF
--- a/panda/src/bullet/bulletConvexHullShape.cxx
+++ b/panda/src/bullet/bulletConvexHullShape.cxx
@@ -143,6 +143,27 @@ add_geom(const Geom *geom, const TransformState *ts) {
 }
 
 /**
+ *
+ */
+int BulletConvexHullShape::
+get_num_points() const {
+  LightMutexHolder holder(BulletWorld::get_global_lock());
+
+  return _shape->getNumPoints();
+}
+
+/**
+ *
+ */
+LPoint3 BulletConvexHullShape::
+get_point(int i) const {
+  LightMutexHolder holder(BulletWorld::get_global_lock());
+
+  nassertr(i >= 0 && i < _shape->getNumPoints(), LPoint3::zero());
+  return btVector3_to_LPoint3(_shape->getUnscaledPoints()[i]);
+}
+
+/**
  * Tells the BamReader how to create objects of type BulletShape.
  */
 void BulletConvexHullShape::

--- a/panda/src/bullet/bulletConvexHullShape.h
+++ b/panda/src/bullet/bulletConvexHullShape.h
@@ -38,12 +38,12 @@ PUBLISHED:
   void add_geom(const Geom *geom,
                 const TransformState *ts=TransformState::make_identity());
 
+  MAKE_SEQ_PROPERTY(points, get_num_points, get_point);
+
+public:
   int get_num_points() const;
   LPoint3 get_point(int i) const;
 
-  MAKE_PROPERTY(num_points, get_num_points);
-
-public:
   virtual btCollisionShape *ptr() const;
 
 private:

--- a/panda/src/bullet/bulletConvexHullShape.h
+++ b/panda/src/bullet/bulletConvexHullShape.h
@@ -38,6 +38,11 @@ PUBLISHED:
   void add_geom(const Geom *geom,
                 const TransformState *ts=TransformState::make_identity());
 
+  int get_num_points() const;
+  LPoint3 get_point(int i) const;
+
+  MAKE_PROPERTY(num_points, get_num_points);
+
 public:
   virtual btCollisionShape *ptr() const;
 

--- a/tests/bullet/test_bullet_bam.py
+++ b/tests/bullet/test_bullet_bam.py
@@ -161,11 +161,14 @@ def test_convex_hull_points():
         (0.0, 1.0, 0.0),
     ])
 
-    assert shape.get_num_points() == 3
-    assert shape.num_points == 3
-    assert shape.get_point(0).almost_equal(core.LPoint3(0.0, 0.0, 0.0))
-    assert shape.get_point(1).almost_equal(core.LPoint3(1.0, 0.0, 0.0))
-    assert shape.get_point(2).almost_equal(core.LPoint3(0.0, 1.0, 0.0))
+    assert len(shape.points) == 3
+    assert shape.points[0].almost_equal(core.LPoint3(0.0, 0.0, 0.0))
+    assert shape.points[1].almost_equal(core.LPoint3(1.0, 0.0, 0.0))
+    assert shape.points[2].almost_equal(core.LPoint3(0.0, 1.0, 0.0))
+
+    points_list = list(shape.points)
+    assert len(points_list) == 3
+    assert points_list[0].almost_equal(core.LPoint3(0.0, 0.0, 0.0))
 
 
 def test_ghost():

--- a/tests/bullet/test_bullet_bam.py
+++ b/tests/bullet/test_bullet_bam.py
@@ -153,6 +153,21 @@ def test_convex_shape():
     assert shape.margin == shape2.margin
 
 
+def test_convex_hull_points():
+    shape = bullet.BulletConvexHullShape()
+    shape.add_array([
+        (0.0, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+    ])
+
+    assert shape.get_num_points() == 3
+    assert shape.num_points == 3
+    assert shape.get_point(0).almost_equal(core.LPoint3(0.0, 0.0, 0.0))
+    assert shape.get_point(1).almost_equal(core.LPoint3(1.0, 0.0, 0.0))
+    assert shape.get_point(2).almost_equal(core.LPoint3(0.0, 1.0, 0.0))
+
+
 def test_ghost():
     node = bullet.BulletGhostNode("some ghost node")
 


### PR DESCRIPTION
## Issue description
This change resolves #1875 by exposing methods to query point counts and individual points from a `BulletConvexHullShape`. Currently, developers can only add points but cannot retrieve them back.
 fixed=#1875
## Solution description
We exposed the following methods/properties on the `BulletConvexHullShape` class:
* `int get_num_points() const`: Returns the total number of points in the shape.
* `LPoint3 get_point(int i) const`: Returns the point at index `i` (includes boundary check `nassertr`).
* Python property `num_points` mapped to `get_num_points()`.

We also added a Python unit test `test_convex_hull_points` in `tests/bullet/test_bullet_bam.py` to verify that added points are retrieved accurately.

## Checklist
I have done my best to ensure that...
* [x] ...I have familiarized myself with the CONTRIBUTING.md file
* [x] ...this change follows the coding style and design patterns of the codebase
* [x] ...I own the intellectual property rights to this code
* [x] ...the intent of this change is clearly explained
* [x] ...existing uses of the Panda3D API are not broken
* [x] ...the changed code is adequately covered by the test suite, where possible.
