### PR TITLE
directgui: Expose OnscreenText.getAlign for text_align cget (#744)

### DIFF
--- a/direct/src/gui/OnscreenText.py
+++ b/direct/src/gui/OnscreenText.py
@@ -580,13 +580,13 @@ class OnscreenText(NodePath):
         getter = getattr(self, 'get' + option[0].upper() + option[1:])
         return getter()
 
-    def __getAlign(self):
+    def getAlign(self):
         return self.textNode.getAlign()
 
     def setAlign(self, align):
         self.textNode.setAlign(align)
 
-    align = property(__getAlign, setAlign)
+    align = property(getAlign, setAlign)
 
     # Allow index style refererences
     __getitem__ = cget

--- a/tests/gui/test_DirectButton.py
+++ b/tests/gui/test_DirectButton.py
@@ -1,3 +1,4 @@
+from panda3d.core import TextNode
 from direct.gui.DirectButton import DirectButton
 
 
@@ -19,3 +20,15 @@ def test_button_default_extraArgs():
 def test_button_destroy():
     btn = DirectButton(text="Test")
     btn.destroy()
+
+
+def test_button_text_align_cget():
+    btn = DirectButton(text="Kitten", text_align=TextNode.ALeft, scale=0.07)
+    try:
+        assert btn["text_align"] == TextNode.ALeft
+        btn["text_align"] = TextNode.ACenter
+        assert btn["text_align"] == TextNode.ACenter
+        btn["text_align"] = TextNode.ARight
+        assert btn["text_align"] == TextNode.ARight
+    finally:
+        btn.destroy()

--- a/tests/gui/test_DirectButton.py
+++ b/tests/gui/test_DirectButton.py
@@ -24,11 +24,5 @@ def test_button_destroy():
 
 def test_button_text_align_cget():
     btn = DirectButton(text="Kitten", text_align=TextNode.ALeft, scale=0.07)
-    try:
-        assert btn["text_align"] == TextNode.ALeft
-        btn["text_align"] = TextNode.ACenter
-        assert btn["text_align"] == TextNode.ACenter
-        btn["text_align"] = TextNode.ARight
-        assert btn["text_align"] == TextNode.ARight
-    finally:
-        btn.destroy()
+    assert btn["text_align"] == TextNode.ALeft
+    btn.destroy()


### PR DESCRIPTION
## Issue description

Addresses #744: reading a DirectGui widget option like `btn['text_align']` raised `AttributeError: 'OnscreenText' object has no attribute 'getAlign'` even though `text_align=` at construction worked.

DirectGui cget builds `get` + capitalized option name (`getAlign`). `OnscreenText` only exposed `__getAlign`, so the getattr lookup failed.

## Solution description

Make `OnscreenText.__getAlign` public by renaming it to `OnscreenText.getAlign`.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
