### PR TITLE
directgui: preserve frameSize bounds in getBounds

### DIFF
--- a/direct/src/gui/DirectGuiBase.py
+++ b/direct/src/gui/DirectGuiBase.py
@@ -919,6 +919,10 @@ class DirectGuiWidget(DirectGuiBase, NodePath):
             self.bounds[3] + bw[1])
 
     def getBounds(self, state = 0):
+        # Use user specified bounds
+        if self['frameSize']:
+            return list(self.bounds)
+
         self.stateNodePath[state].calcTightBounds(self.ll, self.ur)
         # Scale bounds to give a pad around graphics
         vec_right = Vec3.right()

--- a/tests/gui/test_DirectFrame.py
+++ b/tests/gui/test_DirectFrame.py
@@ -1,5 +1,15 @@
+import pytest
+
 from direct.gui.DirectFrame import DirectFrame
 from panda3d.core import NodePath, Texture
+
+
+@pytest.mark.parametrize('relief', ['flat', None])
+def test_frame_getbounds_preserves_framesize(relief):
+    frame = DirectFrame(frameSize=(-1, 1, -1, 1), relief=relief)
+    assert tuple(frame.bounds) == (-1, 1, -1, 1)
+    assert list(frame.getBounds()) == [-1, 1, -1, 1]
+    assert list(frame.bounds) == [-1, 1, -1, 1]
 
 
 def test_frame_empty():


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->

Fixes #1293. If a `DirectGuiWidget` (e.g. `DirectFrame`) has its size set explicitly via `frameSize`, calling `getBounds()` clobbers `self.bounds` with `[0.0, 0.0, 0.0, 0.0]` instead of leaving it at the user-specified size

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

`getBounds()` now returns the existing `self.bounds` (normalized to a list) whenever `frameSize` is explicitly set, without touching `calcTightBounds()`. This mirrors `setFrameSize()`, which already treats an explicit `frameSize` as authoritative and bypasses geometry-derived bounds the same way.

Added a regression test to `tests/gui/test_DirectFrame.py` to confirm the fix. Note: the default `relief='flat'` case doesn't actually reproduce the bug on its own, since the flat frame card provides real geometry sized to `frameSize` that `calcTightBounds()` happens to measure correctly either way. `relief=None` is what's needed to hit the code path this fix addresses, so both are covered.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
