### PR TITLE
Honor the enable flag in MotionTrail.check_for_update

### DIFF
--- a/direct/src/motiontrail/MotionTrail.py
+++ b/direct/src/motiontrail/MotionTrail.py
@@ -464,7 +464,7 @@ class MotionTrail(NodePath, DirectObject):
         if self.pause:
             state = False
 
-        update = state and self.enable
+        state = state and self.enable
 
         return state
 

--- a/tests/motiontrail/test_MotionTrail.py
+++ b/tests/motiontrail/test_MotionTrail.py
@@ -1,0 +1,32 @@
+import pytest
+from panda3d import core
+from direct.motiontrail.MotionTrail import MotionTrail
+
+
+@pytest.fixture
+def motion_trail():
+    trail = MotionTrail('test', core.NodePath('parent'))
+    # Update continuously so check_for_update is only gated by enable/pause.
+    trail.sampling_time = 0.0
+    trail.last_update_time = 0.0
+    return trail
+
+
+def test_check_for_update_respects_enable(motion_trail):
+    # Enabled and not paused: due for an update.
+    motion_trail.enable_motion_trail(True)
+    assert motion_trail.check_for_update(1.0) is True
+
+    # Disabling must prevent updates (per the enable_motion_trail docstring).
+    motion_trail.enable_motion_trail(False)
+    assert motion_trail.check_for_update(1.0) is False
+
+
+def test_check_for_update_respects_pause(motion_trail):
+    motion_trail.enable_motion_trail(True)
+
+    motion_trail.pause_motion_trail(1.0)
+    assert motion_trail.check_for_update(1.0) is False
+
+    motion_trail.resume_motion_trail(1.0)
+    assert motion_trail.check_for_update(1.0) is True


### PR DESCRIPTION
## Issue description

`MotionTrail.check_for_update` ignores the `enable` flag, so `enable_motion_trail(False)` is a no-op even though its docstring says *"passing False to this method prevents it from being updated."*

```python
def check_for_update(self, current_time):
    state = False
    if (current_time - self.last_update_time) >= self.sampling_time:
        state = True
    if self.pause:
        state = False
    update = state and self.enable   # correct value computed…
    return state                     # …but the pre-enable value is returned
```

The method computes `update = state and self.enable` and then returns `state`, discarding the `enable` term. So a disabled motion trail still reports it is due for an update. This affects the manual-driving path too: `update_motion_trail()` gates on `check_for_update`, so a user who calls `enable_motion_trail(False)` and drives the trail by hand still sees it update.

## Solution description

Fold `enable` into the returned value, matching the C++ implementation. `CMotionTrail::check_for_update` (`direct/src/motiontrail/cMotionTrail.cxx`) does exactly this:

```cpp
state = state && _enable;
return state;
```

So the Python port should too:

```python
state = state and self.enable
return state
```

This restores the documented behavior of `enable_motion_trail(False)` and makes the pure-Python path agree with the default C++ path. Only this one line changes.

Added `tests/motiontrail/test_MotionTrail.py` covering `check_for_update` with respect to both `enable` and `pause`. The enable test fails on the current code and passes with the fix.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
