### PR TITLE
cocoadisplay: Fix modifier_state passed to UCKeyTranslate

### DIFF
--- a/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
+++ b/panda/src/cocoadisplay/cocoaGraphicsWindow.mm
@@ -1685,9 +1685,28 @@ handle_key_event(NSEvent *event) {
   const UCKeyboardLayout *layout = (const UCKeyboardLayout *)CFDataGetBytePtr(layout_data);
 
   if ([event type] == NSKeyDown) {
+    // NSEventModifierFlags do not have the same bit representation as the
+    // expected Carbon EventRecord.modifiers value, so we'll translate.
+    UInt32 modifier_state = 0;
+    if (modifierFlags & NSEventModifierFlagCapsLock) {
+      modifier_state |= alphaLock;
+    }
+    if (modifierFlags & NSEventModifierFlagShift) {
+      modifier_state |= shiftKey;
+    }
+    if (modifierFlags & NSEventModifierFlagControl) {
+      modifier_state |= controlKey;
+    }
+    if (modifierFlags & NSEventModifierFlagOption) {
+      modifier_state |= optionKey;
+    }
+    if (modifierFlags & NSEventModifierFlagCommand) {
+      modifier_state |= cmdKey;
+    }
+    // Bit shift to the position UCKeyTranslate expects.
+    modifier_state = (modifier_state >> 8) & 0xFF;
     // Translate it to a unicode character for keystrokes.  I would use
     // interpretKeyEvents and insertText, but that doesn't handle dead keys.
-    UInt32 modifier_state = (modifierFlags >> 16) & 0xFF;
     UniChar ustr[8];
     UniCharCount length;
 


### PR DESCRIPTION
## Issue description
Resolves #1890.

NSEvent's `modifierFlags` flowed into the `modifierKeyState` for `UCKeyTranslate`, but [that value expects Carbon's legacy `EventRecord.modifiers` flags shifted right by 8](https://developer.apple.com/documentation/coreservices/1390584-uckeytranslate). The original `modifierFlags >> 16` brought the flags to the correct bit position, but the enumeration is actually different between Cocoa and Carbon:

| Relative Bit | NSEvent Modifier (Cocoa) | EventRecord Modifier (Carbon) |
| --- | --- | --- |
| 0 | Caps Lock | Command |
| 1 | Shift | Shift |
| 2 | Control | Caps Lock |
| 3 | Option | Option |
| 4 | Command | Control |

Shift and Option modifiers have just coincidentally worked up until now, which probably made the issue slip under the radar.

## Solution description
For the purposes of handling key events, I believe only these 5 bitflag values need to be considered, so I just manually re-inserted them into an empty `modifier_state` depending on their Cocoa-equivalent presence in `modifierFlags`. Then passed them through to `UCKeyTranslate` as documented by Apple in the link above.

This PR fixes the following example keystrokes generated on macOS:
- The `control-a` key combo now sends `\x01` instead of `A`.
- The `meta-a` key combo now sends `a` instead of `\x01`.
- Pressing `a` with the caps lock on now sends `A` instead of `a`.

Tested locally on the hardware described in the issue linked above.

## Checklist
I have done my best to ensure that…
* [X] …I have familiarized myself with the CONTRIBUTING.md file
* [X] …this change follows the coding style and design patterns of the codebase
* [X] …I own the intellectual property rights to this code
* [X] …the intent of this change is clearly explained
* [X] …existing uses of the Panda3D API are not broken
* [X] …the changed code is adequately covered by the test suite, where possible.
