### PR TITLE
CMake: Disable DO_PSTATS when the net library is not built (#1598)

### DIFF
--- a/dtool/Config.cmake
+++ b/dtool/Config.cmake
@@ -580,11 +580,45 @@ option(WANT_NATIVE_NET
   "Define this true to build the low-level native network
 implementation.  Normally this should be set true." ON)
 
-option(HAVE_NET
+cmake_dependent_option(HAVE_NET
   "Do you want to build the high-level network interface?  This layers
 on top of the low-level native_net interface, specified above.
 Normally, if you build NATIVE_NET, you will also build NET."
-  ${WANT_NATIVE_NET})
+  ON "WANT_NATIVE_NET" OFF)
+
+if(IS_MULTICONFIG AND NOT DEFINED DO_PSTATS)
+  set(_do_pstats_vars)
+  foreach(_config ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER "${_config}" _config_upper)
+    list(APPEND _do_pstats_vars "DO_PSTATS_${_config_upper}")
+  endforeach()
+else()
+  set(_do_pstats_vars DO_PSTATS)
+endif()
+
+if(NOT HAVE_NET OR NOT WANT_NATIVE_NET)
+  foreach(_var ${_do_pstats_vars})
+    # Remember the requested value, so that re-enabling the net library in an
+    # existing build directory restores PStats instead of silently leaving it
+    # off.
+    if(NOT DEFINED _${_var}_WITHOUT_NET)
+      set(_${_var}_WITHOUT_NET "${${_var}}" CACHE INTERNAL
+        "Value of ${_var} requested before net support was disabled")
+    endif()
+    set(${_var} OFF CACHE BOOL
+      "PStats client requires HAVE_NET and WANT_NATIVE_NET" FORCE)
+  endforeach()
+  message(WARNING "PStats requires the net library; disabling DO_PSTATS.")
+else()
+  foreach(_var ${_do_pstats_vars})
+    if(DEFINED _${_var}_WITHOUT_NET)
+      set(${_var} "${_${_var}_WITHOUT_NET}" CACHE BOOL
+        "Enable support for performance profiling using PStats?" FORCE)
+      unset(_${_var}_WITHOUT_NET CACHE)
+    endif()
+  endforeach()
+endif()
+unset(_do_pstats_vars)
 
 option(HAVE_EGG
   "Do you want to build the egg loader?  Usually there's no reason to


### PR DESCRIPTION
## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->

Fix for #1598.

> using -DWANT_NATIVE_NET=NO may lead to
```
In file included from /data/git/panda3d-upstream/panda/src/pstatclient/pStatClient.cxx:21,
                 from /opt/python-wasm-sdk/build/panda-host/cmake/panda/src/pstatclient/CMakeFiles/p3pstatclient.dir/Unity/unity_0_cxx.cxx:7:
/data/git/panda3d-upstream/panda/src/pstatclient/pStatClientImpl.h:23:10: fatal error: connectionManager.h: No such file or directory
   23 | #include "connectionManager.h"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Since it's required by `DO_PSTATS`.

## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->

Make `HAVE_NET` a dependent option because it was never buildable without `WANT_NATIVE_NET`.

`pStatClientImpl.h` inherits `ConnectionManager` and includes `connectionManager.h` under `#ifdef DO_PSTATS`, but `panda/src/net` skips building `p3net` entirely unless `HAVE_NET` and `WANT_NATIVE_NET` are both set.  `DO_PSTATS` defaults on for the `Debug` and `Standard` configs, so configuring with `-DWANT_NATIVE_NET=NO` produced a `dtool_config.h` that defined `DO_PSTATS` without the net headers, and pstatclient failed to compile:
```
  pStatClientImpl.h(23,10): fatal error C1083: Cannot open include file:
  'connectionManager.h': No such file or directory
```

Disable `DO_PSTATS` automatically in that case rather than failing the configure.

Also add a hidden cache variable (`_${_var}_WITHOUT_NET`) to remember what `DO_PSTATS` was set to before the guard forced it off, so the value can be put back later. Re-enabling the net library in an existing build directory would otherwise leave PStats silently off.

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.
