### PR TITLE
pgraph: fix find_all_textures() and find_all_materials() to consider textures/materials applied to nodes(#1403)

### DIFF
--- a/panda/src/pgraph/nodePath.cxx
+++ b/panda/src/pgraph/nodePath.cxx
@@ -6412,11 +6412,39 @@ r_find_all_vertex_columns(PandaNode *node,
 }
 
 /**
+ * Returns the first texture set by a TextureAttrib found on the indicated
+ * state whose name matches glob, or nullptr if there is no match.
+ */
+Texture *NodePath::
+find_texture_match(const RenderState *state, const GlobPattern &glob) {
+  const RenderAttrib *attrib =
+    state->get_attrib(TextureAttrib::get_class_slot());
+  if (attrib == nullptr) {
+    return nullptr;
+  }
+
+  const TextureAttrib *ta = DCAST(TextureAttrib, attrib);
+  for (int i = 0; i < ta->get_num_on_stages(); i++) {
+    Texture *texture = ta->get_on_texture(ta->get_on_stage(i));
+    if (texture != nullptr && glob.matches(texture->get_name())) {
+      return texture;
+    }
+  }
+
+  return nullptr;
+}
+
+/**
  *
  */
 Texture *NodePath::
 r_find_texture(PandaNode *node, const RenderState *state,
                const GlobPattern &glob) const {
+  Texture *texture = find_texture_match(state, glob);
+  if (texture != nullptr) {
+    return texture;
+  }
+
   if (node->is_geom_node()) {
     GeomNode *gnode;
     DCAST_INTO_R(gnode, node, nullptr);
@@ -6426,19 +6454,9 @@ r_find_texture(PandaNode *node, const RenderState *state,
       CPT(RenderState) geom_state =
         state->compose(gnode->get_geom_state(i));
 
-      // Look for a TextureAttrib on the state.
-      const RenderAttrib *attrib =
-        geom_state->get_attrib(TextureAttrib::get_class_slot());
-      if (attrib != nullptr) {
-        const TextureAttrib *ta = DCAST(TextureAttrib, attrib);
-        for (int i = 0; i < ta->get_num_on_stages(); i++) {
-          Texture *texture = ta->get_on_texture(ta->get_on_stage(i));
-          if (texture != nullptr) {
-            if (glob.matches(texture->get_name())) {
-              return texture;
-            }
-          }
-        }
+      texture = find_texture_match(geom_state, glob);
+      if (texture != nullptr) {
+        return texture;
       }
     }
   }
@@ -6789,11 +6807,39 @@ r_unify_texture_stages(PandaNode *node, TextureStage *stage) {
 }
 
 /**
+ * Returns the material set by a MaterialAttrib found on the indicated state
+ * whose name matches glob, or nullptr if there is no match.
+ */
+Material *NodePath::
+find_material_match(const RenderState *state, const GlobPattern &glob) {
+  const RenderAttrib *attrib =
+    state->get_attrib(MaterialAttrib::get_class_slot());
+  if (attrib == nullptr) {
+    return nullptr;
+  }
+
+  const MaterialAttrib *ta = DCAST(MaterialAttrib, attrib);
+  if (!ta->is_off()) {
+    Material *material = ta->get_material();
+    if (material != nullptr && glob.matches(material->get_name())) {
+      return material;
+    }
+  }
+
+  return nullptr;
+}
+
+/**
  *
  */
 Material *NodePath::
 r_find_material(PandaNode *node, const RenderState *state,
                const GlobPattern &glob) const {
+  Material *material = find_material_match(state, glob);
+  if (material != nullptr) {
+    return material;
+  }
+
   if (node->is_geom_node()) {
     GeomNode *gnode;
     DCAST_INTO_R(gnode, node, nullptr);
@@ -6803,19 +6849,9 @@ r_find_material(PandaNode *node, const RenderState *state,
       CPT(RenderState) geom_state =
         state->compose(gnode->get_geom_state(i));
 
-      // Look for a MaterialAttrib on the state.
-      const RenderAttrib *attrib =
-        geom_state->get_attrib(MaterialAttrib::get_class_slot());
-      if (attrib != nullptr) {
-        const MaterialAttrib *ta = DCAST(MaterialAttrib, attrib);
-        if (!ta->is_off()) {
-          Material *material = ta->get_material();
-          if (material != nullptr) {
-            if (glob.matches(material->get_name())) {
-              return material;
-            }
-          }
-        }
+      material = find_material_match(geom_state, glob);
+      if (material != nullptr) {
+        return material;
       }
     }
   }

--- a/panda/src/pgraph/nodePath.cxx
+++ b/panda/src/pgraph/nodePath.cxx
@@ -6460,11 +6460,35 @@ r_find_texture(PandaNode *node, const RenderState *state,
 }
 
 /**
+ * Inserts into textures any texture set by a TextureAttrib found on the
+ * indicated state.
+ */
+void NodePath::
+collect_textures(const RenderState *state, NodePath::Textures &textures) {
+  const RenderAttrib *attrib =
+    state->get_attrib(TextureAttrib::get_class_slot());
+  if (attrib == nullptr) {
+    return;
+  }
+
+  const TextureAttrib *ta = DCAST(TextureAttrib, attrib);
+  for (int i = 0; i < ta->get_num_on_stages(); i++) {
+    Texture *texture = ta->get_on_texture(ta->get_on_stage(i));
+    if (texture != nullptr) {
+      textures.insert(texture);
+    }
+  }
+}
+
+/**
  *
  */
 void NodePath::
 r_find_all_textures(PandaNode *node, const RenderState *state,
                     NodePath::Textures &textures) const {
+  // Consider textures applied directly to this node (via the net state).
+  collect_textures(state, textures);
+
   if (node->is_geom_node()) {
     GeomNode *gnode;
     DCAST_INTO_V(gnode, node);
@@ -6473,19 +6497,7 @@ r_find_all_textures(PandaNode *node, const RenderState *state,
     for (int i = 0; i < num_geoms; i++) {
       CPT(RenderState) geom_state =
         state->compose(gnode->get_geom_state(i));
-
-      // Look for a TextureAttrib on the state.
-      const RenderAttrib *attrib =
-        geom_state->get_attrib(TextureAttrib::get_class_slot());
-      if (attrib != nullptr) {
-        const TextureAttrib *ta = DCAST(TextureAttrib, attrib);
-        for (int i = 0; i < ta->get_num_on_stages(); i++) {
-          Texture *texture = ta->get_on_texture(ta->get_on_stage(i));
-          if (texture != nullptr) {
-            textures.insert(texture);
-          }
-        }
-      }
+      collect_textures(geom_state, textures);
     }
   }
 
@@ -6825,11 +6837,35 @@ r_find_material(PandaNode *node, const RenderState *state,
 }
 
 /**
+ * Inserts into materials the material set by a MaterialAttrib found on the
+ * indicated state, if any.
+ */
+void NodePath::
+collect_materials(const RenderState *state, NodePath::Materials &materials) {
+  const RenderAttrib *attrib =
+    state->get_attrib(MaterialAttrib::get_class_slot());
+  if (attrib == nullptr) {
+    return;
+  }
+
+  const MaterialAttrib *ta = DCAST(MaterialAttrib, attrib);
+  if (!ta->is_off()) {
+    Material *material = ta->get_material();
+    if (material != nullptr) {
+      materials.insert(material);
+    }
+  }
+}
+
+/**
  *
  */
 void NodePath::
 r_find_all_materials(PandaNode *node, const RenderState *state,
                     NodePath::Materials &materials) const {
+  // Consider materials applied directly to this node (via the net state).
+  collect_materials(state, materials);
+
   if (node->is_geom_node()) {
     GeomNode *gnode;
     DCAST_INTO_V(gnode, node);
@@ -6838,19 +6874,7 @@ r_find_all_materials(PandaNode *node, const RenderState *state,
     for (int i = 0; i < num_geoms; i++) {
       CPT(RenderState) geom_state =
         state->compose(gnode->get_geom_state(i));
-
-      // Look for a MaterialAttrib on the state.
-      const RenderAttrib *attrib =
-        geom_state->get_attrib(MaterialAttrib::get_class_slot());
-      if (attrib != nullptr) {
-        const MaterialAttrib *ta = DCAST(MaterialAttrib, attrib);
-        if (!ta->is_off()) {
-          Material *material = ta->get_material();
-          if (material != nullptr) {
-            materials.insert(material);
-          }
-        }
-      }
+      collect_materials(geom_state, materials);
     }
   }
 

--- a/panda/src/pgraph/nodePath.h
+++ b/panda/src/pgraph/nodePath.h
@@ -1020,7 +1020,10 @@ private:
   void r_find_all_textures(PandaNode *node, TextureStage *stage,
                            Textures &textures) const;
   static void r_replace_texture(PandaNode *node, Texture *tex, Texture *new_tex);
+
   static void collect_textures(const RenderState *state, Textures &textures);
+  static Texture *find_texture_match(const RenderState *state,
+                                     const GlobPattern &glob);
 
   typedef phash_set<TextureStage *, pointer_hash> TextureStages;
   TextureStage *r_find_texture_stage(PandaNode *node, const RenderState *state,
@@ -1037,7 +1040,10 @@ private:
                            Materials &materials) const;
   static void r_replace_material(PandaNode *node, Material *mat,
                                  const MaterialAttrib *new_attrib);
+
   static void collect_materials(const RenderState *state, Materials &materials);
+  static Material *find_material_match(const RenderState *state,
+                                       const GlobPattern &glob);
 
   PT(NodePathComponent) _head;
   int _backup_key;

--- a/panda/src/pgraph/nodePath.h
+++ b/panda/src/pgraph/nodePath.h
@@ -1020,6 +1020,7 @@ private:
   void r_find_all_textures(PandaNode *node, TextureStage *stage,
                            Textures &textures) const;
   static void r_replace_texture(PandaNode *node, Texture *tex, Texture *new_tex);
+  static void collect_textures(const RenderState *state, Textures &textures);
 
   typedef phash_set<TextureStage *, pointer_hash> TextureStages;
   TextureStage *r_find_texture_stage(PandaNode *node, const RenderState *state,
@@ -1036,6 +1037,7 @@ private:
                            Materials &materials) const;
   static void r_replace_material(PandaNode *node, Material *mat,
                                  const MaterialAttrib *new_attrib);
+  static void collect_materials(const RenderState *state, Materials &materials);
 
   PT(NodePathComponent) _head;
   int _backup_key;

--- a/tests/pgraph/test_nodepath.py
+++ b/tests/pgraph/test_nodepath.py
@@ -356,3 +356,29 @@ def test_nodepath_set_collide_owner():
     assert collider1.node().owner is owner3
     assert collider2.node().owner is owner3
     assert collider3.node().owner is owner2
+
+
+def test_find_all_textures_includes_node_applied():
+    """Tests that textures are found on the node."""
+    from panda3d.core import NodePath, Texture, TextureStage
+
+    tex = Texture("tex")
+    path = NodePath("node")
+    path.set_texture(tex)
+    assert path.find_texture(TextureStage.get_default()) == tex
+    found = path.find_all_textures()
+    assert len(found) == 1
+    assert found.get_num_textures() == 1
+    assert found.get_texture(0) == tex
+
+
+def test_find_all_materials_includes_node_applied():
+    """Tests that materials are found on the node."""
+    from panda3d.core import NodePath, Material
+
+    mat = Material("mat")
+    path = NodePath("node")
+    path.set_material(mat)
+    found = path.find_all_materials()
+    assert found.get_num_materials() == 1
+    assert found.get_material(0) == mat

--- a/tests/pgraph/test_nodepath.py
+++ b/tests/pgraph/test_nodepath.py
@@ -366,6 +366,7 @@ def test_find_all_textures_includes_node_applied():
     path = NodePath("node")
     path.set_texture(tex)
     assert path.find_texture(TextureStage.get_default()) == tex
+    assert path.find_texture("tex") == tex
     found = path.find_all_textures()
     assert len(found) == 1
     assert found.get_num_textures() == 1
@@ -379,6 +380,7 @@ def test_find_all_materials_includes_node_applied():
     mat = Material("mat")
     path = NodePath("node")
     path.set_material(mat)
+    assert path.find_material("mat") == mat
     found = path.find_all_materials()
     assert found.get_num_materials() == 1
     assert found.get_material(0) == mat


### PR DESCRIPTION
## Issue description

Fixes #1403.

`NodePath.find_texture`/`find_material` (by name/glob) and `find_all_textures`/`find_all_materials` only scanned `GeomNode` geom states, so a texture or material applied directly to a node via `NodePath.set_texture`/`set_material` (rather than baked into a `Geom`'s own state) was invisible to these lookups.

## Solution description

Both the singular glob-matching lookups (`r_find_texture`/`r_find_material`) and the "find all" traversals (`r_find_all_textures`/`r_find_all_materials`) now also check the node's own net `RenderState` for a `TextureAttrib`/`MaterialAttrib`, in addition to each `Geom`'s composed state. The attrib-scanning logic was factored into small static helpers (`find_texture_match`/`find_material_match`, `collect_textures`/`collect_materials`) shared between the net-state check and the existing per-geom check, rather than duplicating the scan.

**Disclaimer**: I used Claude to help me investigate and fix the bug.

```ps
PS C:\Dev\panda3d> git branch --show-current
fix/issue-1403-find-all-textures
PS C:\Dev\panda3d> $std = "C:\Dev\panda3d\build\Standard"
>> $env:PYTHONPATH = $std
>> $env:PATH = "$std\bin;" + $env:PATH
PS C:\Dev\panda3d> python -c "from panda3d import core; print(core.__file__)"
C:\Dev\panda3d\build\Standard\panda3d\core.cp312-win_amd64.pyd
PS C:\Dev\panda3d> python -m pytest tests\pgraph\test_nodepath.py -v
 ====== test session starts  ======
platform win32 -- Python 3.12.10, pytest-9.1.1, pluggy-1.6.0 -- C:\Users\dulta\AppData\Local\Programs\Python\Python312\python.exe
cachedir: .pytest_cache
rootdir: C:\Dev\panda3d
configfile: setup.cfg
plugins: cov-7.1.0
collected 17 items                                                                                                                                                                                                                                                                                                                                                                                                

tests/pgraph/test_nodepath.py::test_nodepath_empty PASSED                                                                                                                                                                                                                                                                                                                                                   [  5%]
tests/pgraph/test_nodepath.py::test_nodepath_single PASSED                                                                                                                                                                                                                                                                                                                                                  [ 11%]
tests/pgraph/test_nodepath.py::test_nodepath_parent PASSED                                                                                                                                                                                                                                                                                                                                                  [ 17%]
tests/pgraph/test_nodepath.py::test_nodepath_transform_changes PASSED                                                                                                                                                                                                                                                                                                                                       [ 23%]
tests/pgraph/test_nodepath.py::test_nodepath_transform_composition PASSED                                                                                                                                                                                                                                                                                                                                   [ 29%]
tests/pgraph/test_nodepath.py::test_nodepath_comparison PASSED                                                                                                                                                                                                                                                                                                                                              [ 35%]
tests/pgraph/test_nodepath.py::test_weak_nodepath_comparison PASSED                                                                                                                                                                                                                                                                                                                                         [ 41%]
tests/pgraph/test_nodepath.py::test_nodepath_flatten_tags_identical PASSED                                                                                                                                                                                                                                                                                                                                  [ 47%]
tests/pgraph/test_nodepath.py::test_nodepath_flatten_tags_same_key PASSED                                                                                                                                                                                                                                                                                                                                   [ 52%]
tests/pgraph/test_nodepath.py::test_nodepath_flatten_tags_same_value PASSED                                                                                                                                                                                                                                                                                                                                 [ 58%]
tests/pgraph/test_nodepath.py::test_nodepath_python_tags PASSED                                                                                                                                                                                                                                                                                                                                             [ 64%]
tests/pgraph/test_nodepath.py::test_nodepath_clear_python_tag PASSED                                                                                                                                                                                                                                                                                                                                        [ 70%]
tests/pgraph/test_nodepath.py::test_nodepath_replace_texture PASSED                                                                                                                                                                                                                                                                                                                                         [ 76%]
tests/pgraph/test_nodepath.py::test_nodepath_replace_texture_none PASSED                                                                                                                                                                                                                                                                                                                                    [ 82%]
tests/pgraph/test_nodepath.py::test_nodepath_set_collide_owner PASSED                                                                                                                                                                                                                                                                                                                                       [ 88%]
tests/pgraph/test_nodepath.py::test_find_all_textures_includes_node_applied PASSED                                                                                                                                                                                                                                                                                                                          [ 94%]
tests/pgraph/test_nodepath.py::test_find_all_materials_includes_node_applied PASSED                                                                                                                                                                                                                                                                                                                         [100%]

====== 17 passed in 0.07s ======
PS C:\Dev\panda3d
```

## Checklist
I have done my best to ensure that…
* [x] …I have familiarized myself with the CONTRIBUTING.md file
* [x] …this change follows the coding style and design patterns of the codebase
* [x] …I own the intellectual property rights to this code
* [x] …the intent of this change is clearly explained
* [x] …existing uses of the Panda3D API are not broken
* [x] …the changed code is adequately covered by the test suite, where possible.